### PR TITLE
prometheus node discovery 

### DIFF
--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -28,6 +28,8 @@ data:
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node
+      # Extract label __address__ inner ip address and replace the port to exporter's port to build target address. 
+      # Prometheus will fetch data from target address. 
       relabel_configs:
       - source_labels: [__address__]
         regex: '([^:]+)(:\d*)?'
@@ -38,6 +40,8 @@ data:
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node
+      # Extract label __address__ inner ip address and replace the port to exporter's port to build target address.  
+      # Prometheus will fetch data from target address. 
       relabel_configs:
       - source_labels: [__address__]
         regex: '([^:]+)(:\d*)?'

--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -24,7 +24,7 @@ data:
     # Scrape config for cluster components.
     scrape_configs: 
     - job_name: 'node_exporter'
-      scrape_interval: 15s
+      scrape_interval: 30s
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node
@@ -34,7 +34,7 @@ data:
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__ 
     - job_name: 'cadvisor'
-      scrape_interval: 15s
+      scrape_interval: 30s
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node

--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -30,7 +30,7 @@ data:
         role: node
       relabel_configs:
       - source_labels: [__address__]
-        regex: '(.*):(.*)'
+        regex: '([^:]+)(:\d*)?'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__ 
     - job_name: 'cadvisor'
@@ -40,7 +40,7 @@ data:
         role: node
       relabel_configs:
       - source_labels: [__address__]
-        regex: '(.*):(.*)'
+        regex: '([^:]+)(:\d*)?'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['cadvisor_port'] }}'
         target_label: __address__ 
 

--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -30,7 +30,7 @@ data:
         role: node
       relabel_configs:
       - source_labels: [__address__]
-        regex: '(.*):10250'
+        regex: '(.*):(.*)'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__ 
     - job_name: 'cadvisor'
@@ -40,7 +40,7 @@ data:
         role: node
       relabel_configs:
       - source_labels: [__address__]
-        regex: '(.*):10250'
+        regex: '(.*):(.*)'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['cadvisor_port'] }}'
         target_label: __address__ 
 

--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -23,18 +23,22 @@ data:
   prometheus.yml: |-
     # Scrape config for cluster components.
     scrape_configs: 
-    - job_name: "node_exporter"
-      scrape_interval: "15s"
-      static_configs:
-      - targets: 
-        {% for host in machinelist %}
-        - {{ machinelist[host]['ip']}}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}
-        {% endfor %}
-    - job_name: "cadvisor"
-      scrape_interval: "15s"
-      static_configs:
-      - targets: 
-        {% for host in machinelist %}
-        - {{ machinelist[host]['ip']}}:{{ clusterinfo['prometheusinfo']['cadvisor_port'] }}
-        {% endfor %}
+    - job_name: 'node_exporter'
+      kubernetes_sd_configs:
+      - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
+        role: node
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: '(.*):10250'
+        replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
+        target_label: __address__ 
+    - job_name: 'cadvisor'
+      kubernetes_sd_configs:
+      - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
+        role: node
+      relabel_configs:
+      - source_labels: [__address__]
+        regex: '(.*):10250'
+        replacement: '${1}:{{ clusterinfo['prometheusinfo']['cadvisor_port'] }}'
+        target_label: __address__ 
 

--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -24,6 +24,7 @@ data:
     # Scrape config for cluster components.
     scrape_configs: 
     - job_name: 'node_exporter'
+      scrape_interval: 15s
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node
@@ -33,6 +34,7 @@ data:
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__ 
     - job_name: 'cadvisor'
+      scrape_interval: 15s
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node

--- a/service-deployment/bootstrap/prometheus/prometheus-deployment.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-deployment.yaml.template
@@ -33,9 +33,9 @@ spec:
         prometheus: "true"
       containers:
       - name: prometheus
-        image: quay.io/coreos/prometheus:v1.1.1
+        image: prom/prometheus:v2.1.0
         args:
-          - '-config.file=/etc/prometheus/prometheus.yml'
+          - '--config.file=/etc/prometheus/prometheus.yml'
           - '--web.listen-address=0.0.0.0:{{clusterinfo['prometheusinfo']['prometheus_port']}}'
         ports:
         - name: web


### PR DESCRIPTION

From this PR prometheus will leverage kubernetes api server info to monitor node.
When nodes add and leave, prometheus can dynamic detect the live nodes and profile them.
To solve this issue #348