### PR TITLE
Add utf-8 encoding for stdout in pai-management/k8sPaiLibrary/maintainlib/common.py

### DIFF
--- a/pai-management/k8sPaiLibrary/maintainlib/common.py
+++ b/pai-management/k8sPaiLibrary/maintainlib/common.py
@@ -160,8 +160,6 @@ def sftp_paramiko(src, dst, filename, host_config):
     stdin, stdout, stderr = ssh.exec_command("sudo mkdir -p {0}".format(dst), get_pty=True)
     stdin.write(password + '\n')
     stdin.flush()
-    for response_msg in stdout:
-        print(response_msg.strip('\n'))
 
     ssh.close()
 
@@ -239,8 +237,6 @@ def ssh_shell_with_password_input_paramiko(host_config, commandline):
     stdin.write(password + '\n')
     stdin.flush()
     logger.info("Executing the command on host [{0}]: {1}".format(hostip, commandline))
-    for response_msg in stdout:
-        print (response_msg.strip('\n'))
 
     ssh.close()
     return True

--- a/pai-management/k8sPaiLibrary/maintainlib/common.py
+++ b/pai-management/k8sPaiLibrary/maintainlib/common.py
@@ -160,6 +160,8 @@ def sftp_paramiko(src, dst, filename, host_config):
     stdin, stdout, stderr = ssh.exec_command("sudo mkdir -p {0}".format(dst), get_pty=True)
     stdin.write(password + '\n')
     stdin.flush()
+    for response_msg in stdout:
+        print(response_msg.encode('utf-8').strip('\n'))
 
     ssh.close()
 
@@ -206,7 +208,7 @@ def ssh_shell_paramiko_with_result(host_config, commandline):
     result_stdout = ""
     for response_msg in stdout:
         result_stdout += response_msg
-        print(response_msg.strip('\n'))
+        print(response_msg.encode('utf-8').strip('\n'))
     result_stderr = ""
     for response_msg in stderr:
         result_stderr += response_msg
@@ -237,6 +239,8 @@ def ssh_shell_with_password_input_paramiko(host_config, commandline):
     stdin.write(password + '\n')
     stdin.flush()
     logger.info("Executing the command on host [{0}]: {1}".format(hostip, commandline))
+    for response_msg in stdout:
+        print (response_msg.encode('utf-8').strip('\n'))
 
     ssh.close()
     return True


### PR DESCRIPTION
In ubuntu environment which uses Chinese language, ```python paictl.py cluster k8s-bootup -p /path/to/cluster-configuration/dir``` will cause the encoding error as the picture shown below. 
So I remove the unnecessary output code.
Or maybe it could be resolved by using utf-8 encoding, but i think it's not a universal solution.

![image](https://user-images.githubusercontent.com/6756545/42271365-b5bcd480-7fb5-11e8-9ee1-04b3007b04f9.png)

