### PR TITLE
update hadoop version  [fix nvidia-smi and netstat hang issue]

### DIFF
--- a/hadoop-ai/hadoop-build/build.sh
+++ b/hadoop-ai/hadoop-build/build.sh
@@ -18,16 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 cd /
-wget https://issues.apache.org/jira/secure/attachment/12921722/hadoop-2.7.2.gpu-port.patch
+wget https://issues.apache.org/jira/secure/attachment/12931129/hadoop-2.7.2.gpu-port-20180711.patch
 git clone https://github.com/apache/hadoop.git
 
 cd hadoop
 
 git checkout branch-2.7.2
 
-cp /hadoop-2.7.2.gpu-port.patch /hadoop
+cp /hadoop-2.7.2.gpu-port-20180711.patch /hadoop
 
-git apply hadoop-2.7.2.gpu-port.patch
+git apply hadoop-2.7.2.gpu-port-20180711.patch
 
 mvn package -Pdist,native -DskipTests -Dtar
 


### PR DESCRIPTION
Move Nodemanager GPU information and Port information to a single thread. 

Please check:  to get the source code.
https://github.com/qinchen123/hadoop/tree/new_branch-2.7.2
