### PR TITLE
Solve Environment Issue. 

### DIFF
--- a/pai-management/container-setup.sh
+++ b/pai-management/container-setup.sh
@@ -17,14 +17,11 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pip uninstall requests
-echo y
-pip install requests
-echo y
-pip uninstall docopt
-echo y
-pip install docopt
-echo y
+
+echo y | pip uninstall requests
+echo y | pip install requests
+echo y | pip uninstall docopt
+echo y | pip install docopt
 
 cp -r /docker/* /usr/bin/
 

--- a/pai-management/container-setup.sh
+++ b/pai-management/container-setup.sh
@@ -17,6 +17,12 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+pip uninstall requests
+pip install requests
+pip uninstall docopt
+pip install docopt
+
+
 cp -r /docker/* /usr/bin/
 
 docker run hello-world  || exit $?

--- a/pai-management/container-setup.sh
+++ b/pai-management/container-setup.sh
@@ -18,10 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 pip uninstall requests
+echo y
 pip install requests
+echo y
 pip uninstall docopt
+echo y
 pip install docopt
-
+echo y
 
 cp -r /docker/* /usr/bin/
 


### PR DESCRIPTION
To solve the issue: 
```
/usr/local/lib/python2.7/dist-packages/requests/__init__.py:80: RequestsDependencyWarning: urllib3 (1.13.1) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/pai/pai-management/k8sPaiLibrary/monitorTool/check_node_label_exist.py", line 24, in <module>
    from ..monitorlib import nodestatus
  File "/pai/pai-management/k8sPaiLibrary/monitorlib/nodestatus.py", line 21, in <module>
    from kubernetes import client, config
  File "/usr/local/lib/python2.7/dist-packages/kubernetes/__init__.py", line 20, in <module>
    import kubernetes.config
  File "/usr/local/lib/python2.7/dist-packages/kubernetes/config/__init__.py", line 17, in <module>
    from .kube_config import (list_kube_config_contexts, load_kube_config,
  File "/usr/local/lib/python2.7/dist-packages/kubernetes/config/kube_config.py", line 23, in <module>
    import google.auth.transport.requests
  File "/usr/local/lib/python2.7/dist-packages/google/auth/transport/requests.py", line 31, in <module>
    caught_exc,
  File "/usr/lib/python2.7/dist-packages/six.py", line 718, in raise_from
    raise value
ImportError: The requests library is not installed, please install the requests package to use the requests transport.

```
