### PR TITLE
Lock the image tag for release 0.6.

### DIFF
--- a/cluster-configuration/services-configuration.yaml
+++ b/cluster-configuration/services-configuration.yaml
@@ -43,7 +43,8 @@ cluster:
     #docker-username: your_registry_username
     #docker-password: your_registry_password
 
-    docker-tag: latest
+    # Should match the PAI version, pai-0.6.y for the PAI release 0.6.
+    docker-tag: pai-0.6.y
 
     # The name of the secret in kubernetes will be created in your cluster
     # Must be lower case, e.g., regsecret.

--- a/cluster-configuration/services-configuration.yaml
+++ b/cluster-configuration/services-configuration.yaml
@@ -43,7 +43,7 @@ cluster:
     #docker-username: your_registry_username
     #docker-password: your_registry_password
 
-    # Should match the PAI version, v0.6.1 for the PAI release 0.6.
+    # Should match the PAI version, v0.6.1 for the PAI release 0.6.*.
     docker-tag: v0.6.1
 
     # The name of the secret in kubernetes will be created in your cluster

--- a/cluster-configuration/services-configuration.yaml
+++ b/cluster-configuration/services-configuration.yaml
@@ -43,8 +43,8 @@ cluster:
     #docker-username: your_registry_username
     #docker-password: your_registry_password
 
-    # Should match the PAI version, pai-0.6.y for the PAI release 0.6.
-    docker-tag: pai-0.6.y
+    # Should match the PAI version, v0.6.1 for the PAI release 0.6.
+    docker-tag: v0.6.1
 
     # The name of the secret in kubernetes will be created in your cluster
     # Must be lower case, e.g., regsecret.

--- a/pai-management/doc/how-to-write-pai-configuration.md
+++ b/pai-management/doc/how-to-write-pai-configuration.md
@@ -185,7 +185,7 @@ cluster:
     - ```docker-registry-domain```: E.g., gcr.io. If public，fill docker_registry_domain with the word "public".
     - ```docker-username```: The account of the docker registry
     - ```docker-password```: The password of the account
-    - ```docker-tag```: The image tag of the service. You could set the version here. Or just set latest here.
+    - ```docker-tag```: The image tag of the service, which should match the PAI release version, for example: `pai-0.6.y` for the release 0.6. Or use `latest` for the latest code.
     - ```secret-name```: Must be lower case, e.g., regsecret. The name of the secret in Kubernetes will be created for your cluster.
 
 Note that we provide a read-only public docker registry on DockerHub for official releases. To use this docker registry, th `docker-registry-info` section should be configured as follows, leaving `docker-username` and `docker-password` commented:
@@ -196,7 +196,7 @@ docker-registry-info:
   - docker-registry-domain: docker.io
   #- docker-username: <n/a>
   #- docker-password: <n/a>
-  - docker-tag: latest # or a specific version, i.e. 0.5.0.
+  - docker-tag: pai-0.6.y # the image tag for PAI release 0.6
   - secret-name: <anything>
 ```
 

--- a/pai-management/doc/how-to-write-pai-configuration.md
+++ b/pai-management/doc/how-to-write-pai-configuration.md
@@ -185,7 +185,7 @@ cluster:
     - ```docker-registry-domain```: E.g., gcr.io. If public，fill docker_registry_domain with the word "public".
     - ```docker-username```: The account of the docker registry
     - ```docker-password```: The password of the account
-    - ```docker-tag```: The image tag of the service, which should match the PAI release version, for example: `v0.6.1` for the release 0.6. Or use `latest` for the latest code.
+    - ```docker-tag```: The image tag of the service, which should match the PAI release version, for example: `v0.6.1` for the release 0.6.*. Or use `latest` for the latest code.
     - ```secret-name```: Must be lower case, e.g., regsecret. The name of the secret in Kubernetes will be created for your cluster.
 
 Note that we provide a read-only public docker registry on DockerHub for official releases. To use this docker registry, th `docker-registry-info` section should be configured as follows, leaving `docker-username` and `docker-password` commented:
@@ -196,7 +196,7 @@ docker-registry-info:
   - docker-registry-domain: docker.io
   #- docker-username: <n/a>
   #- docker-password: <n/a>
-  - docker-tag: v0.6.1 # the image tag for PAI release 0.6
+  - docker-tag: v0.6.1 # the image tag for PAI release 0.6.*
   - secret-name: <anything>
 ```
 

--- a/pai-management/doc/how-to-write-pai-configuration.md
+++ b/pai-management/doc/how-to-write-pai-configuration.md
@@ -185,7 +185,7 @@ cluster:
     - ```docker-registry-domain```: E.g., gcr.io. If public，fill docker_registry_domain with the word "public".
     - ```docker-username```: The account of the docker registry
     - ```docker-password```: The password of the account
-    - ```docker-tag```: The image tag of the service, which should match the PAI release version, for example: `pai-0.6.y` for the release 0.6. Or use `latest` for the latest code.
+    - ```docker-tag```: The image tag of the service, which should match the PAI release version, for example: `v0.6.1` for the release 0.6. Or use `latest` for the latest code.
     - ```secret-name```: Must be lower case, e.g., regsecret. The name of the secret in Kubernetes will be created for your cluster.
 
 Note that we provide a read-only public docker registry on DockerHub for official releases. To use this docker registry, th `docker-registry-info` section should be configured as follows, leaving `docker-username` and `docker-password` commented:
@@ -196,7 +196,7 @@ docker-registry-info:
   - docker-registry-domain: docker.io
   #- docker-username: <n/a>
   #- docker-password: <n/a>
-  - docker-tag: pai-0.6.y # the image tag for PAI release 0.6
+  - docker-tag: v0.6.1 # the image tag for PAI release 0.6
   - secret-name: <anything>
 ```
 

--- a/pai-management/quick-start/services-configuration.yaml.template
+++ b/pai-management/quick-start/services-configuration.yaml.template
@@ -43,7 +43,8 @@ cluster:
     #docker-username: <username>
     #docker-password: <password>
 
-    docker-tag: latest
+    # Should match the PAI version, pai-0.6.y for the PAI release 0.6.
+    docker-tag: pai-0.6.y
 
     # The name of the secret in kubernetes will be created in your cluster
     # Must be lower case, e.g., regsecret.

--- a/pai-management/quick-start/services-configuration.yaml.template
+++ b/pai-management/quick-start/services-configuration.yaml.template
@@ -44,7 +44,7 @@ cluster:
     #docker-password: <password>
 
     # Should match the PAI version, pai-0.6.y for the PAI release 0.6.
-    docker-tag: pai-0.6.y
+    docker-tag: v0.6.1
 
     # The name of the secret in kubernetes will be created in your cluster
     # Must be lower case, e.g., regsecret.

--- a/pai-management/quick-start/services-configuration.yaml.template
+++ b/pai-management/quick-start/services-configuration.yaml.template
@@ -43,7 +43,7 @@ cluster:
     #docker-username: <username>
     #docker-password: <password>
 
-    # Should match the PAI version, pai-0.6.y for the PAI release 0.6.
+    # Should match the PAI version, pai-0.6.y for the PAI release 0.6.*.
     docker-tag: v0.6.1
 
     # The name of the secret in kubernetes will be created in your cluster


### PR DESCRIPTION
Lock the docker images tags used for release 0.6 to 'pai-0.6.y'.

@fanyangCS @hwuu please take a look.