### PR TITLE
[exporter] job view network metrics

### DIFF
--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-jobview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-jobview-dashboard.json.template
@@ -280,7 +280,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (irate(container_NetIn{container_label_PAI_JOB_NAME=~\"$job\"}[5m])) ",
+              "expr": "avg by (container_label_PAI_JOB_NAME) (container_NetIn{container_label_PAI_JOB_NAME=~\"$job\"}) ",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -291,7 +291,7 @@
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (irate(container_NetIn{container_label_PAI_JOB_NAME=~\"$job\"}[5m])) ",
+              "expr": "avg by (container_label_PAI_JOB_NAME) (container_NetIn{container_label_PAI_JOB_NAME=~\"$job\"}) ",
               "format": "time_series",
               "hide": false,
               "interval": "",

--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-jobview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-jobview-dashboard.json.template
@@ -291,7 +291,7 @@
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (container_NetIn{container_label_PAI_JOB_NAME=~\"$job\"}) ",
+              "expr": "avg by (container_label_PAI_JOB_NAME) (container_NetOut{container_label_PAI_JOB_NAME=~\"$job\"}) ",
               "format": "time_series",
               "hide": false,
               "interval": "",

--- a/pai-management/bootstrap/prometheus/node-exporter-ds.yaml.template
+++ b/pai-management/bootstrap/prometheus/node-exporter-ds.yaml.template
@@ -90,6 +90,8 @@ spec:
         - mountPath: /datastorage/prometheus
           name: collector-mount
         name: gpu-exporter
+        command: ["python", "/usr/local/job_exporter.py"]
+        args: ["/datastorage/prometheus", "30"]
       volumes:
         - name: docker-bin
           hostPath:

--- a/pai-management/src/gpu-exporter/dockerfile
+++ b/pai-management/src/gpu-exporter/dockerfile
@@ -42,6 +42,7 @@ RUN cd infilter && make && cd ..
 RUN cp infilter/infilter /usr/bin
 #
 # start
-#
-
-CMD python /usr/local/job_exporter.py /datastorage/prometheus 30
+#  
+# The start cmd will be called at K8s config yaml file.
+# local container test cmd example: 
+# CMD python /usr/local/job_exporter.py /datastorage/prometheus 30

--- a/pai-management/src/gpu-exporter/dockerfile
+++ b/pai-management/src/gpu-exporter/dockerfile
@@ -40,9 +40,3 @@ RUN cp -r /usr/local/docker/* /usr/bin/
 RUN git clone https://github.com/yadutaf/infilter
 RUN cd infilter && make && cd ..
 RUN cp infilter/infilter /usr/bin
-#
-# start
-#  
-# The start cmd will be called at K8s config yaml file.
-# local container test cmd example: 
-# CMD python /usr/local/job_exporter.py /datastorage/prometheus 30

--- a/pai-management/src/gpu-exporter/dockerfile
+++ b/pai-management/src/gpu-exporter/dockerfile
@@ -29,7 +29,7 @@ ENV PATH=$PATH:$NV_DRIVER/bin
 WORKDIR /root/
 
 RUN apt-get update && \
-    apt-get -y install wget build-essential python python-pip git pciutils
+    apt-get -y install wget build-essential python python-pip git pciutils iftop lsof
 
 COPY copied_file/exporter/* /usr/local/
 
@@ -37,7 +37,9 @@ RUN wget https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-c
 RUN cp docker-17.06.2-ce.tgz /usr/local
 RUN tar xzvf /usr/local/docker-17.06.2-ce.tgz -C /usr/local/
 RUN cp -r /usr/local/docker/* /usr/bin/
-
+RUN git clone https://github.com/yadutaf/infilter
+RUN cd infilter && make && cd ..
+RUN cp infilter/infilter /usr/bin
 #
 # start
 #

--- a/prometheus/exporter/docker_inspect.py
+++ b/prometheus/exporter/docker_inspect.py
@@ -29,6 +29,10 @@ def parse_docker_inspect(jsonStr):
     labels = []
     envs = []
     inspectMetrics = {}
+    pid = ""
+    
+    if jsonObject[0]["State"]["Pid"]:
+        pid = jsonObject[0]["State"]["Pid"]
 
     if jsonObject[0]["Config"]["Labels"]:
         for key in jsonObject[0]["Config"]["Labels"]:
@@ -41,7 +45,7 @@ def parse_docker_inspect(jsonStr):
             if envItem[0] in targetEnv:
                 envs.append("container_env_{0}=\"{1}\"".format(envItem[0].replace(".", "_"), envItem[1]))
     
-    inspectMetrics = {"env": envs, "labels": labels}
+    inspectMetrics = {"pid": pid, env": envs, "labels": labels}
     return inspectMetrics
     
 def inspect(containerId):

--- a/prometheus/exporter/docker_inspect.py
+++ b/prometheus/exporter/docker_inspect.py
@@ -45,7 +45,7 @@ def parse_docker_inspect(jsonStr):
             if envItem[0] in targetEnv:
                 envs.append("container_env_{0}=\"{1}\"".format(envItem[0].replace(".", "_"), envItem[1]))
     
-    inspectMetrics = {"pid": pid, env": envs, "labels": labels}
+    inspectMetrics = {"pid": pid, "env": envs, "labels": labels}
     return inspectMetrics
     
 def inspect(containerId):

--- a/prometheus/exporter/job_exporter.py
+++ b/prometheus/exporter/job_exporter.py
@@ -23,11 +23,11 @@ import docker_stats
 import docker_inspect
 import gpu_exporter
 import time
-import logging  
+import logging
 import network
 from logging.handlers import RotatingFileHandler
 
-logger = logging.getLogger("gpu_expoter")  
+logger = logging.getLogger("gpu_expoter")
 
 def parse_from_labels(labels):
     gpuIds = []
@@ -79,6 +79,8 @@ def gen_job_metrics(logDir, gpuMetrics, connectionDic):
         containerMemUsage = 'container_MemUsage{{{0}}} {1}\n'.format(labelStr, stats[container]["MemUsage_Limit"]["usage"])
         containerMemLimit = 'container_MemLimit{{{0}}} {1}\n'.format(labelStr, stats[container]["MemUsage_Limit"]["limit"])
         inSize, outSize = network.acc_per_container_network_metrics(connectionDic, pid)
+        # iftop could get last 2s, 10s, 40s connection transform bytes.
+        # leverage iftop cmd get last 40s connection transform bytes.So inSize / 40.
         inBandwidth = inSize / 40
         outBandwidth = outSize / 40
         containerNetIn = 'container_NetIn{{{0}}} {1}\n'.format(labelStr, inBandwidth)
@@ -98,11 +100,11 @@ def gen_job_metrics(logDir, gpuMetrics, connectionDic):
 def main(argv):
     logDir = argv[0]
     timeSleep = int(argv[1])
-    logger.setLevel(logging.INFO)  
-    fh = RotatingFileHandler(logDir + "/gpu_exporter.log", maxBytes= 1024 * 1024 * 10, backupCount=5)  
-    fh.setLevel(logging.INFO) 
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")  
-    fh.setFormatter(formatter)   
+    logger.setLevel(logging.INFO)
+    fh = RotatingFileHandler(logDir + "/gpu_exporter.log", maxBytes= 1024 * 1024 * 10, backupCount=5)
+    fh.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    fh.setFormatter(formatter)
     logger.addHandler(fh)
 
     iter = 0

--- a/prometheus/exporter/job_exporter.py
+++ b/prometheus/exporter/job_exporter.py
@@ -85,8 +85,10 @@ def gen_job_metrics(logDir, gpuMetrics, connectionDic):
         containerMemUsage = 'container_MemUsage{{{0}}} {1}\n'.format(labelStr, stats[container]["MemUsage_Limit"]["usage"])
         containerMemLimit = 'container_MemLimit{{{0}}} {1}\n'.format(labelStr, stats[container]["MemUsage_Limit"]["limit"])
         inSize, outSize = network.acc_per_container_network_metrics(connectionDic, pid)
-        containerNetIn = 'container_NetIn{{{0}}} {1}\n'.format(labelStr, inSize)
-        containerNetOut = 'container_NetOut{{{0}}} {1}\n'.format(labelStr, outSize)
+        inBandwidth = inSize / 40
+        outBandwidth = outSize / 40
+        containerNetIn = 'container_NetIn{{{0}}} {1}\n'.format(labelStr, inBandwidth)
+        containerNetOut = 'container_NetOut{{{0}}} {1}\n'.format(labelStr, outBandwidth)
         containerBlockIn = 'container_BlockIn{{{0}}} {1}\n'.format(labelStr, stats[container]["BlockIO"]["in"])
         containerBlockOut = 'container_BlockOut{{{0}}} {1}\n'.format(labelStr, stats[container]["BlockIO"]["out"])
         containerMemPerc = 'container_MemPerc{{{0}}} {1}\n'.format(labelStr, stats[container]["MemPerc"])

--- a/prometheus/exporter/job_exporter.py
+++ b/prometheus/exporter/job_exporter.py
@@ -110,7 +110,7 @@ def main(argv):
             # collect GPU metrics
             gpuMetrics = gpu_exporter.gen_gpu_metrics_from_smi(logDir)
             # collection connection metrics
-            connectionDic = iftop()
+            connectionDic = network.iftop()
             # join with docker stats metrics and docker inspect labels
             gen_job_metrics(logDir, gpuMetrics, connectionDic)
         except:

--- a/prometheus/exporter/job_exporter.py
+++ b/prometheus/exporter/job_exporter.py
@@ -28,12 +28,6 @@ import network
 from logging.handlers import RotatingFileHandler
 
 logger = logging.getLogger("gpu_expoter")  
-logger.setLevel(logging.INFO)  
-fh = RotatingFileHandler("/datastorage/prometheus/gpu_exporter.log", maxBytes= 1024 * 1024 * 10, backupCount=5)  
-fh.setLevel(logging.INFO) 
-formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")  
-fh.setFormatter(formatter)   
-logger.addHandler(fh)
 
 def parse_from_labels(labels):
     gpuIds = []
@@ -104,6 +98,13 @@ def gen_job_metrics(logDir, gpuMetrics, connectionDic):
 def main(argv):
     logDir = argv[0]
     timeSleep = int(argv[1])
+    logger.setLevel(logging.INFO)  
+    fh = RotatingFileHandler(logDir + "/gpu_exporter.log", maxBytes= 1024 * 1024 * 10, backupCount=5)  
+    fh.setLevel(logging.INFO) 
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")  
+    fh.setFormatter(formatter)   
+    logger.addHandler(fh)
+
     iter = 0
     while(True):
         try:

--- a/prometheus/exporter/job_exporter.py
+++ b/prometheus/exporter/job_exporter.py
@@ -56,7 +56,7 @@ def parse_from_env(envs):
 
     return envStr
 
-def gen_job_metrics(logDir, gpuMetrics, connectionDic):
+def gen_job_metrics(logDir, gpuMetrics, connectionDic, connectionBytesDurtion = 40):
     stats = docker_stats.stats()
     outputFile = open(logDir + "/job_exporter.prom", "w")
     for container in stats:
@@ -81,8 +81,11 @@ def gen_job_metrics(logDir, gpuMetrics, connectionDic):
         inSize, outSize = network.acc_per_container_network_metrics(connectionDic, pid)
         # iftop could get last 2s, 10s, 40s connection transform bytes.
         # leverage iftop cmd get last 40s connection transform bytes.So inSize / 40.
-        inBandwidth = inSize / 40
-        outBandwidth = outSize / 40
+        if connectionBytesDurtion != 40 and connectionBytesDurtion != 10 and connectionBytesDurtion != 2:
+            connectionBytesDurtion = 40
+
+        inBandwidth = inSize / connectionBytesDurtion
+        outBandwidth = outSize / connectionBytesDurtion
         containerNetIn = 'container_NetIn{{{0}}} {1}\n'.format(labelStr, inBandwidth)
         containerNetOut = 'container_NetOut{{{0}}} {1}\n'.format(labelStr, outBandwidth)
         containerBlockIn = 'container_BlockIn{{{0}}} {1}\n'.format(labelStr, stats[container]["BlockIO"]["in"])

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -1,4 +1,4 @@
-  #!/usr/bin/python
+#!/usr/bin/python
 # Copyright (c) Microsoft Corporation
 # All rights reserved.
 #
@@ -131,9 +131,9 @@ def acc_per_container_network_metrics(connectionDic, pid):
 def main(argv):
     timeSleep = 3
     iter = 0
-    connectionDic = iftop()
-    pid = [704]
+    pid = [argv]
     while(True):
+        connectionDic = iftop()
         for id in pid:
             print(id)
             inSize, outSize = acc_per_container_network_metrics(connectionDic, id)

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -76,20 +76,13 @@ def parse_iftop(stats):
     return connectionDic
 
 def iftop():
-    test = "True"
-
-    if(test == "True"):
-        file = open("network/iftop.txt", "r") 
-        iftop = file.read()
-        return parse_iftop(iftop)
-    else:
-        try:
-            iftopCMD = "sudo iftop -t -P -s 1 -L 10000 -B -n -N"
-            iftopResult = subprocess.check_output([iftopCMD], shell=True)
-            result = parse_iftop(iftopResult)
-            return result
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+    try:
+        iftopCMD = "sudo iftop -t -P -s 1 -L 10000 -B -n -N"
+        iftopResult = subprocess.check_output([iftopCMD], shell=True)
+        result = parse_iftop(iftopResult)
+        return result
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
 
 def parse_lsof(stats):
     connections = {}
@@ -111,20 +104,13 @@ def parse_lsof(stats):
     return connections
 
 def lsof(containerPID):
-    test = "True"
-
-    if(test == "True"):
-        file = open("network/lsof.txt", "r") 
-        lsof = file.read()
-        return parse_lsof(lsof)
-    else:
-        try:
-            lsofCMD = "./infilter {} /usr/bin/lsof -i -n".format(containerPID)
-            isofResult = subprocess.check_output([lsofCMD], shell=True)
-            result = parse_lsof(isofResult)
-            return result
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+    try:
+        lsofCMD = "./infilter {} /usr/bin/lsof -i -n".format(containerPID)
+        isofResult = subprocess.check_output([lsofCMD], shell=True)
+        result = parse_lsof(isofResult)
+        return result
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
 
 def acc_per_container_network_metrics(connectionDic, pid):
     connections = lsof(pid)

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -41,7 +41,7 @@ def parse_iftop(stats):
     connectionDic = {}
     data = [line.split(',') for line in stats.splitlines()]
 
-    while True and len(data) > 0:
+    while len(data) > 0:
         item = data.pop(0)
 
         if len(item) > 0 and "------------" in item[0]:
@@ -150,7 +150,7 @@ def main(argv):
     timeSleep = 3
     iter = 0
     pid = [argv]
-    while(True):
+    while True :
         connectionDic = iftop()
         for id in pid:
             print(id)

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import subprocess
+import json
+import sys
+import re
+import time
+
+def convert_to_byte(data):
+    number = float(re.findall(r"(\d+(\.\d+)?)", data)[0][0])
+    if "T" in data:
+        return number * 1024 * 1024 * 1024 * 1024
+    elif "G" in data:
+        return number * 1024 * 1024 * 1024
+    elif "M" in data:
+        return number * 1024 * 1024
+    elif "K" in data:
+        return number * 1024
+    else: 
+        return number
+
+def parse_iftop(stats):
+    connectionDic = {}
+    data = [line.split(',') for line in stats.splitlines()]
+
+    while True and len(data) > 0:
+        item = data.pop(0)
+
+        if len(item) > 0 and "------------" in item[0]:
+            break
+
+    index = 0
+
+    while index < len(data):
+
+        if len(data[index]) > 0 and "------------" in data[index][0]:
+            break
+
+        srcStr = data[index][0]
+        desStr = data[index + 1][0]
+        srcSplit = srcStr.split("B")
+        desSplit = desStr.split("B")
+        srcAddress = re.findall(r'[0-9]+(?:\.[0-9]+){3}:[0-9]+', srcSplit[0])
+        srcIPPort = ""
+
+        if len(srcAddress) > 0:
+            srcIPPort = srcAddress[0]
+
+        desAddress = re.findall(r'[0-9]+(?:\.[0-9]+){3}:[0-9]+', desSplit[0])
+        desIPPort = ""
+
+        if len(desAddress) > 0:
+            desIPPort = desAddress[0]
+
+        connection = srcIPPort + "|" + desIPPort
+        lastOutDataSize = convert_to_byte(srcSplit[-3].strip())
+        lastInDataSize = convert_to_byte(desSplit[-3].strip())
+        connectionDic[connection] = {"inSize": lastInDataSize, "outSize": lastOutDataSize, "src": srcIPPort, "out": desIPPort}
+        index += 2
+    return connectionDic
+
+def iftop():
+    test = "True"
+
+    if(test == "True"):
+        file = open("network/iftop.txt", "r") 
+        iftop = file.read()
+        return parse_iftop(iftop)
+    else:
+        try:
+            iftopCMD = "sudo iftop -t -P -s 1 -L 10000 -B -n -N"
+            iftopResult = subprocess.check_output([iftopCMD], shell=True)
+            result = parse_iftop(iftopResult)
+            return result
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+
+def parse_lsof(stats):
+    connections = {}
+    data = stats.splitlines()
+    data.pop(0)
+    index = 0
+
+    for ditem in data:
+        srcDes = re.findall(r'[0-9]+(?:\.[0-9]+){3}:[0-9]+', ditem)
+        srcStr = ""
+        desStr = ""
+        srcDesStr = ""
+
+        if 2 == len(srcDes):
+            srcStr = srcDes[0]
+            desStr = srcDes[1]
+            srcDesStr = srcStr + "|" + desStr
+            connections[srcDesStr] = {"src": srcStr, "des": desStr}
+    return connections
+
+def lsof(containerPID):
+    test = "True"
+
+    if(test == "True"):
+        file = open("network/lsof.txt", "r") 
+        lsof = file.read()
+        return parse_lsof(lsof)
+    else:
+        try:
+            lsofCMD = "./infilter {} /usr/bin/lsof -i -n".format(containerPID)
+            isofResult = subprocess.check_output([lsofCMD], shell=True)
+            result = parse_lsof(isofResult)
+            return result
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+
+def acc_per_container_network_metrics(connectionDic, pid):
+    connections = lsof(pid)
+    accInBytes = 0
+    accOutBytes = 0
+
+    for conn in connections:
+        inBytes = 0
+        outBytes = 0
+        if conn in connectionDic:
+            inBytes = connectionDic[conn]["inSize"]
+            accInBytes += inBytes
+        if conn in connectionDic:
+            outBytes = connectionDic[conn]["outSize"]
+            accOutBytes += outBytes
+    return accInBytes, accOutBytes
+
+def main(argv):
+    timeSleep = 3
+    iter = 0
+    connectionDic = iftop()
+    pid = [704]
+    while(True):
+        for id in pid:
+            print(id)
+            inSize, outSize = acc_per_container_network_metrics(connectionDic, id)
+            print("pid {}, results: inBytes{}, outBytes{}".format(id, inSize, outSize))
+        time.sleep(timeSleep)
+
+# execute cmd example: python .\network.py 
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -37,7 +37,9 @@ def convert_to_byte(data):
     else: 
         return number
 
-def parse_iftop(stats):
+# iftop return 2s, 10s, 40s connection duration data.
+# connectionBytesDuration only could be set as 40, 10 or 2. 
+def parse_iftop(stats, connectionBytesDuration = 40):
     connectionDic = {}
     data = [line.split(',') for line in stats.splitlines()]
 
@@ -71,8 +73,17 @@ def parse_iftop(stats):
             desIPPort = desAddress[0]
 
         connection = srcIPPort + "|" + desIPPort
-        lastOutDataSize = convert_to_byte(srcSplit[-3].strip())
-        lastInDataSize = convert_to_byte(desSplit[-3].strip())
+
+        index = -3
+        if connectionBytesDuration == 40:
+            index = -3
+        if connectionBytesDuration == 10:
+            index = -4
+        if connectionBytesDuration == 2:
+            index = -5   
+
+        lastOutDataSize = convert_to_byte(srcSplit[index].strip())
+        lastInDataSize = convert_to_byte(desSplit[index].strip())
         connectionDic[connection] = {"inSize": lastInDataSize, "outSize": lastOutDataSize, "src": srcIPPort, "out": desIPPort}
         index += 2
     return connectionDic

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+  #!/usr/bin/python
 # Copyright (c) Microsoft Corporation
 # All rights reserved.
 #
@@ -77,7 +77,7 @@ def parse_iftop(stats):
 
 def iftop():
     try:
-        iftopCMD = "sudo iftop -t -P -s 1 -L 10000 -B -n -N"
+        iftopCMD = "iftop -t -P -s 1 -L 10000 -B -n -N"
         iftopResult = subprocess.check_output([iftopCMD], shell=True)
         result = parse_iftop(iftopResult)
         return result

--- a/prometheus/exporter/network.py
+++ b/prometheus/exporter/network.py
@@ -105,7 +105,7 @@ def parse_lsof(stats):
 
 def lsof(containerPID):
     try:
-        lsofCMD = "./infilter {} /usr/bin/lsof -i -n".format(containerPID)
+        lsofCMD = "infilter {} /usr/bin/lsof -i -n".format(containerPID)
         isofResult = subprocess.check_output([lsofCMD], shell=True)
         result = parse_lsof(isofResult)
         return result


### PR DESCRIPTION
This PR will make monitor to get job network bandwidth
Cause: As PAI job container use host network and launched from yarn nm (which is also running inner container), let tools like docker stats or other tools can't directly get container network traffic metrics. 

Solution:
This solution will get approximate job container network traffic. 

- exporter compute the metrics periodically
- get each container current connections [cmd lsof]
- get each connection last duration transform datasize [cmd iftop] 
- accumulate each container's connection transform size and compute the approximate bandwidth

This will let exporter does not need to maintain state and as a stateless service.
note: the disappeared connections  between 2 time interval may not be accumulated let this solution to be approximate results. 
