### PR TITLE
[REST Server] Save the original job config content

### DIFF
--- a/rest-server/src/controllers/job.js
+++ b/rest-server/src/controllers/job.js
@@ -112,7 +112,8 @@ const get = (req, res) => {
  * Submit or update job.
  */
 const update = (req, res) => {
-  Job.prototype.putJob(req.job.name, req.body, req.user.username, (err) => {
+  Job.prototype.putJob(
+    req.job.name, req.body, req.original_body, req.user.username, (err) => {
     if (err) {
       logger.warn('update job %s error\n%s', req.job.name, err.stack);
       return res.status(500).json({

--- a/rest-server/src/middlewares/parameter.js
+++ b/rest-server/src/middlewares/parameter.js
@@ -35,6 +35,7 @@ const validate = (schema) => {
           message: errorMessage,
         });
       } else {
+        req.original_body = req.body;
         req.body = value;
         next();
       }

--- a/rest-server/src/models/job.js
+++ b/rest-server/src/models/job.js
@@ -132,8 +132,7 @@ class Job {
       });
   }
 
-  putJob(name, data, username, next) {
-    const originData = data;
+  putJob(name, data, originalData, username, next) {
     data.username = username;
     if (!data.outputDir.trim()) {
       data.outputDir = `${launcherConfig.hdfsUri}/Output/${data.username}/${name}`;
@@ -187,7 +186,7 @@ class Job {
           (parallelCallback) => {
             fse.outputJson(
                 path.join(jobDir, launcherConfig.jobConfigFileName),
-                originData,
+                originalData,
                 {'spaces': 2},
                 (err) => parallelCallback(err));
           },


### PR DESCRIPTION
Previous method has an issue: the value of the constant `originData` in `putJob()` function changes after it's initialized, causing the saved job config content still includes unexpected fields such as `username` and other auto-generated ones. This is because `originData` is a *reference* to `data`. So if `data` changes `originData` also changes.