### PR TITLE
Change the threshold of image gc.

### DIFF
--- a/kubernetes-deployment/template/kubelet.sh.template
+++ b/kubernetes-deployment/template/kubelet.sh.template
@@ -43,4 +43,6 @@ docker run \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --allow-privileged=true \
   --logtostderr=true \
+  --image-gc-high-threshold=98 \
+  --image-gc-low-threshold=95 \
   --v=2


### PR DESCRIPTION
--image-gc-high-threshold=98. 
--image-gc-low-threshold=95

```
image-gc-high-threshold, the percent of disk usage which triggers image garbage collection. Default is 90%.
image-gc-low-threshold, the percent of disk usage to which image garbage collection attempts to free. Default is 80%.
```