### PR TITLE
Change the url of listen-peer-urls and listen-client-urls. 

### DIFF
--- a/kubernetes-deployment/template/etcd.yaml.template
+++ b/kubernetes-deployment/template/etcd.yaml.template
@@ -31,11 +31,11 @@ spec:
     - --initial-advertise-peer-urls
     - http://{{ hostcofig['hostip'] }}:2380
     - --listen-peer-urls
-    - http://{{ hostcofig['hostip'] }}:2380
+    - http://0.0.0.0:2380
     - --advertise-client-urls
     - http://{{ hostcofig['hostip'] }}:4001
     - --listen-client-urls
-    - http://{{ hostcofig['hostip'] }}:4001
+    - http://0.0.0.0:4001
     - --initial-cluster
     - {{ clusterconfig['etcd_cluster_ips_peer'] }}
     - --data-dir


### PR DESCRIPTION
change mis-configuration according to https://github.com/coreos/etcd/blob/master/hack/kubernetes-deploy/etcd.yml。

Before
```
 # etcdctl cluster-health
cluster may be unhealthy: failed to list members
Error:  client: etcd cluster is unavailable or misconfigured
error #0: dial tcp 127.0.0.1:2379: getsockopt: connection refused
error #1: dial tcp 127.0.0.1:4001: getsockopt: connection refused

```
After
```
/ # etcdctl cluster-health
member 2a686307d7e5f2d is healthy: got healthy result from http://10.240.0.18:4001
member 4f9baeb86f058c91 is healthy: got healthy result from http://10.240.0.19:4001
member 94c5ddba86d892e6 is healthy: got healthy result from http://10.240.0.20:4001
cluster is healthy

```