### PR TITLE
Fix bug of copy the same file with pai-fs

### DIFF
--- a/pai-fs/fsimpl/BaseFs.py
+++ b/pai-fs/fsimpl/BaseFs.py
@@ -203,8 +203,10 @@ class FileSystem:
             if self.verbose and is_normal_stdout():
                 sys.stdout.write(progressString)
                 sys.stdout.flush()
-            if not dst.exists:
-                dstFs.touch_file(dst)
+            if dst.exists:
+                dstFs.delete_file_dir(dst)
+            dstFs.touch_file(dst)
+
             self.cp_chunk(src, dst, dstFs, 0, 0, True, "wb")
         else:
             chunk = 0
@@ -221,8 +223,9 @@ class FileSystem:
                 dstChunkList.append(dstChunk)
                 self.logger.info("BIG COPY: chunk={0}, dst={1}".format(chunk, dstChunk.abspath))
 
-                if not dstChunk.exists:
-                    dstFs.touch_file(dstChunk)
+                if dstChunk.exists:
+                    dstFs.delete_file_dir(dstChunk)
+                dstFs.touch_file(dstChunk)
                 if dstChunk.size == Constants.DEFAULT_BIG_FILE_THRESHOLD \
                         and src.modificationTime <= dstChunk.modificationTime:
                     if self.verbose:

--- a/pai-fs/fsimpl/BaseFs.py
+++ b/pai-fs/fsimpl/BaseFs.py
@@ -226,6 +226,7 @@ class FileSystem:
                 if dstChunk.exists:
                     dstFs.delete_file_dir(dstChunk)
                 dstFs.touch_file(dstChunk)
+                
                 if dstChunk.size == Constants.DEFAULT_BIG_FILE_THRESHOLD \
                         and src.modificationTime <= dstChunk.modificationTime:
                     if self.verbose:

--- a/pai-fs/fsimpl/BaseFs.py
+++ b/pai-fs/fsimpl/BaseFs.py
@@ -264,7 +264,7 @@ class FileSystem:
             self.logger.info("COPY TARGET: change from {0} to {1}".format(dst.abspath, newDst.abspath))
             dst = newDst
 
-        if dst.exists and !force:
+        if dst.exists and not force:
             if self.verbose:
                 print("%s exist. Add -f to force copy".format(dst.abspath))
             return

--- a/pai-fs/fsimpl/BaseFs.py
+++ b/pai-fs/fsimpl/BaseFs.py
@@ -266,7 +266,7 @@ class FileSystem:
 
         if dst.exists and not force:
             if self.verbose:
-                print("%s exist. Add -f to force copy".format(dst.abspath))
+                print("%s already exists. Add -f to force copy" % (dst.abspath))
             return
         else:
             if self.verbose:

--- a/pai-fs/fsimpl/BaseFs.py
+++ b/pai-fs/fsimpl/BaseFs.py
@@ -266,7 +266,7 @@ class FileSystem:
 
         if dst.exists and not force:
             if self.verbose:
-                print("%s already exists. Add -f to force copy" % (dst.abspath))
+                print("Destination already exists, move will not be performed. Add -f to force copy" % (dst.abspath))
             return
         else:
             if self.verbose:

--- a/pai-fs/fsimpl/BaseFs.py
+++ b/pai-fs/fsimpl/BaseFs.py
@@ -253,7 +253,7 @@ class FileSystem:
         # Step2: concat all chunk files into final file
         self.concat_chunk_files(dstFs, dst, dstChunkList)
 
-    def cp_file(self, src, dst, dstFs):
+    def cp_file(self, src, dst, dstFs, force):
         self.logger.info("COPY: from({0})={1} to({2})={3}".format(src.fs.__class__.__name__,
                                                                   src.abspath,
                                                                   dst.fs.__class__.__name__,
@@ -264,9 +264,9 @@ class FileSystem:
             self.logger.info("COPY TARGET: change from {0} to {1}".format(dst.abspath, newDst.abspath))
             dst = newDst
 
-        if dst.exists and src.size == dst.size and src.modificationTime <= dst.modificationTime:
+        if dst.exists and !force:
             if self.verbose:
-                print("%s -> %s: skipped" % (src.abspath, dst.abspath))
+                print("%s exist. Add -f to force copy".format(dst.abspath))
             return
         else:
             if self.verbose:

--- a/pai-fs/pai-fs.py
+++ b/pai-fs/pai-fs.py
@@ -168,7 +168,7 @@ def mv_command(args):
     return 0
 
 
-def cp_command(args, recursive=False):
+def cp_command(args, recursive=False, force=False):
     global fileSystemWithMetrics
     if len(args) < 2:
         print("cannot initiate copy with only one argument")
@@ -208,7 +208,7 @@ def cp_command(args, recursive=False):
     exitCode = 0
     if srcFileDescriptor.is_file or srcFileDescriptor.is_symlink:
         try:
-            srcFileSystem.cp_file(srcFileDescriptor, dstFileDescriptor, dstFileSystem)
+            srcFileSystem.cp_file(srcFileDescriptor, dstFileDescriptor, dstFileSystem, force)
         except Errors.Unauthorized:
             print("Insufficient privileges to copy the path: {0} -> {1}".format(
                 srcFileDescriptor.abspath, dstFileDescriptor.abspath))
@@ -240,7 +240,7 @@ def cp_command(args, recursive=False):
                     continue
 
             try:
-                srcFileSystem.cp_file(currentFile, dstRootFileDescriptor, dstFileSystem)
+                srcFileSystem.cp_file(currentFile, dstRootFileDescriptor, dstFileSystem, force)
             except Errors.Unauthorized:
                 print("Insufficient privileges to copy the path: {0} -> {1}".format(
                     srcFileDescriptor.abspath, dstFileDescriptor.abspath))
@@ -444,7 +444,7 @@ if __name__ == "__main__":
     elif cmdLineArgs.makeDirectory:
         exitCode=mkdir_command(cmdLineArgs.myArgs)
     elif cmdLineArgs.copy:
-        exitCode=cp_command(cmdLineArgs.myArgs, cmdLineArgs.recursive)
+        exitCode=cp_command(cmdLineArgs.myArgs, cmdLineArgs.recursive, cmdLineArgs.force)
     elif cmdLineArgs.move:
         exitCode=mv_command(cmdLineArgs.myArgs)
     elif cmdLineArgs.hash:


### PR DESCRIPTION
delete the file if we find it has already exist in the path, and then continue the copy process.