### PR TITLE
Fix the spelling mistakes of pai-management/doc and add python instruction in front of paictl.py

### DIFF
--- a/pai-management/doc/add-service.md
+++ b/pai-management/doc/add-service.md
@@ -1,4 +1,4 @@
-# add a serive
+# add a service
 
 For advanced user. A guide for developer to add their own service into pai.
 
@@ -91,7 +91,7 @@ prerequisite: hadoop-run
 Configuration consists of three parts. If any parts in your image's configuration is empty, just remove it.
 
 - ```prerequisite``` part:
-    - Your service image may be built from a base image. If the base image is a customized image and can't be pulled from a docker registry, you will have to build the base image first. In this tutrial, hbase image is built from hadoop-run which is pai's customized image, so we have to build hadoop-run first. After setting prerequisite fileds, paictl will build hadoop-run first.
+    - Your service image may be built from a base image. If the base image is a customized image and can't be pulled from a docker registry, you will have to build the base image first. In this tutrial, hbase image is built from hadoop-run which is pai's customized image, so we have to build hadoop-run first. After setting prerequisite fields, paictl will build hadoop-run first.
     - Note: If your base image could be pulled from a docker registry, just remove this. If your base image is pai's customized image or yourself's customized image added into pai, you must set this field.
 
 
@@ -174,7 +174,7 @@ upgraded-script: upgraded.sh
 This configuration consists of 7 parts.
 
 - ```prerequisite``` parts:
-    - Let's consider this scenario. There are 3 services named ```A```, ```B``` and ```C```. And now serivce ```C``` depends on serivce ```B``` and ```C```. If you wanna start ```C```, you will have to start ```A``` and ```B```. So in this field, you can tell paictl which service should be ready if you wanna start a service.
+    - Let's consider this scenario. There are 3 services named ```A```, ```B``` and ```C```. And now service ```C``` depends on service ```B``` and ```C```. If you wanna start ```C```, you will have to start ```A``` and ```B```. So in this field, you can tell paictl which service should be ready if you wanna start a service.
     - cluster-configuration is a special service in pai. Some important configuration of the cluster and registry's secret are in this service. So this service should be the first service of pai.
 
 -  ```template-list``` parts:
@@ -201,7 +201,7 @@ This configuration consists of 7 parts.
 [Node Label](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/)
 - Benefits
     - With node label and node selector, it is possible to assign a service pod to a specific node. For example, hadoop-name-node should be assigned to the node with the label master. And hadoop-data-node should be assigned to the node with the label worker.
