### PR TITLE
Rest-server via Pylon correctly converts urls of RM/NM.

### DIFF
--- a/pylon/src/nginx.conf.template
+++ b/pylon/src/nginx.conf.template
@@ -71,6 +71,17 @@ http {
     # PAI REST server
     location ~ ^/rest-server/api(.*)$ {
       proxy_pass {{REST_SERVER_URI}}/api$1$is_args$args;
+      #
+      proxy_set_header Accept-Encoding "";
+      subs_filter_types *;
+      subs_filter
+        \"containerLog\":\"http://([^/]*):8042/(.*)\"
+        \"containerLog\":\"$scheme://$http_host/yarn/$1/8042/$2\"
+        r;
+      subs_filter
+        \"appTrackingUrl\":\"http://([^/]*):8088/(.*)\"
+        \"appTrackingUrl\":\"scheme://$http_host/yarn/$1/8088/$2\"
+        r;
     }
 
     # Kubernetes API server.


### PR DESCRIPTION
So that job detail page on web portal can correctly show the urls of app tracking page and container log page.