### PR TITLE
0.5.y hotfix, disable docker option --oom-kill-disable

### DIFF
--- a/rest-server/src/templates/yarnContainerScript.mustache
+++ b/rest-server/src/templates/yarnContainerScript.mustache
@@ -83,7 +83,6 @@ docker run --name $docker_name \
   --network=host \
   --cpus={{{ taskData.cpuNumber }}} \
   --memory={{{ taskData.memoryMB }}}m \
-  --oom-kill-disable \
   $nvidia_devices \
   --device=/dev/fuse \
   --security-opt apparmor:unconfined \


### PR DESCRIPTION
Docker '--oom-kill-disable' option would hang container, prevent it from be killed.
This hot-fix disable this option.

@fanyangCS @hwuu Please helping review.