### PR TITLE
[Web portal] SSH info: refine error messages.

### DIFF
--- a/webportal/src/app/job/job-view/job-detail-table.component.ejs
+++ b/webportal/src/app/job/job-view/job-detail-table.component.ejs
@@ -80,13 +80,15 @@
           <td><%= taskRoles[taskRole].taskStatuses[i].containerIp %></td>
           <td><%= convertGpu(taskRoles[taskRole].taskStatuses[i].containerGpus) %></td>
           <td>
-            <a onclick='showSshInfo("<%= taskRoles[taskRole].taskStatuses[i].containerId %>")'
-              <% if (jobStatus.state !== 'RUNNING') { %>
-                class='disabled'
-              <% } %>
-              href='#'>SSH Info</a>
-            &nbsp;|&nbsp;
-            <a href="<%= taskRoles[taskRole].taskStatuses[i].containerLog %>" target="_blank">Log</a>
+            <div name='sshInfoDiv-<%= taskRoles[taskRole].taskStatuses[i].containerId %>' style='float:left'>
+              <a name='sshInfoLink-<%= taskRoles[taskRole].taskStatuses[i].containerId %>'
+                onclick='showSshInfo("<%= taskRoles[taskRole].taskStatuses[i].containerId %>")'
+                href='#'>SSH Info</a>
+            </div>
+            <div style='float:left'>&nbsp;|&nbsp;</div>
+            <div style='float:left'>
+              <a href="<%= taskRoles[taskRole].taskStatuses[i].containerLog %>" target="_blank">Log</a>
+            </div>
           </td>
         </tr>
       <% } %>

--- a/webportal/src/app/job/job-view/job-detail-table.component.ejs
+++ b/webportal/src/app/job/job-view/job-detail-table.component.ejs
@@ -83,7 +83,7 @@
             <div name='sshInfoDiv-<%= taskRoles[taskRole].taskStatuses[i].containerId %>' style='float:left'>
               <a name='sshInfoLink-<%= taskRoles[taskRole].taskStatuses[i].containerId %>'
                 onclick='showSshInfo("<%= taskRoles[taskRole].taskStatuses[i].containerId %>")'
-                href='#'>SSH Info</a>
+                href='javascript:void(0);'>SSH Info</a>
             </div>
             <div style='float:left'>&nbsp;|&nbsp;</div>
             <div style='float:left'>

--- a/webportal/src/app/job/job-view/job-view.component.js
+++ b/webportal/src/app/job/job-view/job-view.component.js
@@ -216,17 +216,26 @@ const loadJobDetail = (jobName) => {
           convertState,
           convertGpu,
         }));
-        $.ajax({
-          url: `${webportalConfig.restServerUri}/api/v1/jobs/${jobName}/ssh`,
-          type: 'GET',
-          success: (data) => {
-            sshInfo = data;
-          },
-          error: (xhr, textStatus, error) => {
-            const res = JSON.parse(xhr.responseText);
-            alert(res.message);
-          },
-        });
+        $('a[name^=sshInfoLink]').addClass('disabled');
+        if (data.jobStatus.state !== 'RUNNING') {
+          $('div[name^=sshInfoDiv]').attr('title', 'Job is not running.');
+        } else {
+          $.ajax({
+            url: `${webportalConfig.restServerUri}/api/v1/jobs/${jobName}/ssh`,
+            type: 'GET',
+            success: (data) => {
+              sshInfo = data;
+              $('a[name^=sshInfoLink]').removeClass('disabled');
+              $('div[name^=sshInfoDiv]').attr('title', '');
+            },
+            error: (xhr, textStatus, error) => {
+              const res = JSON.parse(xhr.responseText);
+              if (res.message === 'SshInfoNotFound') {
+                $('div[name^=sshInfoDiv]').attr('title', 'This job does not contain SSH info.');
+              }
+            },
+          });
+        }
       }
     },
     error: (xhr, textStatus, error) => {


### PR DESCRIPTION
Features:
- No more prompting dialog for errors related to SSH info.
- The 'SSH Info' links will turn grey if:
    * The job is not running, or
    * The job does not contain ssh info (means it was either submitted using the old rest-server, or submitted directly using launcher, or using a non-standard docker image).
- When the 'SSH Info' links are grey, tooltips on them will explain the reason why the ssh info is not available.