### PR TITLE
Solve Textfile busy issue when deploying service.

### DIFF
--- a/pai-management/bootstrap/cluster-configuration/delete.sh
+++ b/pai-management/bootstrap/cluster-configuration/delete.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-sh stop.sh
+/bin/bash stop.sh
 
 popd > /dev/null

--- a/pai-management/bootstrap/cluster-configuration/start.sh
+++ b/pai-management/bootstrap/cluster-configuration/start.sh
@@ -19,8 +19,8 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x configmap-create.sh
-./configmap-create.sh
+#chmod u+x configmap-create.sh
+/bin/bash configmap-create.sh
 
 kubectl create -f secret.yaml
 

--- a/pai-management/bootstrap/drivers/delete.sh
+++ b/pai-management/bootstrap/drivers/delete.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-sh stop.sh
+/bin/bash stop.sh
 
 popd > /dev/null

--- a/pai-management/bootstrap/drivers/refrash.sh.template
+++ b/pai-management/bootstrap/drivers/refrash.sh.template
@@ -22,7 +22,7 @@ pushd $(dirname "$0") > /dev/null
 echo "Re-label all the node in the cluster!"
 echo "New machine with GPU label will be labeled on kubernetes"
 
-sh node-label.sh
+/bin/bash node-label.sh
 
 echo "Remove the label on the machine without GPU tag"
 

--- a/pai-management/bootstrap/drivers/start.sh
+++ b/pai-management/bootstrap/drivers/start.sh
@@ -19,8 +19,8 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
-./node-label.sh
+#chmod u+x node-label.sh
+/bin/bash node-label.sh
 
 kubectl create -f drivers.yaml
 

--- a/pai-management/bootstrap/end-to-end-test/delete.sh
+++ b/pai-management/bootstrap/end-to-end-test/delete.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-sh stop.sh
+/bin/bash stop.sh
 
 popd > /dev/null

--- a/pai-management/bootstrap/frameworklauncher/refrash.sh.template
+++ b/pai-management/bootstrap/frameworklauncher/refrash.sh.template
@@ -24,7 +24,7 @@ echo "Refrash the configmap of launcher"
 kubectl create configmap frameworklauncher-configmap --from-file=frameworklauncher-configuration/ --dry-run -o yaml | kubectl apply -f -
 
 echo "Relabel the node with laucher tag"
-sh node-label.sh
+/bin/bash node-label.sh
 
 {% for host in machinelist %}
 

--- a/pai-management/bootstrap/frameworklauncher/start.sh
+++ b/pai-management/bootstrap/frameworklauncher/start.sh
@@ -19,13 +19,13 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
-chmod u+x configmap-create.sh
+#chmod u+x configmap-create.sh
 
-./configmap-create.sh
+/bin/bash configmap-create.sh
 
 kubectl create -f frameworklauncher.yaml
 

--- a/pai-management/bootstrap/grafana/delete.sh
+++ b/pai-management/bootstrap/grafana/delete.sh
@@ -20,7 +20,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "Call stop script to stop all service first"
-sh stop.sh
+/bin/bash stop.sh
 
 
 popd > /dev/null

--- a/pai-management/bootstrap/grafana/refrash.sh.template
+++ b/pai-management/bootstrap/grafana/refrash.sh.template
@@ -23,7 +23,7 @@ echo "refrash grafana-configuration"
 kubectl create configmap grafana-configuration --from-file=grafana-configuration/ --dry-run -o yaml | kubectl apply -f -
 
 echo "relabel the node label"
-sh node-label.sh
+/bin/bash node-label.sh
 
 {% for host in machinelist %}
 

--- a/pai-management/bootstrap/grafana/start.sh
+++ b/pai-management/bootstrap/grafana/start.sh
@@ -19,13 +19,13 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x configmap-create.sh
+#chmod u+x configmap-create.sh
 
-./configmap-create.sh
+/bin/bash configmap-create.sh
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
 kubectl create -f grafana.yaml
 

--- a/pai-management/bootstrap/hadoop-service/delete.sh
+++ b/pai-management/bootstrap/hadoop-service/delete.sh
@@ -20,7 +20,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "Call stop to stop all hadoop service first"
-sh stop.sh
+/bin/bash stop.sh
 
 echo "Create hadoop-delete configmap for deleting data on the host"
 kubectl create configmap hadoop-delete --from-file=hadoop-delete/

--- a/pai-management/bootstrap/hadoop-service/refrash.sh.template
+++ b/pai-management/bootstrap/hadoop-service/refrash.sh.template
@@ -24,7 +24,7 @@ echo "refrash hadoop-configuration"
 kubectl create configmap {{ clusterinfo[ 'hadoopinfo' ][ 'configmapname' ] }} --from-file=hadoop-configuration/ --dry-run -o yaml | kubectl apply -f -
 
 echo "relabel the node label"
