### PR TITLE
[Rest Server] Add log message for EXIT trap

### DIFF
--- a/rest-server/src/models/job.js
+++ b/rest-server/src/models/job.js
@@ -192,7 +192,7 @@ class Job {
         let frameworkDescription;
         async.parallel([
           (parallelCallback) => {
-            async.each(['tmp', 'finished'], (file, eachCallback) => {
+            async.each(['log', 'tmp', 'finished'], (file, eachCallback) => {
               fse.ensureDir(path.join(jobDir, file), (err) => eachCallback(err));
             }, (err) => {
               parallelCallback(err);

--- a/rest-server/src/templates/dockerContainerScript.mustache
+++ b/rest-server/src/templates/dockerContainerScript.mustache
@@ -20,7 +20,23 @@
 
 # Bootstrap script for docker container.
 
-trap "kill 0" EXIT
+exec 17>/tmp/pai_dockercontainer_$PAI_CONTAINER_ID.log
+BASH_XTRACEFD=17
+
+function exit_handler()
+{
+  printf "%s %s\n" \
+    "[ERROR]" "EXIT signal received in docker container, exiting ..."
+  set +x
+  exec 17>&-
+  hdfs dfs -put /tmp/pai_dockercontainer_$PAI_CONTAINER_ID.log \
+    {{{ hdfsUri }}}/Container/{{{ jobData.username }}}/{{{ jobData.jobName }}}/log/
+  kill 0
+}
+
+set -x
+trap exit_handler EXIT
+
 
 touch "/alive/docker_$PAI_CONTAINER_ID"
 while /bin/true; do

--- a/rest-server/src/templates/yarnContainerScript.mustache
+++ b/rest-server/src/templates/yarnContainerScript.mustache
@@ -20,7 +20,23 @@
 
 # Entrypoint script for yarn container.
 
-trap "kill 0" EXIT
+exec 13>/tmp/pai_yarncontainer_$CONTAINER_ID.log
+BASH_XTRACEFD=13
+
+function exit_handler()
+{
+  printf "%s %s\n" \
+    "[ERROR]" "EXIT signal received in yarn container, exiting ..."
+  set +x
+  exec 13>&-
+  hdfs dfs -put /tmp/pai_yarncontainer_$CONTAINER_ID.log \
+    {{{ hdfsUri }}}/Container/{{{ jobData.username }}}/{{{ jobData.jobName }}}/log/
+  kill 0
+}
+
+set -x
+trap exit_handler EXIT
+
 
 docker_name="$FRAMEWORK_NAME-$CONTAINER_ID"
 export PAI_DEFAULT_FS_URI={{{ hdfsUri }}}


### PR DESCRIPTION
Add log message for EXIT trap in yarn container script and docker container script by using `set -x`. Update log files to hdfs before exit.

Can not get real line number in `trap EXIT`, pls refer to [GNU mailing list](https://lists.gnu.org/archive/html/bug-bash/2010-09/msg00021.html).