### PR TITLE
add tools for detective broken links in documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tmp/
 dist/
 __pycache__
 *.pyc
+*.swp
+*.swo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ matrix:
       before_install:
         - cd pai-management
       install:
-        - pip install paramiko pyyaml jinja2 python-etcd kubernetes markdown
+        - pip install paramiko pyyaml jinja2 python-etcd kubernetes
       script:
         - python -m unittest discover test/
+    - language: python
+      python: 2.7
+      install:
+        - pip install markdown
+      script:
         - python utilities/doc_checker.py .
     - language: java
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ matrix:
       before_install:
         - cd pai-management
       install:
-        - pip install paramiko pyyaml jinja2 python-etcd kubernetes
+        - pip install paramiko pyyaml jinja2 python-etcd kubernetes markdown
       script:
         - python -m unittest discover test/
+        - python utilities/doc_checker.py .
     - language: java
       jdk: oraclejdk8
       before_install:

--- a/utilities/doc_checker.py
+++ b/utilities/doc_checker.py
@@ -1,0 +1,94 @@
+import sys
+import logging
+import os
+import codecs
+import urlparse
+import markdown # https://python-markdown.github.io/
+
+logger = logging.getLogger(__name__)
+
+class LinkChecker(markdown.treeprocessors.Treeprocessor):
+    def __init__(self, dir_name, file_name, *args, **kwargs):
+        markdown.treeprocessors.Treeprocessor.__init__(self, *args, **kwargs)
+
+        self.dir_name = dir_name
+        self.file_name = file_name
+        self.has_error = False
+
+    def run(self, root):
+        for node in root.iter():
+            if node.tag == "a":
+                link = node.get("href")
+                url = urlparse.urlparse(link)
+
+                # TODO check remot links
+                if url.netloc == "": # local link
+                    path = os.path.join(self.dir_name, url.path)
+                    if url.path == "" and url.fragment != "":
+                        continue
+
+                    # TODO check fragment
+
+                    if not os.path.exists(path):
+                        print "link %s in file %s doesn't exist" % (link, os.path.join(self.dir_name, self.file_name))
+                        self.has_error = True
+
+
+class LinkCheckerExtension(markdown.Extension):
+    def __init__(self, dir_name, file_name, *args, **kwargs):
+        markdown.Extension.__init__(self, *args, **kwargs)
+
+        self.dir_name = dir_name
+        self.file_name = file_name
+
+    def extendMarkdown(self, md, md_globals):
+        md.treeprocessors.add(
+            "link_checker", LinkChecker(self.dir_name, self.file_name, md), ">inline"
+        )
+
+
+def check(doc_path):
+    """ check doc file in `doc_path`. return True on error occurs,
+    broken links will be outputed to stdout """
+    dir_name = os.path.dirname(doc_path)
+    file_name = os.path.basename(doc_path)
+
+    md = markdown.Markdown(extensions=[LinkCheckerExtension(dir_name, file_name)])
+    with codecs.open(doc_path, "r", "utf-8") as f:
+        md.convert(f.read())
+
+    return md.treeprocessors.get("link_checker").has_error
+
+
+def check_all(doc_root):
+    """ check_all iteratively checks docs link. return True on error occurs,
+    broken links will be outputed to stdout """
+    has_error = False
+    for root, dirs, files in os.walk(doc_root):
+        for name in files:
+            if name.endswith(".md"):
+                path = os.path.join(root, name)
+
+                md = markdown.Markdown(extensions=[LinkCheckerExtension(root, name)])
+                with codecs.open(path, "r", "utf-8") as f:
+                    md.convert(f.read())
+                has_error = has_error or md.treeprocessors.get("link_checker").has_error
+    return has_error
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.stderr.write("Usage: doc_checker.py (doc_dir|doc_file)\n")
+        sys.exit(1)
+
+    doc_root = os.path.abspath(sys.argv[1])
+
+    if os.path.isdir(doc_root):
+        has_error = check_all(doc_root)
+    else:
+        has_error = check(doc_root)
+
+    if has_error:
+        sys.exit(2)
+    else:
+        sys.exit(0)


### PR DESCRIPTION
fix #808 

Current working in progress. Already detected broken links:

```
link mailto:opencode@microsoft.com in file /home/dixu/dev/pai/README.md doesn't exist
link ../service-deployment/README.md in file /home/dixu/dev/pai/webportal/README.md doesn't exist
link ../service-deployment/clusterconfig-example.yaml in file /home/dixu/dev/pai/webportal/README.md doesn't exist
link ../service-deployment/README.md in file /home/dixu/dev/pai/pylon/README.md doesn't exist
link ../service-deployment/clusterconfig-example.yaml in file /home/dixu/dev/pai/pylon/README.md doesn't exist
link ../../job-tutorial/Dockerfiles/cuda8.0-cudnn6/Dockerfile.run.cntk in file /home/dixu/dev/pai/examples/keras/README.md doesn't exist
link ./bootstrap/hadoop-service/hadoop-configuration/ in file /home/dixu/dev/pai/pai-management/README-zh.md doesn't exist
link service.yaml in file /home/dixu/dev/pai/pai-management/README-zh.md doesn't exist
link service.yaml in file /home/dixu/dev/pai/pai-management/README-zh.md doesn't exist
link service.yaml in file /home/dixu/dev/pai/pai-management/README-zh.md doesn't exist
link service.yaml in file /home/dixu/dev/pai/pai-management/README-zh.md doesn't exist
link add-service/src/hbase in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link example/add-service/bootstrap/hbase/service.yaml in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/node-label.sh.template in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/hadoop-name-node.yaml.template in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/hadoop-data-node.yaml.template in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/hadoop-data-node.yaml.template in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/ in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/hadoop-data-node.yaml.template in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/hadoop-configuration in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/hadoop-data-node.yaml.template in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../bootstrap/hadoop-service/start.sh in file /home/dixu/dev/pai/pai-management/doc/add-service.md doesn't exist
link ../Dockerfiles/cuda8.0-cudnn6/Dockerfile.build.base in file /home/dixu/dev/pai/job-tutorial/README-zh.md doesn't exist
link ../Dockerfiles/cuda8.0-cudnn6/Dockerfile.run.tensorflow in file /home/dixu/dev/pai/job-tutorial/README-zh.md doesn't exist
```