### PR TITLE
Doc fixing, add missing `python`

### DIFF
--- a/pai-management/doc/cluster-bootup.md
+++ b/pai-management/doc/cluster-bootup.md
@@ -88,7 +88,7 @@ Note that the quick start approach does not provide high availability and custom
 After the configuration files are prepared, the Kubernetes services can be started using `paictl` tool:
 
 ```
-paictl.py cluster k8s-bootup \
+python paictl.py cluster k8s-bootup \
   -p /path/to/cluster-configuration/dir
 ```
 


### PR DESCRIPTION
Fix the doc of `cluster-bootup`, there is a little command typo for run `k8s-bootup`, which should have a `python` prefix.