### PR TITLE
[hotfix] Add description and fix default for "custom-hadoop-binary-path"

### DIFF
--- a/cluster-configuration/services-configuration.yaml
+++ b/cluster-configuration/services-configuration.yaml
@@ -53,7 +53,8 @@ cluster:
 hadoop:
   # custom_hadoop_binary_path is required to build hadoop-ai.
   # More about hadoop-ai please follow the link: https://github.com/Microsoft/pai/tree/master/hadoop-ai.
-  custom-hadoop-binary-path: /pathHadoop/
+  # Notice: the name should be hadoop-{hadoop-version}.tar.gz
+  custom-hadoop-binary-path: /pathHadoop/hadoop-2.7.2.tar.gz
   hadoop-version: 2.7.2
   # Step 1 of 4 to set up Hadoop queues.
   # Define all virtual clusters, equivalent concept of Hadoop queues:

--- a/pai-management/doc/how-to-write-pai-configuration.md
+++ b/pai-management/doc/how-to-write-pai-configuration.md
@@ -206,7 +206,8 @@ Users can browse to https://hub.docker.com/r/openpai to see all the repositories
 ```YAML
 hadoop:
   # custom_hadoop_binary_path specifies the path PAI stores the custom built hadoop-ai
-  custom-hadoop-binary-path: /pathHadoop/
+  # Notice: the name should be hadoop-{hadoop-version}.tar.gz
+  custom-hadoop-binary-path: /pathHadoop/hadoop-2.7.2.tar.gz
   hadoop-version: 2.7.2
   virtualClusters:
     default:

--- a/pai-management/quick-start/services-configuration.yaml.template
+++ b/pai-management/quick-start/services-configuration.yaml.template
@@ -53,7 +53,8 @@ cluster:
 hadoop:
   # When needed, hadoop-ai would be downloaded and built under 'custom-hadoop-binary-path'.
   # More about hadoop-ai please follow the link: https://github.com/Microsoft/pai/tree/master/hadoop-ai.
-  custom-hadoop-binary-path: /pathHadoop/
+  # Notice: the name should be hadoop-{hadoop-version}.tar.gz
+  custom-hadoop-binary-path: /pathHadoop/hadoop-2.7.2.tar.gz
   hadoop-version: 2.7.2
   # Step 1 of 4 to set up Hadoop queues.
   # Define all virtual clusters, equivalent concept of Hadoop queues:


### PR DESCRIPTION
The "custom-hadoop-binary-path" should include a 'filename', but not directory.
Fixes #780 .

@ydye please take a look.