### PR TITLE
Refine VC configuration; fix bugs

### DIFF
--- a/cluster-configuration/services-configuration.yaml
+++ b/cluster-configuration/services-configuration.yaml
@@ -59,7 +59,6 @@ hadoop:
   # Step 1 of 4 to set up Hadoop queues.
   # Define all virtual clusters, equivalent concept of Hadoop queues:
   #   - Each VC will be assigned with (capacity / total_capacity * 100%) of the resources in the system.
-  #   - The 'capacity' fields must be filled in with integer values.
   #   - The 'default' VC can be used by any PAI user, i.e. a user will be automatically put into the
   #     member list of 'default' VC when it is created.
   #   - The system will automatically create the 'default' VC with 0 capacity, if 'default' VC has not

--- a/cluster-configuration/services-configuration.yaml
+++ b/cluster-configuration/services-configuration.yaml
@@ -57,15 +57,17 @@ hadoop:
   custom-hadoop-binary-path: None
   hadoop-version: 2.7.2
   # Step 1 of 4 to set up Hadoop queues.
-  # Define all virtual clusters, equivalent concept of Hadoop queues.
-  # The capacity of each virtual cluster is specified as the percentage of the whole resources in the system.
-  # All un-configured resources will go to an auto-generated virtual cluster called 'default', if the 'default' vc
-  # has not been explicitly specified in this section.
+  # Define all virtual clusters, equivalent concept of Hadoop queues:
+  #   - Each VC will be assigned with (capacity / total_capacity * 100%) of the resources in the system.
+  #   - The 'capacity' fields must be filled in with integer values.
+  #   - The 'default' VC can be used by any PAI user, i.e. a user will be automatically put into the
+  #     member list of 'default' VC when it is created.
+  #   - The system will automatically create the 'default' VC with 0 capacity, if 'default' VC has not
+  #     been explicitly specified here.
   virtualClusters:
-    # 'default' can be omitted here.
-    #default:
-    #  description: Default VC.
-    #  capacity: 40
+    default:
+      description: Default VC.
+      capacity: 40
     vc1:
       description: VC for Alice's team.
       capacity: 20

