### PR TITLE
change metrics name due to node_exporter upgrade

### DIFF
--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -388,7 +388,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - avg (irate(node_cpu{mode=\"idle\"}[5m])) * 100",
+              "expr": "100 - avg (irate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "cpu utilization",
@@ -464,21 +464,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(node_memory_MemTotal) - sum(node_memory_MemFree) - sum(node_memory_Buffers) - sum(node_memory_Cached)",
+              "expr": "sum(node_memory_MemTotal_bytes) - sum(node_memory_MemFree_bytes) - sum(node_memory_Buffers_bytes) - sum(node_memory_Cached_bytes)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "usage",
               "refId": "A"
             },
             {
-              "expr": "sum(node_memory_MemFree)",
+              "expr": "sum(node_memory_MemFree_bytes)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "free",
               "refId": "D"
             },
             {
-              "expr": "sum(node_memory_Buffers) + sum(node_memory_Cached)",
+              "expr": "sum(node_memory_Buffers_bytes) + sum(node_memory_Cached_bytes)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "buff/cache",
@@ -553,14 +553,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_network_receive_bytes{device!~\"lo\"}[5m]))",
+              "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "in",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(node_network_transmit_bytes{device!~\"lo\"}[5m]))",
+              "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "out",
@@ -647,14 +647,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_disk_bytes_read[5m]))",
+              "expr": "sum(rate(node_disk_read_bytes_total[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "read",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(node_disk_bytes_written[5m]))",
+              "expr": "sum(rate(node_disk_written_bytes_total[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "write",

--- a/pai-management/bootstrap/grafana/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/pai-management/bootstrap/grafana/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -74,7 +74,7 @@
               "refId": "A"
             },
             {
-              "expr": "100 - (avg by (instance)(irate(node_cpu{mode=\"idle\",instance=~\"$node\"}[5m])) * 100)",
+              "expr": "100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$node\"}[5m])) * 100)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -175,7 +175,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "node_memory_MemTotal{instance=~'$node'} - node_memory_MemFree{instance=~'$node'} - node_memory_Buffers{instance=~'$node'} - node_memory_Cached{instance=~'$node'}",
+              "expr": "node_memory_MemTotal_bytes{instance=~'$node'} - node_memory_MemFree_bytes{instance=~'$node'} - node_memory_Buffers_bytes{instance=~'$node'} - node_memory_Cached_bytes{instance=~'$node'}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -186,7 +186,7 @@
               "target": ""
             },
             {
-              "expr": "node_memory_MemFree{instance=~'$node'}",
+              "expr": "node_memory_MemFree_bytes{instance=~'$node'}",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -196,7 +196,7 @@
               "step": 600
             },
             {
-              "expr": "node_memory_Buffers{instance=~'$node'} + node_memory_Cached{instance=~'$node'}",
+              "expr": "node_memory_Buffers_bytes{instance=~'$node'} + node_memory_Cached_bytes{instance=~'$node'}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "buff/cache",
@@ -281,7 +281,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_network_receive_bytes{instance=~\"$node\"}[5m]))",
+              "expr": "sum(rate(node_network_receive_bytes_total{instance=~\"$node\"}[5m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -292,7 +292,7 @@
               "target": ""
             },
             {
-              "expr": "sum(rate(node_network_transmit_bytes{instance=~\"$node\"}[5m]))",
+              "expr": "sum(rate(node_network_transmit_bytes_total{instance=~\"$node\"}[5m]))",
               "format": "time_series",
               "hide": true,
               "interval": "",
@@ -388,7 +388,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_disk_bytes_read{instance=~\"$node\"}[5m]))",
+              "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$node\"}[5m]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -399,7 +399,7 @@
               "target": ""
             },
             {
-              "expr": "sum(rate(node_disk_bytes_written{instance=~\"$node\"}[5m]))",
+              "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$node\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -768,7 +768,7 @@
         "multiFormat": "regex values",
         "name": "node",
         "options": [],
-        "query": "label_values(node_boot_time, instance)",
+        "query": "label_values(node_uname_info, instance)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/pai-management/bootstrap/prometheus/node-exporter-ds.yaml.template
+++ b/pai-management/bootstrap/prometheus/node-exporter-ds.yaml.template
@@ -67,7 +67,7 @@ spec:
 #- '--no-collector.loadavg' Exposes load average.
           - '--no-collector.mdadm'
 #- '--no-collector.meminfo' Exposes memory statistics.
-          - '--no-collector.netdev'
+#- '--no-collector.netdev' Exposes network interface statistics such as bytes transferred.
 #- '--no-collector.netstat' Exposes network statistics from /proc/net/netstat. This is the same information as netstat -s.
           - '--no-collector.nfs'
           - '--no-collector.nfsd'


### PR DESCRIPTION
node_exporter upgrade introduced many metrics name change, change grafana metrics to address no data point in font page.