-sh node-label.sh
+/bin/bash node-label.sh
 
 
 {% for host in machinelist %}

--- a/pai-management/bootstrap/hadoop-service/start.sh
+++ b/pai-management/bootstrap/hadoop-service/start.sh
@@ -19,13 +19,13 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
-chmod u+x configmap-create.sh
+#chmod u+x configmap-create.sh
 
-./configmap-create.sh
+/bin/bash configmap-create.sh
 
 
 # Zookeeper

--- a/pai-management/bootstrap/prometheus/delete.sh
+++ b/pai-management/bootstrap/prometheus/delete.sh
@@ -20,7 +20,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "Call stop to stop service first"
-sh stop.sh
+/bin/bash stop.sh
 
 echo "Create prometheus-delete configmap for deleting data on the host"
 kubectl create configmap prometheus-delete --from-file=prometheus-delete/

--- a/pai-management/bootstrap/prometheus/refrash.sh.template
+++ b/pai-management/bootstrap/prometheus/refrash.sh.template
@@ -25,7 +25,7 @@ echo "refrash prometheus configuration"
 kubectl apply -f prometheus-configmap.yaml
 
 echo "relabel node's label"
-sh node-label.sh
+/bin/bash node-label.sh
 
 {% for host in machinelist %}
 

--- a/pai-management/bootstrap/prometheus/start.sh
+++ b/pai-management/bootstrap/prometheus/start.sh
@@ -21,9 +21,9 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
 kubectl create -f prometheus-configmap.yaml
 kubectl create -f node-exporter-ds.yaml

--- a/pai-management/bootstrap/pylon/delete.sh
+++ b/pai-management/bootstrap/pylon/delete.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-sh stop.sh
+/bin/bash stop.sh
 
 popd > /dev/null

--- a/pai-management/bootstrap/pylon/refrash.sh.template
+++ b/pai-management/bootstrap/pylon/refrash.sh.template
@@ -21,7 +21,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "relabel node's lable"
-sh node-label.sh
+/bin/bash node-label.sh
 
 {% for host in machinelist %}
 

--- a/pai-management/bootstrap/pylon/start.sh
+++ b/pai-management/bootstrap/pylon/start.sh
@@ -19,9 +19,9 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
 kubectl create -f pylon.yaml
 

--- a/pai-management/bootstrap/rest-server/delete.sh
+++ b/pai-management/bootstrap/rest-server/delete.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-sh stop.sh
+/bin/bash stop.sh
 
 popd > /dev/null

--- a/pai-management/bootstrap/rest-server/refrash.sh.template
+++ b/pai-management/bootstrap/rest-server/refrash.sh.template
@@ -21,7 +21,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "relabel node's label"
-sh node-label.sh
+/bin/bash node-label.sh
 
 {% for host in machinelist %}
 

--- a/pai-management/bootstrap/rest-server/start.sh
+++ b/pai-management/bootstrap/rest-server/start.sh
@@ -19,9 +19,9 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
 kubectl create -f rest-server.yaml
 

--- a/pai-management/bootstrap/webportal/delete.sh
+++ b/pai-management/bootstrap/webportal/delete.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-sh stop.sh
+/bin/bash stop.sh
 
 popd > /dev/null

--- a/pai-management/bootstrap/webportal/refrash.sh.template
+++ b/pai-management/bootstrap/webportal/refrash.sh.template
@@ -21,7 +21,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "relabel node's label"
-sh node-label.sh
+/bin/bash node-label.sh
 
 {% for host in machinelist %}
 

--- a/pai-management/bootstrap/webportal/start.sh
+++ b/pai-management/bootstrap/webportal/start.sh
@@ -19,9 +19,9 @@
 
 pushd $(dirname "$0") > /dev/null
 
-chmod u+x node-label.sh
+#chmod u+x node-label.sh
 
-./node-label.sh
+/bin/bash node-label.sh
 
 kubectl create -f webportal.yaml
 

--- a/pai-management/paiLibrary/paiService/service_delete.py
+++ b/pai-management/paiLibrary/paiService/service_delete.py
@@ -39,13 +39,7 @@ class service_delete:
 
         delete_script = "bootstrap/{0}/{1}".format(self.service_name, self.service_conf["delete-script"])
 
