### PR TITLE
do not emit invalid gpu metrics if gpu not supported by nvidia-smi

### DIFF
--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -37,8 +37,14 @@ def parse_smi_xml_result(smi):
 
     for gpu in gpuList:
         minorNumber = gpu.getElementsByTagName('minor_number')[0].childNodes[0].data
-        gpuUtil = gpu.getElementsByTagName('utilization')[0].getElementsByTagName('gpu_util')[0].childNodes[0].data.replace("%", "").strip()
-        gpuMemUtil = gpu.getElementsByTagName('utilization')[0].getElementsByTagName('memory_util')[0].childNodes[0].data.replace("%", "").strip()
+        utilization = gpu.getElementsByTagName("utilization")[0]
+
+        gpuUtil = utilization.getElementsByTagName('gpu_util')[0].childNodes[0].data.replace("%", "").strip()
+        gpuMemUtil = utilization.getElementsByTagName('memory_util')[0].childNodes[0].data.replace("%", "").strip()
+
+        if gpuUtil == "N/A" or gpuMemUtil == "N/A":
+            continue
+
         result[str(minorNumber)] = {"gpuUtil": gpuUtil, "gpuMemUtil": gpuMemUtil}
 
     return result

--- a/prometheus/test/data/nvidia_smi_outdated_gpu.xml
+++ b/prometheus/test/data/nvidia_smi_outdated_gpu.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<!DOCTYPE nvidia_smi_log SYSTEM "nvsmi_device_v9.dtd">
+<nvidia_smi_log>
+	<timestamp>Tue Jul 24 09:43:28 2018</timestamp>
+	<driver_version>384.111</driver_version>
+	<attached_gpus>1</attached_gpus>
+	<gpu id="00000000:01:00.0">
+		<product_name>GeForce GT 730</product_name>
+		<product_brand>GeForce</product_brand>
+		<display_mode>N/A</display_mode>
+		<display_active>N/A</display_active>
+		<persistence_mode>Enabled</persistence_mode>
+		<accounting_mode>N/A</accounting_mode>
+		<accounting_mode_buffer_size>N/A</accounting_mode_buffer_size>
+		<driver_model>
+			<current_dm>N/A</current_dm>
+			<pending_dm>N/A</pending_dm>
+		</driver_model>
+		<serial>N/A</serial>
+		<uuid>GPU-09cb2925-9d01-5ca4-810b-6cdebe86b71a</uuid>
+		<minor_number>0</minor_number>
+		<utilization>
+			<gpu_util>N/A</gpu_util>
+			<memory_util>N/A</memory_util>
+			<encoder_util>N/A</encoder_util>
+			<decoder_util>N/A</decoder_util>
+		</utilization>
+	</gpu>
+
+</nvidia_smi_log>

--- a/prometheus/test/test_gpu_exporter.py
+++ b/prometheus/test/test_gpu_exporter.py
@@ -73,5 +73,13 @@ class TestGPUExporter(unittest.TestCase):
         self.assertIn(Metric("nvidiasmi_utilization_memory", {"minor_number": "1"}, "97"),
                 metrics)
 
+    def test_exporter_will_not_report_unsupported_gpu(self):
+        sample_path = "data/nvidia_smi_outdated_gpu.xml"
+        file = open(sample_path, "r")
+        nvidia_smi_result = file.read()
+        nvidia_smi_parse_result = gpu_exporter.parse_smi_xml_result(nvidia_smi_result)
+        self.assertEqual({}, nvidia_smi_parse_result)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fix #949 