### PR TITLE
fix a bug in deploy.py when using cleanup-deployments command

### DIFF
--- a/pai-management/README.md
+++ b/pai-management/README.md
@@ -273,7 +273,7 @@ sudo ./deploy.py -d -p /path/to/configuration/directory
 ## Cleanup your previous deployment
 
 ```
-sudo ./deploy.py -p /path/to/configuration/directory
+sudo ./deploy.py -p /path/to/configuration/directory -c
 sudo ./cleanup-service.py
 ```
 

--- a/pai-management/README.md
+++ b/pai-management/README.md
@@ -273,7 +273,7 @@ sudo ./deploy.py -d -p /path/to/configuration/directory
 ## Cleanup your previous deployment
 
 ```
-sudo ./deploy.py -p /path/to/configuration/directory -c
+sudo ./deploy.py -p /path/to/configuration/directory
 sudo ./cleanup-service.py
 ```
 

--- a/pai-management/deploy.py
+++ b/pai-management/deploy.py
@@ -181,7 +181,7 @@ def clean_up_generated_file(service_config):
 
         for template in template_list:
 
-            if os.path.exists(template):
+            if os.path.exists("bootstrap/{0}/{1}".format(serv,template)):
                 shell_cmd = "rm -rf bootstrap/{0}/{1}".format(serv,template)
                 error_msg = "failed to rm bootstrap/{0}/{1}".format(serv,template)
                 execute_shell(shell_cmd, error_msg)


### PR DESCRIPTION
1. The command to cleanup deployments in `README.md` lose a parameter `-c`
2. There is a bug in `deploy.sh` when execute cleanup command. 

    ```
    # line 184, template is the file name rather than the relative path
    if os.path.exists(template):
    ```
   It should be
   ```
   if os.path.exists("bootstrap/{0}/{1}".format(serv,template)):
   ```