--- a/pai-management/container-setup.sh
+++ b/pai-management/container-setup.sh
@@ -17,6 +17,12 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+
+echo y | pip uninstall requests
+echo y | pip install requests
+echo y | pip uninstall docopt
+echo y | pip install docopt
+
 cp -r /docker/* /usr/bin/
 
 docker run hello-world  || exit $?

--- a/pai-management/paiLibrary/clusterObjectModel/paiObjectModel.py
+++ b/pai-management/paiLibrary/clusterObjectModel/paiObjectModel.py
@@ -219,7 +219,7 @@ class paiObjectModel:
         if "virtualClusters" in self.rawData["serviceConfiguration"]["hadoop"]:
             serviceDict["clusterinfo"]["virtualClusters"] = self.rawData["serviceConfiguration"]["hadoop"]["virtualClusters"]
         else:
-            serviceDict["clusterinfo"]["virtualClusters"] = []
+            serviceDict["clusterinfo"]["virtualClusters"] = {}
 
 
         # section : frameworklauncher

--- a/pai-management/paictl.py
+++ b/pai-management/paictl.py
@@ -159,28 +159,33 @@ def generate_etcd_ip_list(master_list):
 
 
 def generate_configuration_of_hadoop_queues(cluster_config):
-    #
+    """The method to configure VCs:
+      - Each VC correspoonds to a Hadoop queue.
+      - Each VC will be assigned with (capacity / total_capacity * 100%) of the resources in the system.
+      - The system will automatically create the 'default' VC with 0 capacity, if 'default' VC has not
+        been explicitly specified in the configuration file.
+      - If all capacities are 0, resources will be split evenly to each VC.
+    """
     hadoop_queues_config = {}
     #
-    total_weight = 0.0
-    for vc_name in cluster_config["clusterinfo"]["virtualClusters"]:
-        vc_config = cluster_config["clusterinfo"]["virtualClusters"][vc_name]
-        weight = float(vc_config["capacity"])
+    virtual_clusters_config = cluster_config["clusterinfo"]["virtualClusters"]
+    if "default" not in virtual_clusters_config:
+        virtual_clusters_config["default"] = {
+            "description": "Default VC.",
+            "capacity": 0
+        }
+    total_capacity = 0
+    for vc_name in virtual_clusters_config:
+        total_capacity += virtual_clusters_config[vc_name]["capacity"]
+    if total_capacity == 0:
+        for vc_name in virtual_clusters_config:
+            virtual_clusters_config[vc_name][capacity] = 1
+            total_capacity += 1
+    for vc_name in virtual_clusters_config:
         hadoop_queues_config[vc_name] = {
-            "description": vc_config["description"],
-            "weight": weight
+            "description": virtual_clusters_config[vc_name]["description"],
+            "weight": float(virtual_clusters_config[vc_name]["capacity"]) / float(total_capacity) * 100
         }
-        total_weight += weight
-    if "default" not in hadoop_queues_config:
-        hadoop_queues_config["default"] = {
-            "description": "Default virtual cluster.",
-            "weight": max(0.0, 100.0 - total_weight)
-        }
-    if total_weight != 100.0:
-        logger.warning("The sum of capacities (%d) should be equal to 100." % (total_weight))
-        for hq_name in hadoop_queues_config:
-            hq_config = hadoop_queues_config[hq_name]
-            hq_config["weight"] /= (total_weight / 100.0)
     #
     cluster_config["clusterinfo"]["hadoopQueues"] = hadoop_queues_config
 

--- a/pai-management/quick-start/services-configuration.yaml.template
+++ b/pai-management/quick-start/services-configuration.yaml.template
@@ -59,7 +59,6 @@ hadoop:
   # Step 1 of 4 to set up Hadoop queues.
   # Define all virtual clusters, equivalent concept of Hadoop queues:
   #   - Each VC will be assigned with (capacity / total_capacity * 100%) of the resources in the system.
-  #   - The 'capacity' fields must be filled in with integer values.
   #   - The 'default' VC can be used by any PAI user, i.e. a user will be automatically put into the
   #     member list of 'default' VC when it is created.
   #   - The system will automatically create the 'default' VC with 0 capacity, if 'default' VC has not

--- a/pai-management/quick-start/services-configuration.yaml.template
+++ b/pai-management/quick-start/services-configuration.yaml.template
@@ -57,15 +57,17 @@ hadoop:
   custom-hadoop-binary-path: None
   hadoop-version: 2.7.2
   # Step 1 of 4 to set up Hadoop queues.
-  # Define all virtual clusters, equivalent concept of Hadoop queues.
-  # The capacity of each virtual cluster is specified as the percentage of the whole resources in the system.
-  # All un-configured resources will go to an auto-generated virtual cluster called 'default', if the 'default' vc
-  # has not been explicitly specified in this section.
+  # Define all virtual clusters, equivalent concept of Hadoop queues:
+  #   - Each VC will be assigned with (capacity / total_capacity * 100%) of the resources in the system.
+  #   - The 'capacity' fields must be filled in with integer values.
+  #   - The 'default' VC can be used by any PAI user, i.e. a user will be automatically put into the
+  #     member list of 'default' VC when it is created.
+  #   - The system will automatically create the 'default' VC with 0 capacity, if 'default' VC has not
+  #     been explicitly specified here.
   #virtualClusters:
-  #  #'default' can be omitted here.
-  #  #default:
-  #  #  description: Default VC.
-  #  #  capacity: 40
+  #  default:
+  #    description: Default VC.
+  #    capacity: 40
   #  vc1:
   #    description: VC for Alice's team.
   #    capacity: 20
@@ -75,7 +77,6 @@ hadoop:
   #  vc3:
   #    description: VC for Charlie's team.
   #    capacity: 20
-
 
 
 frameworklauncher:


### PR DESCRIPTION
Logic:
- Each VC will be assigned with (capacity / total_capacity * 100%) of the resources in the system.
- The system will automatically create the 'default' VC with 0 capacity, if 'default' VC has not been explicitly specified in the configuration file.
- The system will split resources to each VC evenly if the total capacity is 0.
- The capacity of each VC will be automatically set to 0 if it is a negative number in the configuration file.

Test cases (all passed):
- Define capacities in float numbers.
- Do not include virtualClusters section in service-configurations.yaml file.
- Do not include 'default' VC in virtualClusters section.
- Set the capacity of a VC as a negative number.
- Set the capacities of all VCs as 0.