### PR TITLE
update grafana node view

### DIFF
--- a/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
@@ -18,22 +18,23 @@
   "hideControls": true,
   "id": null,
   "links": [],
+  "refresh": "30s",
   "rows": [
     {
       "collapse": false,
-      "height": 258,
+      "height": 315,
       "panels": [
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": false,
+          "colorValue": true,
           "colors": [
-            "#299c46",
+            "#d44a3a",
             "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
+            "#299c46"
           ],
           "datasource": "PM",
-          "description": "Node Number",
+          "description": "",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -42,15 +43,96 @@
             "thresholdLabels": false,
             "thresholdMarkers": true
           },
+          "height": "312px",
           "id": 9,
           "interval": null,
           "links": [
             {
               "dashboard": "PAI Cluster Node List",
               "type": "absolute",
-              "url": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/db/pai_clusterview"
+              "url": "http://10.151.40.179:3000/dashboard/db/pai_clusterview"
             }
           ],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "minSpan": 3,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(node_uname_info)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{sum(node_uname_info)} node",
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1",
+          "title": "Detected Node Number",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": null,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": true,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "312",
+          "id": 10,
+          "interval": null,
+          "links": [],
           "mappingType": 1,
           "mappingTypes": [
             {
@@ -76,7 +158,7 @@
               "to": "null"
             }
           ],
-          "span": 12,
+          "span": 6,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
@@ -86,16 +168,16 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(node_uname_info)",
+              "expr": "100 * (sum(nvidiasmi_utilization_gpu) / sum(nvidiasmi_attached_gpus))",
               "format": "time_series",
+              "hide": false,
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{sum(node_uname_info)} node",
               "refId": "A"
             }
           ],
-          "thresholds": "",
-          "title": "Detected Node Number",
+          "thresholds": "50, 90",
+          "title": "GPU Usage",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -105,7 +187,161 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": null,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "150",
+          "id": 11,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(nvidiasmi_utilization_gpu)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "50, 90",
+          "title": "Used",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#d44a3a",
+            "rgba(237, 129, 40, 0.89)",
+            "#299c46"
+          ],
+          "datasource": null,
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "150",
+          "id": 12,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "minSpan": 3,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "sum(nvidiasmi_attached_gpus)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "1",
+          "title": "Total",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
         }
       ],
       "repeat": null,
@@ -620,7 +856,7 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -650,5 +886,5 @@
   },
   "timezone": "",
   "title": "PAI_ClusterView",
-  "version": 3
+  "version": 1
 }}

--- a/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
@@ -177,7 +177,7 @@
             }
           ],
           "thresholds": "50, 90",
-          "title": "GPU Usage ( % )",
+          "title": "Active GPUs ( % )",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -255,7 +255,7 @@
             }
           ],
           "thresholds": "50, 90",
-          "title": "Used",
+          "title": "Active GPUs",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -332,7 +332,7 @@
             }
           ],
           "thresholds": "1",
-          "title": "Total",
+          "title": "Total GPUs",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -467,14 +467,14 @@
               "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree) - sum(node_memory_Buffers) - sum(node_memory_Cached)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "memory usage",
+              "legendFormat": "usage",
               "refId": "A"
             },
             {
               "expr": "sum(node_memory_MemFree)",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "memory free",
+              "legendFormat": "free",
               "refId": "D"
             }
           ],
@@ -549,14 +549,14 @@
               "expr": "sum(rate(node_network_receive_bytes{device!~\"lo\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "In",
+              "legendFormat": "in",
               "refId": "A"
             },
             {
               "expr": "sum(rate(node_network_transmit_bytes{device!~\"lo\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Out",
+              "legendFormat": "out",
               "refId": "B"
             }
           ],

--- a/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
@@ -50,7 +50,7 @@
             {
               "dashboard": "PAI Cluster Node List",
               "type": "absolute",
-              "url": "http://10.151.40.179:3000/dashboard/db/pai_clusterview"
+              "url": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/db/pai_clusterview"
             }
           ],
           "mappingType": 1,

