### PR TITLE
fix jinja2 unicodedecodeerror

### DIFF
--- a/pai-management/k8sPaiLibrary/maintainlib/common.py
+++ b/pai-management/k8sPaiLibrary/maintainlib/common.py
@@ -74,7 +74,7 @@ def execute_shell_return(shell_cmd, error_msg):
 def read_template(template_path):
 
     with open(template_path, "r") as fin:
-        template_data = fin.read()
+        template_data = fin.read().decode('utf-8')
 
     return template_data
 

--- a/pai-management/paiLibrary/common/file_handler.py
+++ b/pai-management/paiLibrary/common/file_handler.py
@@ -39,7 +39,7 @@ def load_yaml_config(config_path):
 def read_template(template_path):
 
     with open(template_path, "r") as f:
-        template_data = f.read()
+        template_data = f.read().decode('utf-8')
 
     return template_data
 

--- a/pai-management/paiLibrary/imageTool/host-configure.py
+++ b/pai-management/paiLibrary/imageTool/host-configure.py
@@ -37,7 +37,7 @@ def load_yaml_config(config_path):
 def read_template(template_path):
 
     with open(template_path, "r") as f:
-        template_data = f.read()
+        template_data = f.read().decode('utf-8')
 
     return template_data
 


### PR DESCRIPTION
if template file contains Chinese, it will raise error as follow:

```bash
Traceback (most recent call last):
  File "./paictl.py", line 449, in <module>
    main()
  File "./paictl.py", line 426, in main
    pai_build()
  File "./paictl.py", line 278, in pai_build
    center.run()
  File "/home/pai/paiflow/deploy-pai/pai/pai-management/paiLibrary/paiBuild/build_center.py", line 169, in run
    self.build(image_name)
  File "/home/pai/paiflow/deploy-pai/pai/pai-management/paiLibrary/paiBuild/build_center.py", line 121, in build
    image_build_worker.run()
  File "/home/pai/paiflow/deploy-pai/pai/pai-management/paiLibrary/paiBuild/image_build.py", line 149, in run
    self.prepare_template()
  File "/home/pai/paiflow/deploy-pai/pai/pai-management/paiLibrary/paiBuild/image_build.py", line 78, in prepare_template
    generated_data = template_handler.generate_from_template_dict(template_data, map_dict)
  File "/home/pai/paiflow/deploy-pai/pai/pai-management/paiLibrary/common/template_handler.py", line 27, in generate_from_template_dict
    generated_file = jinja2.Template(template_data).render(
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 926, in __new__
    return env.from_string(source, template_class=cls)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 862, in from_string
    return cls.from_code(self, self.compile(source), globals, None)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 551, in compile
    source = self._parse(source, name, filename)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 470, in _parse
    return Parser(self, source, name, encode_filename(filename)).parse()
  File "/usr/lib/python2.7/dist-packages/jinja2/parser.py", line 31, in __init__
    self.stream = environment._tokenize(source, name, filename, state)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 501, in _tokenize
    source = self.preprocess(source, name, filename)
  File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 495, in preprocess
    self.iter_extensions(), text_type(source))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 265: ordinal not in range(128)
```