-        cmd = "chmod +x {0}".format(delete_script)
-        err_msg = "Failed to run command [{0}] to grant execution permission to file {1}".format(cmd, delete_script)
-        self.logger.info("Change the permission of the script in path {0}.".format(delete_script))
-        self.logger.info("Begin to execute the cmd [ {0} ]".format(cmd))
-        linux_shell.execute_shell(cmd, err_msg)
-
-        cmd = "./{0}".format(delete_script)
+        cmd = "/bin/bash {0}".format(delete_script)
         err_msg = "Failed to execute the delete script of service {0}".format(self.service_name)
         self.logger.info("Begin to execute service {0}'s delete script.".format(self.service_name))
         linux_shell.execute_shell(cmd, err_msg)

--- a/pai-management/paiLibrary/paiService/service_refrash.py
+++ b/pai-management/paiLibrary/paiService/service_refrash.py
@@ -39,13 +39,7 @@ class service_refrash:
 
         refrash_script = "bootstrap/{0}/{1}".format(self.service_name, self.service_conf["refrash-script"])
 
-        cmd = "chmod +x {0}".format(refrash_script)
-        err_msg = "Failed to run command [{0}] to grant execution permission to file {1}".format(cmd, refrash_script)
-        self.logger.info("Change the permission of the script in path {0}.".format(refrash_script))
-        self.logger.info("Begin to execute the cmd [ {0} ]".format(cmd))
-        linux_shell.execute_shell(cmd, err_msg)
-
-        cmd = "./{0}".format(refrash_script)
+        cmd = "/bin/bash {0}".format(refrash_script)
         err_msg = "Failed to execute the refrash script of service {0}".format(self.service_name)
         self.logger.info("Begin to execute service {0}'s refrash script.".format(self.service_name))
         linux_shell.execute_shell(cmd, err_msg)

--- a/pai-management/paiLibrary/paiService/service_start.py
+++ b/pai-management/paiLibrary/paiService/service_start.py
@@ -39,13 +39,7 @@ class service_start:
 
         start_script = "bootstrap/{0}/{1}".format(self.service_name, self.service_conf["start-script"])
 
-        cmd = "chmod +x {0}".format(start_script)
-        err_msg = "Failed to run command [{0}] to grant execution permission to file {1}".format(cmd, start_script)
-        self.logger.info("Change the permission of the script in path {0}.".format(start_script))
-        self.logger.info("Begin to execute the cmd [ {0} ]".format(cmd))
-        linux_shell.execute_shell(cmd, err_msg)
-
-        cmd = "./{0}".format(start_script)
+        cmd = "/bin/bash {0}".format(start_script)
         err_msg = "Failed to execute the start script of service {0}".format(self.service_name)
         self.logger.info("Begin to execute service {0}'s start script.".format(self.service_name))
         linux_shell.execute_shell(cmd, err_msg)

--- a/pai-management/paiLibrary/paiService/service_stop.py
+++ b/pai-management/paiLibrary/paiService/service_stop.py
@@ -38,13 +38,7 @@ class service_stop:
 
         stop_script = "bootstrap/{0}/{1}".format(self.service_name, self.service_conf["stop-script"])
 
-        cmd = "chmod +x {0}".format(stop_script)
-        err_msg = "Failed to run command [{0}] to grant execution permission to file {1}".format(cmd, stop_script)
-        self.logger.info("Change the permission of the script in path {0}.".format(stop_script))
-        self.logger.info("Begin to execute the cmd [ {0} ]".format(cmd))
-        linux_shell.execute_shell(cmd, err_msg)
-
-        cmd = "./{0}".format(stop_script)
+        cmd = "/bin/bash {0}".format(stop_script)
         err_msg = "Failed to execute the stop script of service {0}".format(self.service_name)
         self.logger.info("Begin to execute service {0}'s stop script.".format(self.service_name))
         linux_shell.execute_shell(cmd, err_msg)


### PR DESCRIPTION
In the [SO problem: What generates the “text file busy” message in Unix?
](https://stackoverflow.com/questions/16764946/what-generates-the-text-file-busy-message-in-unix?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa), they says, ```The Text file busy error in specific is about trying to modify an executable while it is executing. The "Text" here refers to the fact that the file being modified is the text segment for a running program. This is a very special case, and not the generic one that your answer seems to suggest. Even so, your answer isn't entirely incorrect. – ArjunShank```

And we have a lot of shell and code will first set the permission of the script with the command ``` chmod u+x```, and with high potential, it will break the process of deployment.

This afternoon, @hao1939 , comes across this issue.
```
Error2: 
/bin/sh: 1: ./bootstrap/end-to-end-test/start.sh: Text file busy
2018-06-07 09:18:25,723 [ERROR] - paiLibrary.common.linux_shell : Failed to execute the start script of service end-to-end-test
``` 


## My solution

Remove all code which will call ```chmod``` to make script executable. And instead, run the script with the command following ```/bin/bash script.sh ```