--- a/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
@@ -177,13 +177,13 @@
             }
           ],
           "thresholds": "50, 90",
-          "title": "GPU Usage",
+          "title": "GPU Usage ( % )",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
             {
               "op": "=",
-              "text": "N/A",
+              "text": "0",
               "value": "null"
             }
           ],
@@ -261,7 +261,7 @@
           "valueMaps": [
             {
               "op": "=",
-              "text": "N/A",
+              "text": "0",
               "value": "null"
             }
           ],

--- a/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-clusterview-dashboard.json.template
@@ -168,7 +168,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "100 * (sum(nvidiasmi_utilization_gpu) / sum(nvidiasmi_attached_gpus))",
+              "expr": "100 * (count(nvidiasmi_utilization_gpu > 0) / sum(nvidiasmi_attached_gpus))",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -247,8 +247,9 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(nvidiasmi_utilization_gpu)",
+              "expr": "count(nvidiasmi_utilization_gpu > 0)",
               "format": "time_series",
+              "hide": false,
               "intervalFactor": 2,
               "refId": "A"
             }

--- a/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
@@ -1,4 +1,4 @@
-{"dashboard":{
+{"dashboard": {
   "annotations": {
     "list": [
       {
@@ -19,7 +19,7 @@
   "hideControls": true,
   "id": null,
   "links": [],
-  "refresh": false,
+  "refresh": "30s",
   "rows": [
     {
       "collapse": false,
@@ -401,7 +401,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Disk Space Used",
+          "title": "Disk",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -629,22 +629,26 @@
               "type": "hidden"
             },
             {
-              "alias": "",
-              "colorMode": null,
+              "alias": "Node",
+              "colorMode": "value",
               "colors": [
-                "rgba(245, 54, 54, 0.9)",
+                "#ba43a9",
                 "rgba(237, 129, 40, 0.89)",
                 "rgba(50, 172, 45, 0.97)"
               ],
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
+              "decimals": 0,
               "link": true,
-              "linkTooltip": "",
-              "linkUrl": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/script/gpu.js?orgId=1&host=$__cell_2&rows=$__cell_4",
+              "linkTooltip": "Click to view usage  of each GPU",
+              "linkUrl": "http://10.151.40.179:3000/dashboard/script/gpu.js?orgId=1&host=$__cell_2&rows=$__cell_4",
               "pattern": "instance",
-              "thresholds": [],
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                "0.0.0.0:0"
+              ],
               "type": "number",
-              "unit": "short"
+              "unit": "none"
             },
             {
               "alias": "",
@@ -700,24 +704,11 @@
                 "rgba(50, 172, 45, 0.97)"
               ],
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
+              "decimals": 0,
+              "link": false,
               "pattern": "Value",
               "preserveFormat": false,
               "sanitize": false,
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "decimals": 2,
-              "pattern": "/.*/",
               "thresholds": [],
               "type": "number",
               "unit": "short"
@@ -736,6 +727,7 @@
           ],
           "title": "GPU Metrics",
           "transform": "table",
+          "transparent": false,
           "type": "table"
         }
       ],
@@ -756,10 +748,8 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {
-          "text": "",
-          "value": [
-            ""
-          ]
+          "text": "10.151.40.202:9100",
+          "value": "10.151.40.202:9100"
         },
         "datasource": "PM",
         "hide": 0,
@@ -782,7 +772,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -813,5 +803,5 @@
   },
   "timezone": "browser",
   "title": "PAI_NodeView",
-  "version": 7
+  "version": 1
 }}

--- a/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
@@ -13,324 +13,14 @@
     ]
   },
   "description": "Dashboard to view multiple servers",
-  "editable": true,
+  "editable": false,
   "gnetId": 405,
   "graphTooltip": 0,
