### PR TITLE
Fix web portal build: no example files copied

### DIFF
--- a/pai-management/src/webportal/image.yaml
+++ b/pai-management/src/webportal/image.yaml
@@ -19,6 +19,8 @@
 copy-list:
   - src: ../job-tutorial
     dst: src/webportal/copied_file
+  - src: ../examples
+    dst:  src/webportal/copied_file
   - src: ../webportal
     dst:  src/webportal/copied_file
 


### PR DESCRIPTION
Introduced in #715 

This makes web portal depends on example directory in its build context.