### PR TITLE
Install Cron in base-image

### DIFF
--- a/pai-management/src/base-image/dockerfile
+++ b/pai-management/src/base-image/dockerfile
@@ -46,7 +46,8 @@ RUN apt-get -y update && \
       inotify-tools \
       rsync \
       realpath \
-      net-tools
+      net-tools \
+      cron
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 
 


### PR DESCRIPTION
Ref: https://serverfault.com/questions/853364/cron-and-crontab-are-missing-in-docker-image-of-ubuntu-16-04