### PR TITLE
[Rest Server] Refine HDFS Usage

### DIFF
--- a/rest-server/src/models/job.js
+++ b/rest-server/src/models/job.js
@@ -98,15 +98,18 @@ class Job {
         let frameworkDescription;
         async.parallel([
           (parallelCallback) => {
-            async.each(['tmp', 'alive', 'finished'], (file, eachCallback) => {
-              fs.mkdir(path.join(jobDir, file), (err) => eachCallback(err));
-            }, (err) => {
-              if (err && err.code !== 'EEXIST') {
-                parallelCallback(err);
-              } else {
-                parallelCallback();
-              }
-            });
+            async.each(
+                ['tmp', 'finished', "YarnContainerScripts", "DockerContainerScripts"],
+                (file, eachCallback) => {
+                  fs.mkdir(path.join(jobDir, file), (err) => eachCallback(err));
+                },
+                (err) => {
+                  if (err && err.code !== 'EEXIST') {
+                    parallelCallback(err);
+                  } else {
+                    parallelCallback();
+                  }
+                });
           },
           (parallelCallback) => {
             async.each([ ... Array(data.taskRoles.length).keys() ], (idx, eachCallback) => {
@@ -211,7 +214,7 @@ class Job {
         'taskService': {
           'version': 0,
           'entryPoint': `source YarnContainerScripts/${i}.sh`,
-          'sourceLocations': [`/Launcher/$FRAMEWORK_NAME/YarnContainerScripts`],
+          'sourceLocations': [`/Launcher/${data.jobName}/YarnContainerScripts`],
           'resource': {
             'cpuNumber': data.taskRoles[i].cpuNumber,
             'memoryMB': data.taskRoles[i].memoryMB,

--- a/rest-server/src/templates/dockerContainerScript.mustache
+++ b/rest-server/src/templates/dockerContainerScript.mustache
@@ -60,10 +60,8 @@ cd $HOME
 hdfs dfs -get $AII_CODE_DIR code || exit 1
 cd code
 
-# TODO: yarn container and docker container communication need to
-# be changed to use local file system instead of hdfs
 while /bin/true; do
-  [ $(( $(date +%s%3N) - $(hdfs dfs -stat %Y $HDFS_LAUNCHER_PREFIX/$FRAMEWORK_NAME/alive/$TASK_INDEX) )) -gt 120000 ] \
+  [ $(( $(date +%s) - $(stat -c %Y /alive/$AII_CONTAINER_ID) )) -gt 60 ] \
     && pkill -9 --ns 1
   sleep 20
 done &

--- a/rest-server/src/templates/yarnContainerScript.mustache
+++ b/rest-server/src/templates/yarnContainerScript.mustache
@@ -20,12 +20,11 @@
 
 # Entrypoint script for yarn container.
 
-docker_name=$FRAMEWORK_NAME-$RANDOM-$RANDOM
+docker_name="$FRAMEWORK_NAME-$CONTAINER_ID"
 
-# TODO: yarn container and docker container communication need to
-# be changed to use local file system instead of hdfs
+mkdir -p "/tmp/aii-root/alive/$APP_ID"
 while /bin/true; do
-  hdfs dfs -touchz {{{ hdfsUri }}}/Launcher/$FRAMEWORK_NAME/alive/$TASK_INDEX
+  touch "/tmp/aii-root/alive/$APP_ID/$CONTAINER_ID"
   sleep 20
   [ ! "$(docker ps | grep $docker_name)" ] && break
 done &
@@ -47,8 +46,10 @@ docker run --name $docker_name \
   --oom-kill-disable \
   --device=$nvidia_devices \
   --volume /var/drivers/nvidia/current:/usr/local/nvidia:ro \
+  --volume /tmp/aii-root/alive/$APP_ID:/alive \
   --env FRAMEWORK_NAME=$FRAMEWORK_NAME \
   --env AII_TASK_INDEX=$TASK_INDEX \
   --env AII_CURRENT_CONTAINER_IP=$CONTAINER_IP \
+  --env AII_CONTAINER_ID=$CONTAINER_ID \
   --entrypoint '/bin/bash' {{{ jobData.image }}} \
   '-c' 'hdfs dfs -get {{{ hdfsUri }}}/Launcher/$FRAMEWORK_NAME/DockerContainerScripts/{{{ idx }}}.sh bootstrap.sh && source bootstrap.sh'

--- a/service-deployment/bootstrap/hadoop-service/hadoop-node-manager.yaml.template
+++ b/service-deployment/bootstrap/hadoop-service/hadoop-node-manager.yaml.template
@@ -44,6 +44,8 @@ spec:
           name: docker-var-lib
         - mountPath: /var/drivers
           name: driver-path
+        - mountPath: /tmp/aii-root
+          name: aii-tmp-path
         - mountPath: /hadoop-configuration
           name: hadoop-config-volume
         env:
@@ -75,6 +77,9 @@ spec:
       - name: driver-path
         hostPath:
           path: /var/drivers
+      - name: aii-tmp-path
+        hostPath:
+          path: /tmp/aii-root
       - name: hadoop-config-volume
         configMap:
           name: {{ clusterinfo[ 'hadoopinfo' ][ 'configmapname' ] }}


### PR DESCRIPTION
- change launcher's entryPoint and use its sourceLocations
- change hdfs `copyToLocal` to `get`
- change yarn container and docker container communication from hdfs to local file system