-  "hideControls": false,
+  "hideControls": true,
   "id": null,
   "links": [],
   "refresh": false,
   "rows": [
-    {
-      "collapse": false,
-      "height": 243,
-      "panels": [
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "PM",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 21,
-          "interval": null,
-          "links": [
-            {
-              "type": "absolute",
-              "url": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/db/pai_clusterview"
-            }
-          ],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 2,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(node_uname_info)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "title": "Cluster Dashboard (Node Number)",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
-        },
-        {
-          "columns": [],
-          "datasource": "PM",
-          "fontSize": "100%",
-          "id": 22,
-          "links": [],
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": true
-          },
-          "span": 10,
-          "styles": [
-            {
-              "alias": "Time",
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "pattern": "Time",
-              "type": "hidden"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "Time",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "",
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "__name__",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "domainname",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "job",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "machine",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "release",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "sysname",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "pattern": "version",
-              "thresholds": [],
-              "type": "hidden",
-              "unit": "short"
-            },
-            {
-              "alias": "status",
-              "colorMode": "cell",
-              "colors": [
-                "rgba(50, 172, 45, 0.97)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(245, 54, 54, 0.9)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 0,
-              "pattern": "Value",
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 2,
-              "link": true,
-              "linkTargetBlank": true,
-              "linkTooltip": "",
-              "linkUrl": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/db/pai_nodeview?var-node=$__cell",
-              "pattern": "instance",
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "decimals": 2,
-              "pattern": "/.*/",
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            }
-          ],
-          "targets": [
-            {
-              "expr": "node_uname_info",
-              "format": "table",
-              "instant": true,
-              "intervalFactor": 2,
-              "refId": "A"
-            }
-          ],
-          "title": "Cluster Info",
-          "transform": "table",
-          "type": "table"
-        }
-      ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
-    },
     {
       "collapse": false,
       "height": 266,
@@ -403,7 +93,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$node CPU",
+          "title": "CPU",
           "tooltip": {
             "msResolution": false,
             "shared": false,
@@ -509,7 +199,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$node Memory",
+          "title": "Memory",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -607,7 +297,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$node Network Traffic",
+          "title": "Network Traffic",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -711,7 +401,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$node Disk Space Used",
+          "title": "Disk Space Used",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -794,7 +484,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$node GPU Utilization",
+          "title": "GPU Utilization",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -822,7 +512,7 @@
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": true
+              "show": false
             }
           ]
         },
@@ -873,7 +563,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "$node GPU Memory",
+          "title": "GPU Memory",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -901,7 +591,7 @@
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": true
+              "show": false
             }
           ]
         }
@@ -1059,9 +749,7 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [
-    "prometheus"
-  ],
+  "tags": [],
   "templating": {
     "list": [
       {
@@ -1069,13 +757,15 @@
         "allValue": null,
         "current": {
           "text": "",
-          "value": ""
+          "value": [
+            ""
+          ]
         },
         "datasource": "PM",
-        "hide": 2,
+        "hide": 0,
         "includeAll": false,
         "label": "",
-        "multi": true,
+        "multi": false,
         "multiFormat": "regex values",
         "name": "node",
         "options": [],
@@ -1123,5 +813,5 @@
   },
   "timezone": "browser",
   "title": "PAI_NodeView",
-  "version": 4
+  "version": 7
 }}

--- a/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
@@ -78,7 +78,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{$node} CPU utilization",
+              "legendFormat": "{$node} cpu utilization",
               "refId": "B"
             }
           ],
@@ -179,7 +179,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Usage",
+              "legendFormat": "usage",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -191,7 +191,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Free",
+              "legendFormat": "free",
               "refId": "E",
               "step": 600
             }
@@ -474,7 +474,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "GPU AVG Utilization",
+              "legendFormat": "avg gpu utilization",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -556,7 +556,7 @@
               "expr": "avg(nvidiasmi_utilization_memory{instance=~\"$node\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "GPU Memory Utilization",
+              "legendFormat": "gpu memory",
               "refId": "B"
             }
           ],

--- a/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
@@ -640,7 +640,7 @@
               "decimals": 0,
               "link": true,
               "linkTooltip": "Click to view usage  of each GPU",
-              "linkUrl": "http://10.151.40.179:3000/dashboard/script/gpu.js?orgId=1&host=$__cell_2&rows=$__cell_4",
+              "linkUrl": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/script/gpu.js?orgId=1&host=$__cell_2&rows=$__cell_4",
               "pattern": "instance",
               "preserveFormat": false,
               "sanitize": false,

