### PR TITLE
Build hadoop only when needed

### DIFF
--- a/pai-management/paiLibrary/paiBuild/build_center.py
+++ b/pai-management/paiLibrary/paiBuild/build_center.py
@@ -117,7 +117,6 @@ class build_center:
             self.build(base_image)
 
         if image_build_worker.need_hadoop_binary():
-            self.hadoop_binary_remove()
             self.hadoop_ai_build()
             self.hadoop_binary_prepare()
 
@@ -128,9 +127,6 @@ class build_center:
         self.logger.info("{0}'s image building is successful.".format(image_name))
         self.logger.info("-----------------------------------------------------------")
         self.tag(image_name)
-
-        if image_build_worker.need_hadoop_binary():
-            self.hadoop_binary_remove()
 
 
 
@@ -155,6 +151,8 @@ class build_center:
 
     def run(self):
 
+        self.hadoop_binary_remove()
+
         self.done_dict = dict()
         self.docker_cli = docker_handler.docker_handler(
             docker_registry = self.cluster_object_model['clusterinfo']['dockerregistryinfo']['docker_registry_domain'],
@@ -172,6 +170,7 @@ class build_center:
                 continue
             self.build(image_name)
 
+        self.hadoop_binary_remove()
 
 
 

--- a/pai-management/paiLibrary/paiBuild/build_center.py
+++ b/pai-management/paiLibrary/paiBuild/build_center.py
@@ -115,6 +115,7 @@ class build_center:
         base_image = image_build_worker.get_dependency()
         if base_image != None:
             self.build(base_image)
+            self.tag(base_image)
 
         if image_build_worker.need_hadoop_binary:
             self.hadoop_binary_remove()

--- a/pai-management/paiLibrary/paiBuild/build_center.py
+++ b/pai-management/paiLibrary/paiBuild/build_center.py
@@ -116,12 +116,20 @@ class build_center:
         if base_image != None:
             self.build(base_image)
 
+        if image_build_worker.need_hadoop_binary:
+            self.hadoop_binary_remove()
+            self.hadoop_ai_build()
+            self.hadoop_binary_prepare()
+
         self.logger.info("-----------------------------------------------------------")
         self.logger.info("Begin to build {0}'s image.".format(image_name))
         image_build_worker.run()
         self.done_dict[image_name] = True
         self.logger.info("{0}'s image building is successful.".format(image_name))
         self.logger.info("-----------------------------------------------------------")
+
+        if image_build_worker.need_hadoop_binary:
+            self.hadoop_binary_remove()
 
 
 
@@ -146,10 +154,6 @@ class build_center:
 
     def run(self):
 
-        self.hadoop_binary_remove()
-        self.hadoop_ai_build()
-        self.hadoop_binary_prepare()
-
         self.done_dict = dict()
         self.docker_cli = docker_handler.docker_handler(
             docker_registry = self.cluster_object_model['clusterinfo']['dockerregistryinfo']['docker_registry_domain'],
@@ -168,7 +172,7 @@ class build_center:
             self.build(image_name)
             self.tag(image_name)
 
-        self.hadoop_binary_remove()
+
 
 
 

--- a/pai-management/paiLibrary/paiBuild/build_center.py
+++ b/pai-management/paiLibrary/paiBuild/build_center.py
@@ -116,7 +116,7 @@ class build_center:
         if base_image != None:
             self.build(base_image)
 
-        if image_build_worker.need_hadoop_binary:
+        if image_build_worker.need_hadoop_binary():
             self.hadoop_binary_remove()
             self.hadoop_ai_build()
             self.hadoop_binary_prepare()
@@ -129,7 +129,7 @@ class build_center:
         self.logger.info("-----------------------------------------------------------")
         self.tag(image_name)
 
-        if image_build_worker.need_hadoop_binary:
+        if image_build_worker.need_hadoop_binary():
             self.hadoop_binary_remove()
 
 

--- a/pai-management/paiLibrary/paiBuild/build_center.py
+++ b/pai-management/paiLibrary/paiBuild/build_center.py
@@ -115,7 +115,6 @@ class build_center:
         base_image = image_build_worker.get_dependency()
         if base_image != None:
             self.build(base_image)
-            self.tag(base_image)
 
         if image_build_worker.need_hadoop_binary:
             self.hadoop_binary_remove()
@@ -128,6 +127,7 @@ class build_center:
         self.done_dict[image_name] = True
         self.logger.info("{0}'s image building is successful.".format(image_name))
         self.logger.info("-----------------------------------------------------------")
+        self.tag(image_name)
 
         if image_build_worker.need_hadoop_binary:
             self.hadoop_binary_remove()
@@ -171,7 +171,7 @@ class build_center:
             if image_name in self.done_dict and self.done_dict[image_name] == True:
                 continue
             self.build(image_name)
-            self.tag(image_name)
+
 
 
 

--- a/pai-management/paiLibrary/paiBuild/image_build.py
+++ b/pai-management/paiLibrary/paiBuild/image_build.py
@@ -59,6 +59,12 @@ class image_build:
 
         return self.base_image
 
+    def need_hadoop_binary(self):
+
+        for copy_file in self.copy_list:
+            if str(copy_file["src"]) == "src/hadoop-run/hadoop":
+                return True
+        return False
 
 
     def prepare_template(self):

--- a/pai-management/paiLibrary/paiBuild/image_build.py
+++ b/pai-management/paiLibrary/paiBuild/image_build.py
@@ -61,6 +61,9 @@ class image_build:
 
     def need_hadoop_binary(self):
 
+        if self.copy_list == None:
+            return False
+
         for copy_file in self.copy_list:
             if str(copy_file["src"]) == "src/hadoop-run/hadoop":
                 return True

--- a/pai-management/src/hadoop-run/image.yaml
+++ b/pai-management/src/hadoop-run/image.yaml
@@ -17,5 +17,11 @@
 
 prerequisite: base-image
 
+copy-list:
+  # TODO It's a bit tricky here.
+  # This two line indicates it need hadoop-ai. For now, I don't want to make much change on code, so.
+  - src: src/hadoop-run/hadoop
+    dst: src/hadoop-run/tmp
+
 template-list:
   - dockerfile


### PR DESCRIPTION
1. Check image.yaml, when `src/hadoop-run/hadoop` is in the copy-list, build hadoop-ai, else skip hadoop-ai. Fixes #720 .
2. Move 'tag()' into the 'build()', now the base_image could be tagged. Fixes #747 .

@ydye , @haowu, please take a look.

