### PR TITLE
[Deployment] Edit /etc/hosts in k8s Deployment

### DIFF
--- a/kubernetes-deployment/bootstrap.py
+++ b/kubernetes-deployment/bootstrap.py
@@ -196,7 +196,7 @@ def remoteBootstrap(cluster_info, host_config):
 
 
     sftp_paramiko(src_local, dst_remote, srcipt_package, host_config)
-    commandline = "tar -xvf kubernetes.tar && sudo ./src/start.sh {0}:8080 {1}".format(cluster_info['api-servers-ip'], host_config['username'])
+    commandline = "tar -xvf kubernetes.tar && sudo ./src/start.sh {0}:8080 {1} {2}".format(cluster_info['api-servers-ip'], host_config['username'], host_config['hostip'])
     ssh_shell_paramiko(host_config, commandline)
 
 

--- a/kubernetes-deployment/start.sh
+++ b/kubernetes-deployment/start.sh
@@ -18,6 +18,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+# Edit /etc/hosts file for remote host
+
+# set host ip
+hostip=$3
+
+# Change 127.0.0.1 line to "127.0.0.1 localhost"
+grep -q "127.0.0.1" /etc/hosts && \
+    sed -i "/127.0.0.1/c\127.0.0.1 localhost" /etc/hosts || \
+    sed -i "\$a127.0.0.1 localhost"
+
+# Comment 127.0.1.1 line
+sed -i "/127.0.1.1/s/^/# /" /etc/hosts
+
+# Change hostip line to "$hostip $hostname"
+grep -q "$hostip" /etc/hosts && \
+    sed -i "/$hostip/c\$hostip $(hostname)" /etc/hosts || \
+    sed -i "\$a$hostip $(hostname)"
+
+
 # Prepare docker for remote host
 if command -v docker >/dev/null 2>&1; then
     echo docker has been installed. And skip docker install.


### PR DESCRIPTION
According to [Hadoop Wiki](https://wiki.apache.org/hadoop/ConnectionRefused) and #25, edit /etc/hosts during k8s deployment:
- Change `127.0.0.1` line to `127.0.0.1 localhost`, append if it doesn't
exist
- Comment `127.0.1.1` line
- Change host ip line to `hostip hostname`, append if it doesn't exist