### PR TITLE
Web Portal: fix vc column rendering in job table

### DIFF
--- a/webportal/src/app/job/job-view/job-view.component.js
+++ b/webportal/src/app/job/job-view/job-view.component.js
@@ -197,7 +197,10 @@ const loadJobs = (specifiedVc) => {
         return '<a href="view.html?jobName=' + name + '">' + name + '</a>';
       } },
       {title: 'User', data: 'username'},
-      {title: 'Virtual Cluster', data: 'virtualCluster', defaultContent: 'default'},
+      {title: 'Virtual Cluster', data: 'virtualCluster', render(virtualCluster) {
+        let vcName = virtualCluster || 'default';
+        return '<a href="virtual-clusters.html?vcName=' + vcName + '">' + vcName + '</a>';
+      }},
       {title: 'Start Time', data: 'createdTime', render(createdTime, type) {
         if (type !== 'display') return Math.round(createdTime / 1000);
         return convertTime(false, createdTime)


### PR DESCRIPTION
Introduced in #691

[`A link`](https://github.com/Microsoft/pai/pull/691/files#diff-297d09e3d94ba04115fb129259ce38e9L183) is used to render vc column, which I copied as [`virtualCluster`](https://github.com/Microsoft/pai/pull/691/files#diff-297d09e3d94ba04115fb129259ce38e9R200) by mistake.