### PR TITLE
Add memory and cpu_vcores configuration for each nodemanager

### DIFF
--- a/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
+++ b/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
@@ -34,3 +34,11 @@ sed  -i "s/{HDFS_ADDRESS}/${HDFS_ADDRESS}/g" $HADOOP_CONF_DIR/core-site.xml
 
 sed  -i "s/{LOGSERVER_ADDRESS}/${LOGSERVER_ADDRESS}/g" $HADOOP_CONF_DIR/mapred-site.xml 
 
+# set memory and cpu resource for nodemanager
+mem_available=`cat /proc/meminfo | grep "MemAvailable" | awk '{print $2}'`
+# memory size to nodemanager is floor(available_memory * 0.8)
+let mem_available=mem_available*8/10/1024/1024*1024
+sed  -i "s/{mem_available}/${mem_available}/g" $HADOOP_CONF_DIR/yarn-site.xml
+
+cpu_vcores=`cat /proc/cpuinfo | grep "processor" | wc -l`
+sed  -i "s/{cpu_vcores}/${cpu_vcores}/g" $HADOOP_CONF_DIR/yarn-site.xml

--- a/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
+++ b/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
@@ -35,10 +35,10 @@ sed  -i "s/{HDFS_ADDRESS}/${HDFS_ADDRESS}/g" $HADOOP_CONF_DIR/core-site.xml
 sed  -i "s/{LOGSERVER_ADDRESS}/${LOGSERVER_ADDRESS}/g" $HADOOP_CONF_DIR/mapred-site.xml 
 
 # set memory and cpu resource for nodemanager
-mem_available=`cat /proc/meminfo | grep "MemTotal" | awk '{print $2}'`
+mem_total=`cat /proc/meminfo | grep "MemTotal" | awk '{print $2}'`
 # memory size to nodemanager is floor(available_memory * 0.8)
-let mem_available=mem_available*8/10/1024/1024*1024
-sed  -i "s/{mem_available}/${mem_available}/g" $HADOOP_CONF_DIR/yarn-site.xml
+let mem_allocated=mem_total*8/10/1024/1024*1024
+sed  -i "s/{mem_allocated}/${mem_allocated}/g" $HADOOP_CONF_DIR/yarn-site.xml
 
 cpu_vcores=`cat /proc/cpuinfo | grep "processor" | wc -l`
 sed  -i "s/{cpu_vcores}/${cpu_vcores}/g" $HADOOP_CONF_DIR/yarn-site.xml

--- a/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
+++ b/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
@@ -36,9 +36,9 @@ sed  -i "s/{LOGSERVER_ADDRESS}/${LOGSERVER_ADDRESS}/g" $HADOOP_CONF_DIR/mapred-s
 
 # set memory and cpu resource for nodemanager
 mem_total=`cat /proc/meminfo | grep "MemTotal" | awk '{print $2}'`
-# memory size to nodemanager is floor(available_memory * 0.8)
-let mem_allocated=mem_total*8/10/1024/1024*1024
-sed  -i "s/{mem_allocated}/${mem_allocated}/g" $HADOOP_CONF_DIR/yarn-site.xml
+# memory size to nodemanager is floor(mem_total * 0.8)
+let mem_total=mem_total*8/10/1024/1024*1024
+sed  -i "s/{mem_total}/${mem_total}/g" $HADOOP_CONF_DIR/yarn-site.xml
 
 cpu_vcores=`cat /proc/cpuinfo | grep "processor" | wc -l`
 sed  -i "s/{cpu_vcores}/${cpu_vcores}/g" $HADOOP_CONF_DIR/yarn-site.xml

--- a/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
+++ b/pai-management/bootstrap/hadoop-service/hadoop-configuration/nodemanager-generate-script.sh
@@ -35,7 +35,7 @@ sed  -i "s/{HDFS_ADDRESS}/${HDFS_ADDRESS}/g" $HADOOP_CONF_DIR/core-site.xml
 sed  -i "s/{LOGSERVER_ADDRESS}/${LOGSERVER_ADDRESS}/g" $HADOOP_CONF_DIR/mapred-site.xml 
 
 # set memory and cpu resource for nodemanager
-mem_available=`cat /proc/meminfo | grep "MemAvailable" | awk '{print $2}'`
+mem_available=`cat /proc/meminfo | grep "MemTotal" | awk '{print $2}'`
 # memory size to nodemanager is floor(available_memory * 0.8)
 let mem_available=mem_available*8/10/1024/1024*1024
 sed  -i "s/{mem_available}/${mem_available}/g" $HADOOP_CONF_DIR/yarn-site.xml

--- a/pai-management/config-patch/nodemanager-yarn-site.xml.patch
+++ b/pai-management/config-patch/nodemanager-yarn-site.xml.patch
@@ -15,7 +15,7 @@
 +
 +    <property>
 +        <name>yarn.nodemanager.resource.memory-mb</name>
-+        <value>{mem_allocated}</value>
++        <value>{mem_total}</value>
 +        <description>Number of memory that can be allocated for containers.</description>
 +    </property>
 +

--- a/pai-management/config-patch/nodemanager-yarn-site.xml.patch
+++ b/pai-management/config-patch/nodemanager-yarn-site.xml.patch
@@ -9,13 +9,13 @@
 +   
 +    <property>
 +        <name>yarn.nodemanager.resource.cpu-vcores</name>
-+        <value>24</value>
++        <value>{cpu_vcores}</value>
 +        <description>Number of CPU cores that can be allocated for containers.</description>
 +    </property>
 +
 +    <property>
 +        <name>yarn.nodemanager.resource.memory-mb</name>
-+        <value>204800</value>
++        <value>{mem_available}</value>
 +        <description>Number of memory that can be allocated for containers.</description>
 +    </property>
 +

--- a/pai-management/config-patch/nodemanager-yarn-site.xml.patch
+++ b/pai-management/config-patch/nodemanager-yarn-site.xml.patch
@@ -15,7 +15,7 @@
 +
 +    <property>
 +        <name>yarn.nodemanager.resource.memory-mb</name>
-+        <value>{mem_available}</value>
++        <value>{mem_allocated}</value>
 +        <description>Number of memory that can be allocated for containers.</description>
 +    </property>
 +


### PR DESCRIPTION
In current version, `yarn.nodemanager.resource.cpu-vcores` and `yarn.nodemanager.resource.memory-mb` are hard coded in each nodemanager's `yarn-site.xml` file where memory is `200G` and vcores is `24`. It is unsafe for yarn to allocate container on different nodes.

This pr add a feature that each nodemanager could set different `memory` and `cpu-vcores` according to nodes' hardware. 

The rule to set `cpu-vcores` and `memory-mb` is:
 `cpu-vcores` = (`count` of cpu cores in current node)
`memory-mb` = (`available memory` * 0.8)