### PR TITLE
[Web Portal + REST Server] Respect the linebreak style rule of ESLint.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,8 +7,8 @@
 *.py     text diff=python
 *.pl     text diff=perl
 *.pm     text diff=perl
-*.css    text
-*.js     text
+*.css    text eol=lf
+*.js     text eol=lf
 *.sql    text
 
 *.sh     text eol=lf

--- a/rest-server/.eslintrc.js
+++ b/rest-server/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   "extends": ["eslint:recommended", "google"],
   "rules": {
-    "linebreak-style": 0,
     "max-len": [0, 80],
     "require-jsdoc": 0,
     "valid-jsdoc": 0,

--- a/webportal/.eslintrc.js
+++ b/webportal/.eslintrc.js
@@ -11,7 +11,6 @@ module.exports = {
     "userLogout": false,
   },
   "rules": {
-    "linebreak-style": 0,
     "max-len": [0, 80],
     "new-cap": 0,
     "require-jsdoc": 0,


### PR DESCRIPTION
Git will convert the linebreak in the file according to underlying OS (https://help.github.com/articles/dealing-with-line-endings/). In Windows, the line ending character will be automatically converted to 'CRLF' for the first time the repo is cloned to local. To fix the issue, just 3 steps:

1. Open a command line window and then go to `webportal` or `rest-server` folder.
2. Run: `node .\node_modules\eslint\bin\eslint.js src/**/*.js --fix`.
3. Run: `git add .`.

After these steps, Git will never convert the line ending characters back to 'CRLF' anymore.