### PR TITLE
fix port not trige preemption issue

### DIFF
--- a/frameworklauncher/src/main/java/com/microsoft/frameworklauncher/common/utils/ValueRangeUtils.java
+++ b/frameworklauncher/src/main/java/com/microsoft/frameworklauncher/common/utils/ValueRangeUtils.java
@@ -238,6 +238,9 @@ public class ValueRangeUtils {
   public static List<ValueRange> getSubRange(List<ValueRange> availableRange, int requestNumber, int baseValue) {
 
     List<ValueRange> resultList = new ArrayList<ValueRange>();
+    if(getValueNumber(availableRange) <= 0) {
+      return resultList;
+    }
     Random random = new Random();
     //Pick a random number from 0 to the max value;
     int maxValue = availableRange.get(availableRange.size() - 1).getEnd();


### PR DESCRIPTION
The issue is:
When there is not enough node  (filteredNodes.size() < 1)  to meet the request,  Framework launcher will throw a NotAvailableException if user request ports (getPortNumber() > 0)

We need Framework lunch still submit this job to yarn to preempt other's job. 

The fix is:
1. Allocate the port after Label And GPU filtering.
2. Do resource fit in. 
3. if don't have enough resource( filteredNodes.size() < 1) , still submit the request with the port selected in step1. 
4. If there have enough resource, and Step1 don't successfully select the ports, select the port in the small result set. 



