### PR TITLE
fix TypeError: 'NoneType' object is not iterable

### DIFF
--- a/pai-management/kubernetesTool/servicestatus.py
+++ b/pai-management/kubernetesTool/servicestatus.py
@@ -44,7 +44,8 @@ def is_service_ready(servicename):
         return False
 
     for pod in pod_list.items:
-
+        if pod.status.container_statuses is None:
+            return False
         for container in pod.status.container_statuses:
             if container.ready != True:
                 return False


### PR DESCRIPTION
When run `cleanup-service.py`, sometimes cleaning-one-shot created, but status.container_statuses still None, it will cause follow error, and cleaning-one-shot-ds will not be deleted.

```bash
daemonset.extensions "cleaning-one-shot" created
Traceback (most recent call last):
  File "./cleanup-service.py", line 141, in <module>
    main()
  File "./cleanup-service.py", line 118, in main
    while servicestatus.is_service_ready('cleaning-one-shot') != True:
  File "/home/pai/pai-tools/pai-deploy/pai/pai-management/kubernetesTool/servicestatus.py", line 49, in is_service_ready
    for container in pod.status.container_statuses:
TypeError: 'NoneType' object is not iterable
```
