### PR TITLE
fix error in parsing docker stats

### DIFF
--- a/prometheus/exporter/docker_stats.py
+++ b/prometheus/exporter/docker_stats.py
@@ -20,8 +20,8 @@ import subprocess
 import json
 import sys
 import re
-import logging  
-logger = logging.getLogger("gpu_expoter")  
+import logging
+logger = logging.getLogger("gpu_expoter")
 
 def parse_percentile(data):
     return data.replace("%", "")
@@ -41,15 +41,23 @@ def parse_usage_limit(data):
 def convert_to_byte(data):
     data = data.lower()
     number = float(re.findall(r"\d+", data)[0])
-    if ("tb" in data) or ("tib" in data):
-        return number * 1024 * 1024 * 1024 * 1024
-    elif ("gb" in data) or ("gib" in data):
-        return number * 1024 * 1024 * 1024
-    elif ("mb" in data) or ("mib" in data):
-        return number * 1024 * 1024
-    elif ("kb" in data) or ("kib" in data):
-        return number * 1024
-    else: 
+    if "tb" in data:
+        return number * 10 ** 12
+    elif "gb" in data:
+        return number * 10 ** 9
+    elif "mb" in data:
+        return number * 10 ** 6
+    elif "kb" in data:
+        return number * 10 ** 3
+    elif "tib" in data:
+        return number * 2 ** 40
+    elif "gib" in data:
+        return number * 2 ** 30
+    elif "mib" in data:
+        return number * 2 ** 20
+    elif "kib" in data:
+        return number * 2 ** 10
+    else:
         return number
 
 def parse_docker_stats(stats):
@@ -72,7 +80,7 @@ def parse_docker_stats(stats):
         }
         containerStats[id] = containerInfo
     return containerStats
-    
+
 def stats():
     try:
         dockerStatsCMD = "docker stats --no-stream --format \"table {{.Container}}, {{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.MemPerc}}\""

--- a/prometheus/exporter/docker_stats.py
+++ b/prometheus/exporter/docker_stats.py
@@ -40,7 +40,7 @@ def parse_usage_limit(data):
 
 def convert_to_byte(data):
     data = data.lower()
-    number = float(re.findall(r"\d+", data)[0])
+    number = float(re.findall(r"[0-9.]+", data)[0])
     if "tb" in data:
         return number * 10 ** 12
     elif "gb" in data:

--- a/prometheus/test/test_docker_stats.py
+++ b/prometheus/test/test_docker_stats.py
@@ -55,36 +55,31 @@ class TestDockerStats(unittest.TestCase):
         file = open(sample_path, "r")
         docker_stats = file.read()
         stats_info = parse_docker_stats(docker_stats)
-        target_stats_info = {'722dac0a62cf0243e63a268b8ef995e8386c185c712f545c0c403b295a529636': {'BlockIO': {'out': 163577856.0, 'in': 29360128.0}, 'NetIO': {'out': 456340275200.0, 'in': 1099511627776.0}, 'CPUPerc': '0.00', 'MemPerc': '0.19', 'id': '722dac0a62cf0243e63a268b8ef995e8386c185c712f545c0c403b295a529636', 'MemUsage_Limit': {'usage': 111149056.0, 'limit': 59055800320.0}}, '33a22dcd4ba31ebc4a19fae865ee62285b6fae98a6ab72d2bc65e41cdc70e419': {'BlockIO': {'out': 0.0, 'in': 29360128.0}, 'NetIO': {'out': 0.0, 'in': 0.0}, 'CPUPerc': '0.00', 'MemPerc': '6.23', 'id': '33a22dcd4ba31ebc4a19fae865ee62285b6fae98a6ab72d2bc65e41cdc70e419', 'MemUsage_Limit': {'usage': 18874368.0, 'limit': 314572800.0}}}
+        target_stats_info = {'722dac0a62cf0243e63a268b8ef995e8386c185c712f545c0c403b295a529636': {'BlockIO': {'out': 156000000.0, 'in': 28600000.0}, 'NetIO': {'out': 425000000000.0, 'in': 1580000000000.0}, 'CPUPerc': '0.00', 'MemPerc': '0.19', 'id': '722dac0a62cf0243e63a268b8ef995e8386c185c712f545c0c403b295a529636', 'MemUsage_Limit': {'usage': 111149056.0, 'limit': 59088012574.72}}, '33a22dcd4ba31ebc4a19fae865ee62285b6fae98a6ab72d2bc65e41cdc70e419': {'BlockIO': {'out': 0.0, 'in': 28000000.0}, 'NetIO': {'out': 0.0, 'in': 0.0}, 'CPUPerc': '0.00', 'MemPerc': '6.23', 'id': '33a22dcd4ba31ebc4a19fae865ee62285b6fae98a6ab72d2bc65e41cdc70e419', 'MemUsage_Limit': {'usage': 19587399.68, 'limit': 314572800.0}}}
         self.assertEqual(target_stats_info, stats_info)
-        pass
 
     def test_convert_to_byte(self):
-        data = "380.4MiB"
-        result = convert_to_byte(data)
-        self.assertEqual(398458880.0, result)
-        pass
+        self.assertEqual(380.4 * 2 ** 20, convert_to_byte("380.4MiB"))
+        self.assertEqual(380.4 * 2 ** 20, convert_to_byte("380.4mib"))
+        self.assertEqual(380.4 * 10 ** 6, convert_to_byte("380.4MB"))
 
     def test_parse_usage_limit(self):
         data = "380.4MiB / 55.03GiB"
         result = parse_usage_limit(data)
-        target = {'usage': 398458880.0, 'limit': 59055800320.0}
+        target = {'usage': 380.4 * 2 ** 20, 'limit': 55.03 * 2 ** 30}
         self.assertEqual(target, result)
-        pass
 
     def test_parse_io(self):
         data = "0B / 0B"
         result = parse_io(data)
         target = {'out': 0.0, 'in': 0.0}
         self.assertEqual(target, result)
-        pass
 
     def test_parse_percentile(self):
         data = "24.45%"
         result = parse_percentile(data)
         target = "24.45"
         self.assertEqual(target, result)
-        pass
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`tb` and `tib` is different, means 10^12 and 2^40 respectively.