### PR TITLE
refine node exporter config & remove deprecated cadvisor config of configmap

### DIFF
--- a/service-deployment/bootstrap/prometheus/node-exporter-ds.yaml.template
+++ b/service-deployment/bootstrap/prometheus/node-exporter-ds.yaml.template
@@ -36,24 +36,22 @@ spec:
         resources:
           limits:
             memory: "1Gi"
+        securityContext:
+          privileged: true
         volumeMounts:
-        - mountPath: /datastorage/prometheus
+        - mountPath: /datastorage
           name: collector-mount
-        - name: rootfs
-          mountPath: /rootfs
-          readOnly: true
-        - name: var-run
-          mountPath: /var/run
-          readOnly: false
-        - name: sys
-          mountPath: /sys
-          readOnly: true
-        - name: docker
-          mountPath: /var/lib/docker
-          readOnly: true
         name: node-exporter
         args:
           - '--collector.textfile.directory=/datastorage/prometheus'
+          - '--no-collector.arp'
+          - '--no-collector.edac'
+          - '--no-collector.entropy'
+          - '--no-collector.infiniband'
+          - '--no-collector.vmstat'
+          - '--no-collector.wifi'
+          - '--no-collector.xfs'
+          - '--no-collector.zfs'
         ports:
         - containerPort: {{ clusterinfo['prometheusinfo']['node_exporter_port'] }}
           hostPort: {{ clusterinfo['prometheusinfo']['node_exporter_port'] }}
@@ -78,7 +76,7 @@ spec:
           name: device-mount
         - mountPath: /var/drivers
           name: driver-path
-        - mountPath: /datastorage/prometheus
+        - mountPath: /datastorage
           name: collector-mount
         name: gpu-exporter
       volumes:
@@ -99,7 +97,7 @@ spec:
             path: /var/drivers
         - name: collector-mount
           hostPath:
-            path: {{ clusterinfo[ 'dataPath' ] }}/prometheus
+            path: {{ clusterinfo[ 'dataPath' ] }}
         - name: rootfs
           hostPath:
             path: /

--- a/service-deployment/bootstrap/prometheus/node-exporter-ds.yaml.template
+++ b/service-deployment/bootstrap/prometheus/node-exporter-ds.yaml.template
@@ -36,8 +36,6 @@ spec:
         resources:
           limits:
             memory: "1Gi"
-        securityContext:
-          privileged: true
         volumeMounts:
         - mountPath: /datastorage
           name: collector-mount

--- a/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/service-deployment/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -35,16 +35,3 @@ data:
         regex: '([^:]+)(:\d*)?'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__ 
-    - job_name: 'cadvisor'
-      scrape_interval: 30s
-      kubernetes_sd_configs:
-      - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
-        role: node
-      # Extract label __address__ inner ip address and replace the port to exporter's port to build target address.  
-      # Prometheus will fetch data from target address. 
-      relabel_configs:
-      - source_labels: [__address__]
-        regex: '([^:]+)(:\d*)?'
-        replacement: '${1}:{{ clusterinfo['prometheusinfo']['cadvisor_port'] }}'
-        target_label: __address__ 
-


### PR DESCRIPTION
- filter node exporter not used metrics

- remove path which node exporter have no permission
error log:
time="2018-04-16T07:53:55Z" level=error msg="Error on statfs() system call for \"/var/lib/docker/overlay2/9ce7c6d18109cad5da031f46fe78a176ae06a304df160f9b158df5b2c3ba035e/merged\": permission denied" source="filesystem_linux.go:57"

- remove deprecated prometheus configmap

For issue:
https://github.com/Microsoft/pai/issues/482
https://github.com/Microsoft/pai/issues/458
