### PR TITLE
[Pylon] Refine and fix bugs

### DIFF
--- a/pylon/src/nginx.conf.template
+++ b/pylon/src/nginx.conf.template
@@ -54,7 +54,7 @@ http {
     # The proxy to WebHDFS API depends on it.
     #
 
-    location ~ ^/a/([^/]+)/(\d*)(.*)$ {
+    location ~ ^/a/([^/]+):(\d*)(.*)$ {
       set $target_host   $1;
       set $target_port   :$2;
       set $target_path   $3$is_args$args;
@@ -76,11 +76,11 @@ http {
       subs_filter_types *;
       subs_filter
         \"containerLog\":\"http://([^/]*):8042/(.*)\"
-        \"containerLog\":\"$scheme://$http_host/yarn/$1/8042/$2\"
+        \"containerLog\":\"$scheme://$http_host/yarn/$1:8042/$2\"
         r;
       subs_filter
         \"appTrackingUrl\":\"http://([^/]*):8088/(.*)\"
-        \"appTrackingUrl\":\"scheme://$http_host/yarn/$1/8088/$2\"
+        \"appTrackingUrl\":\"$scheme://$http_host/yarn/$1:8088/$2\"
         r;
     }
 
@@ -120,7 +120,7 @@ http {
       # Add '/' to the end of the URL, otherwise there will be a 404 error.
       return 301 $scheme://$http_host$request_uri/;
     }
-    location ~ ^/yarn/([^/]+)/(\d+)/(.*/)?([^/]*)$ {
+    location ~ ^/yarn/([^/]+):(\d+)/(.*/)?([^/]*)$ {
       set $target_host   $1;
       set $target_port   $2;
       set $target_path   $3$4$is_args$args;
@@ -131,7 +131,7 @@ http {
       proxy_intercept_errors on;
       error_page 301 302 307 = @handle_yarn_redirect;
       #
-      set $base $scheme://$http_host/yarn/$target_host/$target_port/;
+      set $base $scheme://$http_host/yarn/$target_host:$target_port/;
       #
       subs_filter
         "<html>"
@@ -148,23 +148,27 @@ http {
       #
       subs_filter
         href=(['"])/([^/]*):8042(['"])
-        href=$1$scheme://$http_host/yarn/$2/8042/node$3
+        href=$1$scheme://$http_host/yarn/$2:8042/node$3
         r;
       subs_filter
         href=(['"])http://([^/]*):8042(['"])
-        href=$1$scheme://$http_host/yarn/$2/8042/node$3
+        href=$1$scheme://$http_host/yarn/$2:8042/node$3
         r;
       subs_filter
         href=(['"])http://([^/]*):8042/(.*)(['"])
-        href=$1$scheme://$http_host/yarn/$2/8042/$3$4
+        href=$1$scheme://$http_host/yarn/$2:8042/$3$4
         r;
       subs_filter
         href=(['"])http://([^/]*):8088(['"])
-        href=$1$scheme://$http_host/yarn/$2/8088/cluster$3
+        href=$1$scheme://$http_host/yarn/$2:8088/cluster$3
         r;
       subs_filter
         href=(['"])http://([^/]*):8088/(.*)(['"])
-        href=$1$scheme://$http_host/yarn/$2/8088/$3$4
+        href=$1$scheme://$http_host/yarn/$2:8088/$3$4
+        r;
+      subs_filter
+        url=http://([^/]*):8188/(.*)\">
+        url=$scheme://$http_host/yarn/$1:8188/$2\">
         r;
       #
       subs_filter
@@ -176,12 +180,12 @@ http {
       set $target_path   $1$is_args$args;
       set $yarn_root_url {{YARN_WEB_PORTAL_URI}};
       if ($yarn_root_url ~ ^http://([^/]+):(\d+)$) {
-        return 301 $scheme://$http_host/yarn/$1/$2$target_path;
+        return 301 $scheme://$http_host/yarn/$1:$2$target_path;
       }
     }
     location @handle_yarn_redirect {
       if ($upstream_http_location ~ ^http://([^/]+):(\d+)/(.*/)?([^/]*)$) {
-        return 301 $scheme://$http_host/yarn/$1/$2/$3$4$is_args$args;
+        return 301 $scheme://$http_host/yarn/$1:$2/$3$4$is_args$args;
       }
     }
 

--- a/pylon/src/nginx.conf.template
+++ b/pylon/src/nginx.conf.template
@@ -75,11 +75,11 @@ http {
       proxy_set_header Accept-Encoding "";
       subs_filter_types *;
       subs_filter
-        \"containerLog\":\"http://([^/]*):8042/(.*)\"
+        \"containerLog\":\"http://([^/]*):8042/([^\"]*)\"
         \"containerLog\":\"$scheme://$http_host/yarn/$1:8042/$2\"
         r;
       subs_filter
-        \"appTrackingUrl\":\"http://([^/]*):8088/(.*)\"
+        \"appTrackingUrl\":\"http://([^/]*):8088/([^\"]*)\"
         \"appTrackingUrl\":\"$scheme://$http_host/yarn/$1:8088/$2\"
         r;
     }
@@ -147,27 +147,40 @@ http {
         r;
       #
       subs_filter
-        href=(['"])/([^/]*):8042(['"])
-        href=$1$scheme://$http_host/yarn/$2:8042/node$3
+        href=\'http://([^/]*):8042\'
+        href=\'$scheme://$http_host/yarn/$1:8042/node\'
         r;
       subs_filter
-        href=(['"])http://([^/]*):8042(['"])
-        href=$1$scheme://$http_host/yarn/$2:8042/node$3
+        href=\'http://([^/]*):8042/([^\']*)\'
+        href=\'$scheme://$http_host/yarn/$1:8042/$2\'
         r;
       subs_filter
-        href=(['"])http://([^/]*):8042/(.*)(['"])
-        href=$1$scheme://$http_host/yarn/$2:8042/$3$4
+        href=\'http://([^/]*):8088/([^\']*)\'
+        href=\'$scheme://$http_host/yarn/$1:8088/$2\'
+        r;
+      #
+      subs_filter
+        href=\"/([^/]*):8042\"
+        href=\"$scheme://$http_host/yarn/$1:8042/node\"
+        r;
+     subs_filter
+        href=\"http://([^/]*):8042\"
+        href=\"$scheme://$http_host/yarn/$1:8042/node\"
         r;
       subs_filter
-        href=(['"])http://([^/]*):8088(['"])
-        href=$1$scheme://$http_host/yarn/$2:8088/cluster$3
+        href=\"http://([^/]*):8042/([^\"]*)\"
+        href=\"$scheme://$http_host/yarn/$1:8042/$2\"
         r;
       subs_filter
-        href=(['"])http://([^/]*):8088/(.*)(['"])
-        href=$1$scheme://$http_host/yarn/$2:8088/$3$4
+        href=\"http://([^/]*):8088\"
+        href=\"$scheme://$http_host/yarn/$1:8088/cluster\"
         r;
       subs_filter
-        url=http://([^/]*):8188/(.*)\">
+        href=\"http://([^/]*):8088/([^\"]*)\"
+        href=\"$scheme://$http_host/yarn/$1:8088/$2\"
+        r;
+      subs_filter
+        url=http://([^/]*):8188/([^\"]*)\">
         url=$scheme://$http_host/yarn/$1:8188/$2\">
         r;
       #


### PR DESCRIPTION
Refine 1: Change the urls of yarn web pages from `/yarn/<ip>/<port>/...` to `/yarn/<ip>:<port>/...`, more consistent with the format of native yarn web page urls.

Refine 2: Support job history server (port 8188), thus the logs of finished jobs can now be viewed via pylon.

Fix bug: PAI REST API returns incorrect yarn url.