-    - With node label, we are able to management a serivce on a specific node, but do not affect the same service on other nodes.
+    - With node label, we are able to management a service on a specific node, but do not affect the same service on other nodes.
 - Example
     - [Hadoop Service's node-label.sh](../bootstrap/hadoop-service/node-label.sh.template)
     - [Hadoop name node](../bootstrap/hadoop-service/hadoop-name-node.yaml.template)
@@ -251,7 +251,7 @@ This configuration consists of 7 parts.
 
 #### Place the Module into PAI <a name="Service_Place"></a>
 
- Note that the name of service's directory should be same with the serivce name.
+ Note that the name of service's directory should be same with the service name.
 
 For example, now we wanna add a service module "XYZ" into pai. You will first create a directory named "XYZ" in the path ```pai/pai-management/bootstrap/XYZ```. That is the service's directory named as the service's name.
 

--- a/pai-management/doc/cluster-bootup.md
+++ b/pai-management/doc/cluster-bootup.md
@@ -2,7 +2,7 @@
 
 This document introduces the detailed procedures to boot up PAI on a cluster. Please refer to this [section](../README.md) if user need the complete information on cluster deployment and maintenance.
 
-Please refer to Section [single box deployment](./single-box-deployment.md) if user would like to deplay PAI on a single server.
+Please refer to Section [single box deployment](./single-box-deployment.md) if user would like to deploy PAI on a single server.
 
 
 Table of contents:
@@ -41,7 +41,7 @@ With the cluster being set up, the steps to bring PAI up on it are as follows:
 This method is for advanced users. PAI configuration consists of 4 YAML files:
 
 - [`cluster-configuration.yaml`](./how-to-write-pai-configuration.md#cluster_configuration) - Machine-level configurations, including login info, machine SKUs, labels of each machine, etc.
-- [`kubernetes-configuration.yaml`](./how-to-write-pai-configuration.md#kubernetes_configuration) - Kubernetes-level configurations, part 1. This file contains basic configurations of Kuberntes, such as the version info, network configurations, etc.
+- [`kubernetes-configuration.yaml`](./how-to-write-pai-configuration.md#kubernetes_configuration) - Kubernetes-level configurations, part 1. This file contains basic configurations of Kubernetes, such as the version info, network configurations, etc.
 - [`k8s-role-definition.yaml`](./how-to-write-pai-configuration.md#k8s_role_definition) - Kubernetes-level configurations, part 2. This file contains the mappings of Kubernetes roles and machine labels.
 - [`serivices-configuration.yaml`](./how-to-write-pai-configuration.md#services_configuration) - Service-level configurations. This file contains the definitions of cluster id, docker registry, and those of all individual PAI services.
 
@@ -51,7 +51,7 @@ If you want to deploy PAI in single box environment, please refer to [Single Box
 
 ## Step 1b. Prepare PAI configuration: A quick start approach using `paictl` tool <a name="step-1b"></a>
 
-The second way, which is designed for fast deployment, is to generate a set of default configuration files from a very simple stariting-point file using the `paictl` maintenance tool:
+The second way, which is designed for fast deployment, is to generate a set of default configuration files from a very simple starting-point file using the `paictl` maintenance tool:
 
 ```
 python paictl.py cluster generate-configuration \
@@ -61,7 +61,7 @@ python paictl.py cluster generate-configuration \
 
 The 4 configuration files will be stored into the `/path/to/cluster-configuration/dir` folder. Note that most of the fields in the 4 configuration fields are automatically generated using default values. See [Appendix](#appendix) for an incomplete list of these default values.
 
-The `quick-start.yaml` file consits of the following sections:
+The `quick-start.yaml` file consists of the following sections:
 
 - `machines` - The list of all machines. The first machine will be configured as the master, and all other machines will be configured as workers.
 - `ssh-username` and `ssh-password`: Log-in info of all machines.
@@ -109,7 +109,7 @@ where `<master>` denotes the IP address of the load balancer of Kubernetes maste
 When Kubernetes is up and running, PAI services can then be deployed to it using `paictl` tool:
 
 ```
-paictl.py service start \
+python paictl.py service start \
   -p /path/to/cluster-configuration/dir \
   [ -n service-name ]
 ```
@@ -132,7 +132,7 @@ The `paictl` tool sets the following default values in the 4 configuration files
 - The first machine in the machine list will be configured as the master node.
 - If not explicitly specified, the SSH port is set to `22`.
 - If not explicitly specified, the cluster DNS is set to the value of the `nameserver` field in `/etc/resolv.conf` file of the master node.
-- If not explicitly specified, the IP range used by Kuberntes is set to `10.254.0.0/16`.
+- If not explicitly specified, the IP range used by Kubernetes is set to `10.254.0.0/16`.
 - The docker registry is set to `docker.io`, and the docker namespace is set to `openpai`. In another word, all PAI service images will be pulled from `docker.io/openpai` (see [this link](https://hub.docker.com/r/openpai/) on DockerHub for the details of all images).
 - Cluster id is set to `pai-example`.
 - Cluster id is set to `pai-example`.

--- a/pai-management/doc/how-to-setup-dev-box.md
+++ b/pai-management/doc/how-to-setup-dev-box.md
@@ -31,7 +31,7 @@ sudo docker run -itd \
 sudo docker exec -it dev-box /bin/bash
 cd /pai/pai-management
 
-# Now you are free to configure your cluaster and run PAI commands...
+# Now you are free to configure your cluster and run PAI commands...
 
 ```
 
@@ -76,6 +76,6 @@ sudo docker run -itd \
 sudo docker exec -it dev-box /bin/bash
 cd /pai/pai-management
 
-# Now you are free to configure your cluaster and run PAI commands...
+# Now you are free to configure your cluster and run PAI commands...
 
 ```

--- a/pai-management/doc/how-to-write-pai-configuration.md
+++ b/pai-management/doc/how-to-write-pai-configuration.md
@@ -12,7 +12,7 @@ Note: Please do not change the name of the configuration files. And those 4 file
 - [Set up cluster-configuration.yaml](#cluster_configuration)
 - [Set up k8s-role-definition.yaml](#k8s_role_definition)
 - [Set up kubernetes-configuration.yaml](#kubernetes_configuration)
-- [Set up serivices-configuration.yaml](#services_configuration)
+- [Set up services-configuration.yaml](#services_configuration)
 - [Kubernetes High Availability Configuration](#k8s-high-availability-configuration)
 
 ## Set up cluster-configuration.yaml <a name="cluster_configuration"></a>
@@ -29,7 +29,7 @@ default-machine-properties:
   sshport: port
 ```
 
-Set the default value of username, password, and sshport in default-machine-properties. PAI will use these default values to access cluter machines. User can override the default access information for each machine in [machine-list](#m_list).
+Set the default value of username, password, and sshport in default-machine-properties. PAI will use these default values to access cluster machines. User can override the default access information for each machine in [machine-list](#m_list).
 
 ### ```machine-sku```
 
@@ -94,7 +94,7 @@ machine-list:
 - ```hostname```: Required. You could the hostname by the command ```echo `hostname` ``` on the host.
 - ```hostip```: Required. The ip address of the corresponding host.
 - ```machine-type```: Required. The sku name defined in the ```machine-sku```.
-- ```etcdid```: K8s-Master Required. The etcd is part of kuberentes master. If you assign the k8s-role=master to a node, you should set this filed. This value will be used when starting and fixing k8s.
+- ```etcdid```: K8s-Master Required. The etcd is part of kubernetes master. If you assign the k8s-role=master to a node, you should set this filed. This value will be used when starting and fixing k8s.
 - ```sshport, username, password```: Optional. Used if this machine's account and port is different from the default properties. Or you can remove them.
 - ```k8s-role```: Required. You could set this value to ```master```, ```worker``` or ```proxy```. If you want to configure more than 1 k8s-master, please refer to [Kubernetes High Availability Configuration](#k8s-high-availability-configuration).
 - ```dashboard```: Select one node to set this field. And set the value as ``` "true" ```.
@@ -133,7 +133,7 @@ kubernetes:
 
 ### ```User *must* set the following fields to bootstrap a cluster ```
 
-- ```cluster-dns```: Find the namesever address in  /etc/resolv.conf
+- ```cluster-dns```: Find the nameserver address in  /etc/resolv.conf
 - ```load-balance-ip```: If the cluster has only one k8s-master, please set this field with the ip-address of your k8s-master. If there are more than one k8s-master, please refer to [k8s high availability configuration](#k8s-high-availability-configuration).
 
 ### ```Some values could use the default value```
@@ -147,7 +147,7 @@ kubernetes:
 - ```kube-controller-manager-version```: The version of kube-controller-manager.If the registry is gcr, you could find the version tag [here](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/cloud-controller-manager?gcrImageListsize=50)
 - ```dashboard-version```: The version of kubernetes-dashboard. If the registry is gcr, you could find the version tag [here](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/kubernetes-dashboard-amd64?gcrImageListsize=50)
 
-## Set up serivices-configuration.yaml <a name="services_configuration"></a>
+## Set up services-configuration.yaml <a name="services_configuration"></a>
 
 An example services-configuration.yaml file is available [here](../../cluster-configuration/services-configuration.yaml). The following explains the details of the yaml file.
 

--- a/pai-management/doc/machine-maintenance.md
+++ b/pai-management/doc/machine-maintenance.md
@@ -62,7 +62,7 @@ If some nodes in your cluster is unhealthy, you should repair them. The node sta
 
 
 ### Note:
-- This method will delete all kuberentes related data of pai in your cluster.
+- This method will delete all kubernetes related data of pai in your cluster.
 
 ### Steps:
 

--- a/pai-management/doc/paictl.md
+++ b/pai-management/doc/paictl.md
@@ -30,7 +30,7 @@ A tool to manage your pai cluster.
 ### Build infrastructure image(s) <a name="Image_Build"></a>
 
 ```
-paictl.py image build -p /path/to/cluster-configuration/dir [ -n image-name ]
+python paictl.py image build -p /path/to/cluster-configuration/dir [ -n image-name ]
 ```
 
 - Build hadoop-ai with tuned configurations.
@@ -40,7 +40,7 @@ paictl.py image build -p /path/to/cluster-configuration/dir [ -n image-name ]
 ### Push infrastructure image(s) <a name="Image_Push"></a>
 
 ```
-paictl.py image push -p /path/to/cluster-configuration/dir [ -n image-name ]
+python paictl.py image push -p /path/to/cluster-configuration/dir [ -n image-name ]
 ```
 
 - Push the tagged image to the docker registry which is configured in the cluster-configuration.
@@ -52,7 +52,7 @@ paictl.py image push -p /path/to/cluster-configuration/dir [ -n image-name ]
 ### Repair machines that have problems <a name="Machine_Repair"></a>
 
 ```
-paictl.py machine repair -p /path/to/cluster-configuration/dir -l machine-list.yaml
+python paictl.py machine repair -p /path/to/cluster-configuration/dir -l machine-list.yaml
 ```
 
 - See an example of the machine list [here](#Machine_Nodelist_Example).
@@ -60,7 +60,7 @@ paictl.py machine repair -p /path/to/cluster-configuration/dir -l machine-list.y
 ### Add machines to the cluster <a name="Machine_Add"></a>
 
 ```
-paictl.py machine add -p /path/to/cluster-configuration/dir -l machine-list.yaml
+python paictl.py machine add -p /path/to/cluster-configuration/dir -l machine-list.yaml
 ```
 
 - See an example of the machine list [here](#Machine_Nodelist_Example).
@@ -68,7 +68,7 @@ paictl.py machine add -p /path/to/cluster-configuration/dir -l machine-list.yaml
 ### Remove machines from the cluster <a name="Machine_Remove"></a>
 
 ```
-paictl.py machine remove -p /path/to/cluster-configuration/dir -l machine-list.yaml
+python paictl.py machine remove -p /path/to/cluster-configuration/dir -l machine-list.yaml
 ```
 
 - See an example of the machine list [here](#Machine_Nodelist_Example).
@@ -78,7 +78,7 @@ paictl.py machine remove -p /path/to/cluster-configuration/dir -l machine-list.y
 ### Start service(s) <a name="Service_Start"></a>
 
 ```
-paictl.py service start -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service start -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 1) Start all services by default.
@@ -87,7 +87,7 @@ paictl.py service start -p /path/to/cluster-configuration/dir [ -n service-name 
 ### Stop service(s) <a name="Service_Stop"></a>
 
 ```
-paictl.py service stop -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service stop -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 - Stop all services by default.
@@ -96,7 +96,7 @@ paictl.py service stop -p /path/to/cluster-configuration/dir [ -n service-name ]
 ### Delete service(s) <a name="Service_Delete"></a>
 
 ```
-paictl.py service delete -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service delete -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 - 'Delete' a service means to stop that service and then delete all of its persisted data in HDFS, Yarn, ZooKeeper, etc. 
@@ -106,7 +106,7 @@ paictl.py service delete -p /path/to/cluster-configuration/dir [ -n service-name
 ### Upgrade service(s) <a name="Service_Upgrade"></a>
 
 ```
-paictl.py service upgrade -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service upgrade -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 - Refresh all the labels on each node.
@@ -118,7 +118,7 @@ paictl.py service upgrade -p /path/to/cluster-configuration/dir [ -n service-nam
 ### Bootstrap the whole cluster (K8S + Service) with cluster-configuration <a name="Cluster_Boot"></a>
 
 ```
-paictl.py cluster bootstrap -p /path/to/clsuster-configuration/dir
+python paictl.py cluster bootstrap -p /path/to/clsuster-configuration/dir
 ```
 
 - Install kubectl in the deployment box.
@@ -128,7 +128,7 @@ paictl.py cluster bootstrap -p /path/to/clsuster-configuration/dir
 ### Bootstrap Kubernetes <a name="Cluster_K8s_Boot"></a>
 
 ```
-paictl.py cluster start-kubernetes -p /path/to/cluster-configuration/dir
+python paictl.py cluster start-kubernetes -p /path/to/cluster-configuration/dir
 ```
 
 - Install kubectl in the deployment box.
@@ -137,7 +137,7 @@ paictl.py cluster start-kubernetes -p /path/to/cluster-configuration/dir
 ### Stop Kubernetes <a name="Cluster_K8s_Stop"></a>
 
 ```
-paictl.py cluster stop-kubernetes -p /path/to/cluster-configuration/dir
+python paictl.py cluster stop-kubernetes -p /path/to/cluster-configuration/dir
 ```
 
 - Stop Kubernetes in the specified cluster.
@@ -145,16 +145,16 @@ paictl.py cluster stop-kubernetes -p /path/to/cluster-configuration/dir
 ### Upgrade Kubernetes <a name="Cluster_K8s_upgrade"></a>
 
 ```
-paictl.py cluster upgrade-kubernetes -p /path/to/cluster-configuration/dir
+python paictl.py cluster upgrade-kubernetes -p /path/to/cluster-configuration/dir
 ```
 
-- Stop all infrasturcture services in the specified cluster.
+- Stop all infrastructure services in the specified cluster.
 - Upgrade Kubernetes to a newer version.
 
 ### Generate cluster-configuration template files from a machine list <a name="Cluster_Conf_Generate"></a>
 
 ```
-paictl.py cluster generate-configuration -p /path/to/machinelist.csv
+python paictl.py cluster generate-configuration -p /path/to/machinelist.csv
 ```
 
 - The machine list should be provided in CSV format.
@@ -165,12 +165,12 @@ paictl.py cluster generate-configuration -p /path/to/machinelist.csv
 ## Install kubectl <a name="Kubectl"></a>
 
 ```
-paictl.py utility install-kubectl -p /path/to/cluster-configuration/dir
+python paictl.py utility install-kubectl -p /path/to/cluster-configuration/dir
 ```
 
 - The `kubectl` is a prerequisite to do all maintenance operations. If you find that `kubectl` has not been installed or correctly configured in your maintenance box, you have to install it first.
 
-## Appenix: An example of the `machine-list.yaml` file <a name="Machine_Nodelist_Example"></a>
+## Appendix: An example of the `machine-list.yaml` file <a name="Machine_Nodelist_Example"></a>
 
 ```yaml
 machine-list:

--- a/pai-management/doc/service-maintain.md
+++ b/pai-management/doc/service-maintain.md
@@ -8,7 +8,7 @@
 #### Start service in the cluster <a name="Service_Start"></a>
 
 ```
-paictl.py service start -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service start -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 1) Starting all service in your cluster.
@@ -18,7 +18,7 @@ paictl.py service start -p /path/to/cluster-configuration/dir [ -n service-name 
 #### Stop service in the cluster <a name="Service_Stop"></a>
 
 ```
-paictl.py service stop -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service stop -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 1) Stop all service in your cluster.
@@ -28,7 +28,7 @@ paictl.py service stop -p /path/to/cluster-configuration/dir [ -n service-name ]
 #### Delete (Stop and clean Data) Service in the cluster <a name="Service_Delete"></a>
 
 ```
-paictl.py service delete -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service delete -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 1) Firstly, it will stop all service on your cluster.
@@ -39,7 +39,7 @@ paictl.py service delete -p /path/to/cluster-configuration/dir [ -n service-name
 #### Fresh Service in the cluster <a name="Service_Delete"></a>
 
 ```
-paictl.py service refresh -p /path/to/cluster-configuration/dir [ -n service-name ]
+python paictl.py service refresh -p /path/to/cluster-configuration/dir [ -n service-name ]
 ```
 
 1) Update the configmap


### PR DESCRIPTION
Fix the spelling mistakes of pai-management/doc and add python instruction in front of paictl.py.