### PR TITLE
fix docker build apt-get related error

### DIFF
--- a/pai-management/src/end-to-end-test/dockerfile
+++ b/pai-management/src/end-to-end-test/dockerfile
@@ -17,7 +17,6 @@
 
 FROM hadoop-run
 
-RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get -y update && \
     apt-get -y install python git jq && \
     apt-get clean && \

--- a/pai-management/src/end-to-end-test/dockerfile
+++ b/pai-management/src/end-to-end-test/dockerfile
@@ -17,6 +17,7 @@
 
 FROM hadoop-run
 
+RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get -y update && \
     apt-get -y install python git jq && \
     apt-get clean && \

--- a/pai-management/src/frameworklauncher/dockerfile
+++ b/pai-management/src/frameworklauncher/dockerfile
@@ -19,7 +19,7 @@ FROM hadoop-run
 
 RUN apt-get -y update && \
     apt-get -y install maven
-RUN rm -rf /var/lib/apt/lists
+RUN rm -rf /var/lib/apt/lists/*
 
 COPY copied_file/ /usr/local/
 RUN chmod u+x /usr/local/frameworklauncher/build.sh

--- a/pai-management/src/frameworklauncher/dockerfile
+++ b/pai-management/src/frameworklauncher/dockerfile
@@ -17,6 +17,7 @@
 
 FROM hadoop-run
 
+RUN rm -rf /var/lib/apt/lists
 RUN apt-get -y update && \
     apt-get -y install maven
 

--- a/pai-management/src/frameworklauncher/dockerfile
+++ b/pai-management/src/frameworklauncher/dockerfile
@@ -17,9 +17,9 @@
 
 FROM hadoop-run
 
-RUN rm -rf /var/lib/apt/lists
 RUN apt-get -y update && \
     apt-get -y install maven
+RUN rm -rf /var/lib/apt/lists
 
 COPY copied_file/ /usr/local/
 RUN chmod u+x /usr/local/frameworklauncher/build.sh

--- a/pai-management/src/hadoop-run/dockerfile.template
+++ b/pai-management/src/hadoop-run/dockerfile.template
@@ -20,6 +20,7 @@ FROM base-image
 ENV HADOOP_VERSION=hadoop-{{ clusterconfig['clusterinfo']['hadoopinfo']['hadoopversion'] }}
 
 RUN apt-get -y install zookeeper libsnappy-dev
+RUN rm -rf /var/lib/apt/lists/*
 
 COPY hadoop/hadoop-{{ clusterconfig['clusterinfo']['hadoopinfo']['hadoopversion'] }}.tar.gz /usr/local/
 


### PR DESCRIPTION
This fix if for #710 #711 .

Hi @abuccts,   @ydye ,

Please help reviewing this Dockerfile fix.
As discussed before, we'd better fix the base image.
Bad lucky, the Dockerfile of base image (which is src/hadoop-run/dockerfile) is out of control.

Also noticed that the 'src/hadoop-run/dockerfile' was generated on the fly, maybe someone know how we can update it?





Clean up the apt-get cache before run any apt-get command.