### PR TITLE
Fix:memory usage size line at node view and cluster view page

### DIFF
--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -464,7 +464,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree) - sum(node_memory_Buffers) - sum(node_memory_Cached)",
+              "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "usage",

--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -464,7 +464,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree)",
+              "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree) - sum(node_memory_Buffers) - sum(node_memory_Cached)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "usage",
@@ -476,6 +476,13 @@
               "intervalFactor": 2,
               "legendFormat": "free",
               "refId": "D"
+            },
+            {
+              "expr": "sum(node_memory_Buffers) + sum(node_memory_Cached)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "buff/cache",
+              "refId": "B"
             }
           ],
           "thresholds": [],

--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -175,7 +175,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_MemTotal{instance=~'$node'} - node_memory_MemFree{instance=~'$node'} - node_memory_Buffers{instance=~'$node'} - node_memory_Cached{instance=~'$node'}",
+              "expr": "node_memory_MemTotal{instance=~'$node'} - node_memory_MemFree{instance=~'$node'}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,

--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -175,7 +175,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_MemTotal{instance=~'$node'} - node_memory_MemFree{instance=~'$node'}",
+              "expr": "node_memory_MemTotal{instance=~'$node'} - node_memory_MemFree{instance=~'$node'} - node_memory_Buffers{instance=~'$node'} - node_memory_Cached{instance=~'$node'}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -194,6 +194,13 @@
               "legendFormat": "free",
               "refId": "E",
               "step": 600
+            },
+            {
+              "expr": "node_memory_Buffers{instance=~'$node'} + node_memory_Cached{instance=~'$node'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "buff/cache",
+              "refId": "B"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
memory usage at cluster view and node view.
 just use 3 lines: 
![image](https://user-images.githubusercontent.com/5576848/39230721-17ae22dc-489a-11e8-914b-db674411620b.png)


Extend from PR#520, as dir change conflict
https://github.com/Microsoft/pai/pull/520