--- a/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
@@ -13,17 +13,17 @@
     ]
   },
   "description": "Dashboard to view multiple servers",
-  "editable": false,
+  "editable": true,
   "gnetId": 405,
   "graphTooltip": 0,
-  "hideControls": true,
+  "hideControls": false,
   "id": null,
   "links": [],
   "refresh": false,
   "rows": [
     {
       "collapse": false,
-      "height": 258,
+      "height": 243,
       "panels": [
         {
           "cacheTimeout": null,
@@ -76,7 +76,7 @@
               "to": "null"
             }
           ],
-          "span": 12,
+          "span": 2,
           "sparkline": {
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
@@ -93,7 +93,7 @@
             }
           ],
           "thresholds": "",
-          "title": "Detected Node Number",
+          "title": "Cluster Dashboard (Node Number)",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -104,6 +104,224 @@
             }
           ],
           "valueName": "avg"
+        },
+        {
+          "columns": [],
+          "datasource": "PM",
+          "fontSize": "100%",
+          "id": 22,
+          "links": [],
+          "pageSize": null,
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": 0,
+            "desc": true
+          },
+          "span": 10,
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "hidden"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "Time",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "__name__",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "domainname",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "job",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "machine",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "release",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "sysname",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "pattern": "version",
+              "thresholds": [],
+              "type": "hidden",
+              "unit": "short"
+            },
+            {
+              "alias": "status",
+              "colorMode": "cell",
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 0,
+              "pattern": "Value",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "link": true,
+              "linkTargetBlank": true,
+              "linkTooltip": "",
+              "linkUrl": "{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_url'] }}:{{ clusterconfig['clusterinfo']['grafanainfo']['grafana_port'] }}/dashboard/db/pai_nodeview?var-node=$__cell",
+              "pattern": "instance",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "/.*/",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "expr": "node_uname_info",
+              "format": "table",
+              "instant": true,
+              "intervalFactor": 2,
+              "refId": "A"
+            }
+          ],
+          "title": "Cluster Info",
+          "transform": "table",
+          "type": "table"
         }
       ],
       "repeat": null,
@@ -604,7 +822,7 @@
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": false
+              "show": true
             }
           ]
         },
@@ -683,7 +901,7 @@
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": false
+              "show": true
             }
           ]
         }
@@ -841,15 +1059,17 @@
   ],
   "schemaVersion": 14,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "prometheus"
+  ],
   "templating": {
     "list": [
       {
         "allFormat": "glob",
         "allValue": null,
         "current": {
-          "text": "10.0.1.5:9100",
-          "value": "10.0.1.5:9100"
+          "text": "",
+          "value": ""
         },
         "datasource": "PM",
         "hide": 2,
@@ -903,5 +1123,5 @@
   },
   "timezone": "browser",
   "title": "PAI_NodeView",
-  "version": 3
+  "version": 4
 }}

--- a/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
+++ b/service-deployment/src/grafana/pai-nodeview-dashboard.json.template
@@ -748,8 +748,8 @@
         "allFormat": "glob",
         "allValue": null,
         "current": {
-          "text": "10.151.40.202:9100",
-          "value": "10.151.40.202:9100"
+          "text": "",
+          "value": ""
         },
         "datasource": "PM",
         "hide": 0,


### PR DESCRIPTION
Have done the test and deployed at big gpu cluster. See:
Cluster view: http://10.151.40.179:3000/dashboard/db/pai_clusterview?refresh=30s&orgId=1 
Node view: http://10.151.40.179:3000/dashboard/db/pai_nodeview?refresh=30s&orgId=1 

### Update log:
- Add GPU usage gauge panel in cluster view
- Redesign layout of cluster view
- Set default time range and refresh time (see top right corner)
- Add drop-down box of node view (see top left corner of it)
- Remove graph titles' IP prefix
- Change GPU count to int

Other advice for revision welcomed.
