### PR TITLE
Web Portal: Fix status display in jobs table

### DIFF
--- a/webportal/src/app/job/job-view/job-view.component.js
+++ b/webportal/src/app/job/job-view/job-view.component.js
@@ -207,7 +207,10 @@ const loadJobs = (specifiedVc) => {
         return convertTime(true, createdTime, completedTime)
       } },
       {title: 'Retries', data: 'retries'},
-      {title: 'Status', data: null, render: getHumanizedJobStateString },
+      {title: 'Status', data: null, render(data, type) {
+        if (type !== 'display') return getHumanizedJobStateString(data)
+        return convertState(getHumanizedJobStateString(data))
+      } },
       {title: 'Stop', data: null, render(job, type) {
         let hjss = getHumanizedJobStateString(job);
         return (hjss === 'Waiting' || hjss === 'Running') ?


### PR DESCRIPTION
Introduced in #691

[`convertState`](/Microsoft/pai/pull/691/files#diff-297d09e3d94ba04115fb129259ce38e9L189) is used to render status column, which I copied as [`getHumanizedJobStateString`](/Microsoft/pai/pull/691/files#diff-297d09e3d94ba04115fb129259ce38e9R210) by mistake.