### PR TITLE
Fix bugs in webportal deployment

### DIFF
--- a/service-deployment/bootstrap/webportal/webportal-ds.yaml.template
+++ b/service-deployment/bootstrap/webportal/webportal-ds.yaml.template
@@ -34,8 +34,6 @@ spec:
       - name: webportal
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}webportal
         imagePullPolicy: Always
-        securityContext:
-          privileged: true
         env:
         - name: REST_SERVER_URI
           value: {{ clusterinfo['webportalinfo']['rest_server_uri'] }}

--- a/service-deployment/bootstrap/webportal/webportal-ds.yaml.template
+++ b/service-deployment/bootstrap/webportal/webportal-ds.yaml.template
@@ -33,6 +33,9 @@ spec:
       containers:
       - name: webportal
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}webportal
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
         env:
         - name: REST_SERVER_URI
           value: {{ clusterinfo['webportalinfo']['rest_server_uri'] }}

--- a/service-deployment/src/webportal/dockerfile
+++ b/service-deployment/src/webportal/dockerfile
@@ -24,7 +24,7 @@ ENV NODE_ENV=production \
 
 COPY copied_file/ /usr/src/
 COPY copied_file/webportal/ /usr/src/app/
-RUN npm install
+RUN npm run yarn install
 
 EXPOSE ${SERVER_PORT}
 


### PR DESCRIPTION
Fix bug in webportal deployment:
- Always pull docker image.
- Use `yarn install` instead of `npm install`.