### PR TITLE
Add service healthcheck

### DIFF
--- a/pai-management/bootstrap/grafana/grafana.yaml.template
+++ b/pai-management/bootstrap/grafana/grafana.yaml.template
@@ -24,12 +24,12 @@ spec:
   selector:
     matchLabels:
        task: monitor
-       k8s-app: grafana
+       app: grafana
   template:
     metadata:
       labels:
         task: monitor
-        k8s-app: grafana
+        app: grafana
     spec:
       hostNetwork: true
       hostPID: true

--- a/pai-management/bootstrap/prometheus/service.yaml
+++ b/pai-management/bootstrap/prometheus/service.yaml
@@ -29,6 +29,7 @@ template-list:
   - refresh.sh
   - delete.yaml
   - watchdog-ds.yaml
+  - watchdog-configmap.yaml
   - alert-deployment.yaml
   - alert-configmap.yaml
 

--- a/pai-management/bootstrap/prometheus/start.sh.template
+++ b/pai-management/bootstrap/prometheus/start.sh.template
@@ -29,6 +29,7 @@ kubectl create -f prometheus-configmap.yaml
 kubectl create configmap prometheus-alert --from-file=../../../prometheus/prometheus-alert
 kubectl create -f node-exporter-ds.yaml
 kubectl create -f prometheus-deployment.yaml
+kubectl create -f watchdog-configmap.yaml
 kubectl create -f watchdog-ds.yaml
 {% if clusterinfo['prometheusinfo']['alerting'] %}
 kubectl create -f alert-configmap.yaml

--- a/pai-management/bootstrap/prometheus/stop.sh.template
+++ b/pai-management/bootstrap/prometheus/stop.sh.template
@@ -24,6 +24,7 @@ daemonset/watchdog
 deployment/prometheus-deployment
 configmap/prometheus-configmap
 configmap/prometheus-alert
+configmap/watchdog
 deployment/alertmanager
 configmap/alertmanager
 "

--- a/pai-management/bootstrap/prometheus/watchdog-configmap.yaml.template
+++ b/pai-management/bootstrap/prometheus/watchdog-configmap.yaml.template
@@ -5,7 +5,7 @@ metadata:
 data:
   config.yml: |-
 
-hosts:
-{% for _, hostInfo in machinelist.items() %}
-- {hostip: {{ hostInfo['ip'] }}, port: {{ hostInfo['sshport'] }}, username: {{ hostInfo['username'] }}, password: {{ hostInfo['password'] }} }
-{% endfor %}
+    hosts:
+    {% for _, hostInfo in machinelist.items() %}
+    - {hostip: {{ hostInfo['ip'] }}, port: {{ hostInfo['sshport'] }}, username: {{ hostInfo['username'] }}, password: {{ hostInfo['password'] }} }
+    {% endfor %}

--- a/pai-management/bootstrap/prometheus/watchdog-configmap.yaml.template
+++ b/pai-management/bootstrap/prometheus/watchdog-configmap.yaml.template
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: watchdog
+data:
+  config.yml: |-
+
+hosts:
+{% for _, hostInfo in machinelist.items() %}
+- {hostip: {{ hostInfo['ip'] }}, port: {{ hostInfo['sshport'] }}, username: {{ hostInfo['username'] }}, password: {{ hostInfo['password'] }} }
+{% endfor %}

--- a/pai-management/bootstrap/prometheus/watchdog-ds.yaml.template
+++ b/pai-management/bootstrap/prometheus/watchdog-ds.yaml.template
@@ -44,14 +44,21 @@ spec:
         volumeMounts:
         - mountPath: /datastorage/prometheus
           name: collector-mount
+        - mountPath: /etc/watchdog
+          name: config-volume
         name: watchdog
         env:
         - name: K8S_API_SERVER_URI
           value: {{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}
+        command: ['python']
+        args: ['/usr/local/watchdog.py', '/datastorage/prometheus', '30']
       volumes:
         - name: collector-mount
           hostPath:
             path: {{ clusterinfo[ 'dataPath' ] }}/prometheus
+        - name: config-volume
+          configMap:
+            name: watchdog
       imagePullSecrets:
       - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
       hostNetwork: true

--- a/pai-management/src/watchdog/dockerfile
+++ b/pai-management/src/watchdog/dockerfile
@@ -30,10 +30,3 @@ RUN apt-get update && \
 COPY copied_file/exporter/watchdog.py /usr/local/
 COPY copied_file/exporter/utils.py /usr/local/
 COPY copied_file/common.py /usr/local
-COPY copied_file/cluster-configuration.yaml /usr/local
-
-#
-# start
-#
-
-CMD python /usr/local/watchdog.py /datastorage/prometheus /usr/local/cluster-configuration.yaml 30

--- a/pai-management/src/watchdog/image.yaml
+++ b/pai-management/src/watchdog/image.yaml
@@ -20,5 +20,3 @@ copy-list:
     dst: src/watchdog/copied_file
   - src: ../pai-management/k8sPaiLibrary/maintainlib/common.py
     dst: src/watchdog/copied_file
-  - src: ../cluster-configuration/cluster-configuration.yaml
-    dst: src/watchdog/copied_file

--- a/prometheus/doc/watchdog-metrics.md
+++ b/prometheus/doc/watchdog-metrics.md
@@ -1,4 +1,4 @@
-# Watchdog 
+# Watchdog
 watchdog will check service / K8S / Node level health. It is a long running service and will continues report & record health metrics to log files.
 # How to use
 For example
@@ -8,7 +8,7 @@ ssh watchdogPodHostIP
 
 cd /var/log/containers
 
-vi watchdog-xx.log 
+vi watchdog-xx.log
 
 log example:
 
@@ -37,47 +37,32 @@ go to k8s container log folder
 
 cd /var/log/containers
 
-vi watchdog-xx.log 
+vi watchdog-xx.log
 
 # Metrics
 ## Service Health Metrics
 
-| Metric name| Note | 
+| Metric name| Description |
 | ---------- |  ----------- |
-| cluster_current_probe_not_ready_pod_count | cluster pods' occurs readiness probe failed error, condition is not ready, total count |
-| cluster_current_phase_failed_pod_count| cluster pods' phase become failed total count |
-| cluster_phase_unknown_pod_count | cluster pods' phase become unknown total count |
-| cluster_current_status_not_ready_container_count| cluster pods' contains container status is not ready total count |
-| cluster_current_terminated_container_count | cluster pods' container status is terminated total count |
-| cluster_current_waiting_container_count| cluster pods' container status is waiting  total count |
-| cluster_container_once_restarted_pod_count| cluster pods' container restart total count |
-| service_current_probe_not_ready_pod_count| specific pod occurs readiness probe failed error, condition is not ready, value is 1 |
-| service_current_phase_failed_pod_count| specific pod phase is failed, value is 1 |
-| service_current_phase_unknown_pod_count| specific pod phase become unknown, value is 1 |
-| service_current_not_ready_container_count| specific pod contains container status is not ready, value is 1 |
-| service_current_terminated_container_count| specific pod container status is terminated total count, value is 1 |
-| service_current_waiting_container_count| specific pod container status is waiting  total count, value is 1 |
-| service_restarted_container_count| specific pod's container restart total count |
-| pod_current_probe_not_ready| each service occurs readiness probe failed error, condition is not ready, total count |
-| pod_current_phase_failed| each service pods' phase become failed total count |
-| pod_current_phase_unknown| each service pods' phase become unknown total count |
-| container_current_not_ready| each service pods' contains container status is not ready total count |
-| container_current_terminated| each service pods' container status is terminated total count |
-| container_current_waiting | each service pods' container status is waiting  total count |
-| container_accumulation_restart_total| each service pods' container restart total count |
-
-## K8s Health Metrics
-| Metric name| Labels/tags |
-| ---------- |  ----------- |
-| apiserver_current_status_error| api server health status, 1 is error |
-| etcd_current_status_error| etcd health status, 1 is error |
-| kubelet_current_status_error| each node kubelet health status, 1 is error |
+| pai_pod_count | describe count of pai service like webportal, grafana, lable contains pod status like phase="running", ready="true" |
+| pai_container_count | describe count of pai service container, like pai_pod_count, lable in pai_contain_count contains container status like state="running" |
 
 ## Node Health Metrics
-| Metric name| Labels/tags |
+| Metric name| Description |
 | ---------- |  ----------- |
-| node_current_notready| node status, value 1 is error|
-| notready_node_count| all nodes not ready count|
-| node_current_docker_error| per node docker daemon occurs error, 1 is error |
-| docker_error_node_count| all nodes docker occurs error node count |
+| pai_node_count | describe count of node in open pai, lable describe state of node like ready="true" and condition like disk_pressure="false" |
 
+## Docker Daemon Health Metrics
+| Metric name| Description |
+| ---------- |  ----------- |
+| docker_daemon_count | has error key in label, if error != "ok", means docker daemon is not functioning correctly |
+
+## K8s Health Metrics
+| Metric name| Description |
+| ---------- |  ----------- |
+| k8s_api_server_count | has error key in label, if error != "ok", means api server is not functioning correctly |
+| k8s_etcd_count | has error key in label, if error != "ok", means etcd is not functioning correctly |
+| k8s_kubelet_count | has error key in label, if error != "ok", means kubelet is not functioning correctly |
+
+# Alerting
+Alerting rules are under `[prometheus/prometheus-alert](../prometheus-alert)`, we added some basic healthcheck rules for pai service and node.

--- a/prometheus/doc/watchdog-metrics.md
+++ b/prometheus/doc/watchdog-metrics.md
@@ -65,4 +65,8 @@ vi watchdog-xx.log
 | k8s_kubelet_count | has error key in label, if error != "ok", means kubelet is not functioning correctly |
 
 # Alerting
-Alerting rules are under `[prometheus/prometheus-alert](../prometheus-alert)`, we added some basic healthcheck rules for pai service and node.
+Alerting rules are under `[prometheus/prometheus-alert](../prometheus-alert)`, we added some basic
+healthcheck rules for pai service and node. You can add more alert rule by adding file `*.rules` to
+`prometheus/prometheus-alert` directory. Read doc from
+[prometheus](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) for rule
+syntax reference.

--- a/prometheus/exporter/utils.py
+++ b/prometheus/exporter/utils.py
@@ -16,6 +16,7 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import re
 import codecs
 import subprocess
 
@@ -125,3 +126,10 @@ class Singleton(object):
 
         logger.info("gpu info is too old")
         return None
+
+
+def camel_to_underscore(label):
+    """ convert camel case into underscore
+    https://stackoverflow.com/a/1176023 """
+    tmp = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', label)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', tmp).lower()

--- a/prometheus/exporter/watchdog.py
+++ b/prometheus/exporter/watchdog.py
@@ -33,158 +33,168 @@ from utils import Metric
 
 logger = logging.getLogger(__name__)
 
-class Service:
-    kube_pod_status_probe_not_ready = 0
-    kube_pod_status_phase_failed = 0
-    kube_pod_status_phase_unknown = 0
-    pod_container_status_waiting = 0
-    pod_container_status_terminated = 0
-    pod_container_status_not_ready = 0
-    pod_container_status_restart_total = 0
+
+class MetricEntity(object):
+    """ interface that has one method that can convert this obj into Metric """
+    def to_metric(self):
+        pass
+
+
+class PaiPod(MetricEntity):
+    """ represent a pod count, all fields except condition_map should of type string """
+
+    def __init__(self, name, phase, host_ip, condition_map):
+        self.name = name
+        self.phase = phase
+        self.host_ip = host_ip # maybe None
+        self.condition_map = condition_map
+
+    def to_metric(self):
+        label = {"name": self.name, "phase": self.phase}
+
+        if self.host_ip is not None:
+            label["host_ip"] = self.host_ip
+
+        for k, v in self.condition_map.items():
+            label[k] = v
+
+        return Metric("pai_pod_count", label, 1)
+
+
+class PaiContainer(MetricEntity):
+    """ represent a container count, all fields should of type string """
+
+    def __init__(self, service_name, name, state, ready):
+        self.service_name = service_name
+        self.name = name
+        self.state = state
+        self.ready = ready
+
+    def to_metric(self):
+        label = {"service_name": self.service_name, "name": self.name, "state": self.state,
+                "ready": self.ready}
+        return Metric("pai_container_count", label, 1)
+
+
+class PaiNode(MetricEntity):
+    """ will output metric like
+    pai_node_count{name="1.2.3.4", out_of_disk="true", memory_pressure="true"} 1 """
+
+    def __init__(self, name, condition_map):
+        self.name = name
+        self.condition_map = condition_map
+
+    def to_metric(self):
+        label = {"name": self.name}
+        for k, v in self.condition_map.items():
+            label[k] = v
+
+        return Metric("pai_node_count", label, 1)
+
+
+def catch_exception(fn, msg, default, *args, **kwargs):
+    """ wrap fn call with try catch, makes watchdog more robust """
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:
+        logger.exception(msg)
+        return default
+
+
+def keep_not_none(item):
+    """ used in filter to keep item that is not None """
+    return item is not None
+
+
+def to_metric(metric_entity):
+    return metric_entity.to_metric()
+
+
+def parse_pod_item(pod):
+    """ return pai_pod and list of pai_container, return None on not pai service
+    Because we are parsing json outputed by k8s, its format is subjected to change,
+    we should test if field exists before accessing it to avoid KeyError """
+    labels = pod["metadata"].get("labels")
+    if labels is None or "app" not in labels.keys():
+        logger.warning("unkown pod %s", pod["metadata"]["name"])
+        return None
+
+    service_name = labels["app"] # get pai service name from label
+
+    status = pod["status"]
+
+    if status.get("phase") is not None:
+        phase = status["phase"].lower()
+    else:
+        phase = "unknown"
+
+    host_ip = None
+    if status.get("hostIP") is not None:
+        host_ip = status["hostIP"]
+
+    condition_map = {}
+
+    conditions = status.get("conditions")
+    if conditions is not None:
+        for cond in conditions:
+            cond_t = cond["type"].lower() # Initialized|Ready|PodScheduled
+            cond_status = cond["status"].lower()
+
+            condition_map[cond_t] = cond_status
+
+    pai_pod = PaiPod(service_name, phase, host_ip, condition_map)
+
+    # generate pai_containers
+    pai_containers = []
+
+    if status.get("containerStatuses") is not None:
+        container_statuses = status["containerStatuses"]
+
+        for container_status in container_statuses:
+            container_name = container_status["name"]
+
+            ready = False
+
+            if container_status.get("ready") is not None:
+                ready = container_status["ready"]
+
+            container_state = None
+            if container_status.get("state") is not None:
+                state = container_status["state"]
+                if len(state) != 1:
+                    logger.error("unexpected state %s in container %s",
+                            json.dumps(state), container_name)
+                else:
+                    container_state = state.keys()[0].lower()
+
+            pai_containers.append(PaiContainer(service_name, container_name,
+                container_state, str(ready)))
+
+    return pai_pod, pai_containers
+
+
+def robust_parse_pod_item(item):
+    return catch_exception(parse_pod_item,
+            "catch exception when parsing pod item",
+            None,
+            item)
+
 
 def parse_pods_status(podsJsonObject):
-    kube_pod_status_probe_not_ready = 0
-    kube_pod_status_phase_failed = 0
-    kube_pod_status_phase_unknown = 0
-    pod_container_status_waiting = 0
-    pod_container_status_terminated = 0
-    pod_container_status_not_ready = 0
-    pod_container_status_restarted_pod_count = 0
-
     metrics = []
 
-    serviceMetrics = collections.defaultdict(lambda : Service())
-    existServiceKey = {}
+    results = filter(keep_not_none,
+            map(robust_parse_pod_item, podsJsonObject["items"]))
 
-    podItems = podsJsonObject["items"]
+    pai_pods = map(lambda result: result[0], results)
+    pai_containers = map(lambda result: result[1], results)
+    pai_containers = [subitem for sublist in pai_containers for subitem in sublist]
 
-    for pod in podItems:
-        # all / per pod phase failed/unkown/Not ready (condition)
-        serviceName = ""
+    pod_metrics = map(to_metric, pai_pods)
+    container_metrics = map(to_metric, pai_containers)
 
-        if "generateName" in pod["metadata"]:
-            serviceName = pod["metadata"]["generateName"]
-        else:
-            serviceName = pod["metadata"]["name"]
+    return pod_metrics + container_metrics
 
-        service = serviceMetrics[serviceName]
-
-        status = pod["status"]
-        phase = status["phase"]
-        conditions = status["conditions"]
-        ready = "True"
-        init = "True"
-        scheduled = "True"
-
-        # 1. check not ready pod
-        for condition in conditions:
-            if condition["type"] == "Ready":
-                ready = condition["status"]
-            elif condition["type"] == "Initialized":
-                init = condition["status"]
-            elif condition["type"] == "PodScheduled":
-                scheduled = condition["status"]
-
-        # NOTE: this map will be reused in multiple metrics, do not modify this map
-        label = {"pod": pod["metadata"]["name"], "hostip": pod["status"]["hostIP"]}
-
-        if ready != "True" and init == "True" and scheduled == "True":
-            kube_pod_status_probe_not_ready += 1
-            # specific pod occurs readiness probe failed error, condition is not ready, value is 1
-            metrics.append(Metric("pod_current_probe_not_ready", label, 1))
-            service.kube_pod_status_probe_not_ready += 1
-
-        # 2. check failed phase pods
-        if phase == "Failed":
-            kube_pod_status_phase_failed += 1
-            # specific pod phase become faile, value is 1
-            metrics.append(Metric("pod_current_phase_failed", label, 1))
-            service.kube_pod_status_phase_failed += 1
-
-        # 3. check unknown phase pods
-        if phase == "Unknown":
-            kube_pod_status_phase_unknown += 1
-            # specific pod phase become unknown, value is 1
-            metrics.append(Metric("pod_current_phase_unknown", label, 1))
-            service.kube_pod_status_phase_unknown += 1
-
-        containerStatus = status["containerStatuses"]
-
-        # 4. check pod containers running/waiting/terminated status
-        for perContainerStatus in containerStatus:
-            containerReady = perContainerStatus["ready"]
-            restartCount = perContainerStatus["restartCount"]
-
-            containerLabel = copy.deepcopy(label)
-            containerLabel["container"] = perContainerStatus["name"]
-
-            if not containerReady:
-                pod_container_status_not_ready +=1
-                # specific pod contains container status is not ready, value is 1
-                metrics.append(Metric("container_current_not_ready", containerLabel, 1))
-                service.pod_container_status_not_ready += 1
-
-            state = perContainerStatus["state"]
-            if "terminated" in state:
-                pod_container_status_terminated += 1
-                # specific pod container status is terminated total count, value is 1
-                metrics.append(Metric("container_current_terminated", containerLabel, 1))
-                service.pod_container_status_terminated += 1
-
-            if "waiting" in state:
-                pod_container_status_waiting += 1
-                # specific pod container status is waiting  total count, value is 1
-                metrics.append(Metric("container_current_waiting", containerLabel, 1))
-                service.pod_container_status_waiting += 1
-
-            if restartCount > 0:
-                pod_container_status_restarted_pod_count += 1
-                # specific pod's container restart total count
-                metrics.append(Metric("container_accumulation_restart_total", containerLabel, restartCount))
-                service.pod_container_status_restart_total += 1
-
-    # service level aggregation metrics
-    for serviceName, service in serviceMetrics.items():
-        label = {"service": serviceName}
-        # each service occurs readiness probe failed error, condition is not ready, total count
-        if service.kube_pod_status_probe_not_ready != 0:
-            metrics.append(Metric("service_current_probe_not_ready_pod_count", label,
-                service.kube_pod_status_probe_not_ready))
-        # each service pods' phase become failed total count
-        if service.kube_pod_status_phase_failed != 0:
-            metrics.append(Metric("service_current_phase_failed_pod_count", label,
-                service.kube_pod_status_phase_failed))
-        # each service pods' phase become unknown total count
-        if service.kube_pod_status_phase_unknown != 0:
-            metrics.append(Metric("service_current_phase_unknown_pod_count", label,
-                service.kube_pod_status_phase_unknown))
-        # each service pods' contains container status is not ready total count
-        if service.pod_container_status_waiting != 0:
-            metrics.append(Metric("service_current_waiting_container_count", label,
-                service.pod_container_status_waiting))
-        # each service pods' container status is terminated total count
-        if service.pod_container_status_terminated != 0:
-            metrics.append(Metric("service_current_terminated_container_count", label,
-                service.pod_container_status_terminated))
-        # each service pods' container status is waiting  total count
-        if service.pod_container_status_not_ready != 0:
-            metrics.append(Metric("service_current_probe_not_ready_pod_count", label,
-                service.pod_container_status_not_ready))
-        # each service pods' container restart total count
-        if service.pod_container_status_restart_total != 0:
-            metrics.append(Metric("service_restarted_container_count", label,
-                service.pod_container_status_restart_total))
-
-    emptyLabel = {}
-    metrics.append(Metric("cluster_current_probe_not_ready_pod_count", emptyLabel, kube_pod_status_probe_not_ready))
-    metrics.append(Metric("cluster_current_phase_failed_pod_count", emptyLabel, kube_pod_status_phase_failed))
-    metrics.append(Metric("cluster_phase_unknown_pod_count", emptyLabel, kube_pod_status_phase_unknown))
-    metrics.append(Metric("cluster_current_status_not_ready_container_count", emptyLabel, pod_container_status_not_ready))
-    metrics.append(Metric("cluster_current_terminated_container_count", emptyLabel, pod_container_status_terminated))
-    metrics.append(Metric("cluster_current_waiting_container_count", emptyLabel, pod_container_status_waiting))
-    metrics.append(Metric("cluster_container_once_restarted_pod_count", emptyLabel, pod_container_status_restarted_pod_count))
-
-    return metrics
 
 def collect_k8s_componentStaus(address, nodesJsonObject):
     metrics = []
@@ -238,27 +248,42 @@ def collect_k8s_componentStaus(address, nodesJsonObject):
 
     return metrics
 
+
+def parse_node_item(node):
+    name = node["metadata"]["name"]
+
+    cond_map = {}
+
+    if node.get("status") is not None:
+        status = node["status"]
+
+        if status.get("conditions") is not None:
+            conditions = status["conditions"]
+
+            for cond in conditions:
+                cond_t = utils.camel_to_underscore(cond["type"])
+                status = cond["status"].lower()
+
+                cond_map[cond_t] = status
+    else:
+        logger.warning("unexpected structure of node %s: %s", name, json.dumps(node))
+
+    return PaiNode(name, cond_map)
+
+
+def robust_parse_node_item(item):
+    return catch_exception(parse_node_item,
+            "catch exception when parsing node item",
+            None,
+            item)
+
+
 def parse_nodes_status(nodesJsonObject):
     nodeItems = nodesJsonObject["items"]
 
-    metrics = []
-    readyNodeCount = 0
-    dockerError = 0
+    return map(to_metric,
+            map(robust_parse_node_item, nodesJsonObject["items"]))
 
-    for name in nodeItems:
-        # 1. check each node status
-        for condition in name["status"]["conditions"]:
-            if "Ready" == condition["type"]:
-                readyStatus = condition["status"]
-                if readyStatus != "True":
-                    # node status, value 1 is error
-                    label = {"node": name["metadata"]["name"]}
-                    metrics.append(Metric("node_current_notready", label, 1))
-                else:
-                    readyNodeCount += 1
-
-    metrics.append(Metric("notready_node_count", {}, len(nodeItems) - readyNodeCount))
-    return metrics
 
 def collect_docker_daemon_status(configFilePath):
     metrics = []

--- a/prometheus/exporter/watchdog.py
+++ b/prometheus/exporter/watchdog.py
@@ -45,7 +45,7 @@ class PaiPod(MetricEntity):
 
     def __init__(self, name, phase, host_ip, condition_map):
         self.name = name
-        self.phase = phase
+        self.phase = phase # should be lower case
         self.host_ip = host_ip # maybe None
         self.condition_map = condition_map
 
@@ -82,6 +82,7 @@ class PaiNode(MetricEntity):
 
     def __init__(self, name, condition_map):
         self.name = name
+        # key should be underscore instead of camel case, value should be lower case
         self.condition_map = condition_map
 
     def to_metric(self):

--- a/prometheus/exporter/watchdog.py
+++ b/prometheus/exporter/watchdog.py
@@ -298,6 +298,18 @@ def load_machine_list(configFilePath):
     return cluster_config['hosts']
 
 
+#####
+# Watchdog generate 7 metrics:
+# * pai_pod_count
+# * pai_container_count
+# * pai_node_count
+# * docker_daemon_count
+# * k8s_api_server_count
+# * k8s_etcd_count
+# * k8s_kubelet_count
+# Document about these metrics is in `prometheus/doc/watchdog-metrics.md`
+#####
+
 def main(argv):
     logDir = argv[0]
     timeSleep = int(argv[1])

--- a/prometheus/exporter/watchdog.py
+++ b/prometheus/exporter/watchdog.py
@@ -169,7 +169,7 @@ def parse_pod_item(pod):
                     container_state = state.keys()[0].lower()
 
             pai_containers.append(PaiContainer(service_name, container_name,
-                container_state, str(ready)))
+                container_state, str(ready).lower()))
 
     return pai_pod, pai_containers
 

--- a/prometheus/prometheus-alert/k8s.rules
+++ b/prometheus/prometheus-alert/k8s.rules
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Rule Syntax Reference: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+
+groups:
+    - name: k8s_component
+      rules:
+      - alert: k8sApiServerNotOk
+        expr: k8s_api_server_count{error!="ok"} > 0
+        for: 1m
+        labels:
+          type: k8s_component
+        annotations:
+          summary: "api server in {{$labels.address}} is not ok"
+          description: "api server in {{$labels.address}} is {{$labels.error}"
+      - alert: k8sEtcdNotOk
+        expr: k8s_etcd_count{error!="ok"} > 0
+        for: 1m
+        labels:
+          type: k8s_component
+        annotations:
+          summary: "etcd server in {{$labels.address}} is not ok"
+          description: "etcd server in {{$labels.address}} is {{$labels.error}"
+      - alert: k8sKubeletNotOk
+        expr: k8s_kubelet_count{error!="ok"} > 0
+        for: 1m
+        labels:
+          type: k8s_component
+        annotations:
+          summary: "kubelet in {{$labels.address}} is not ok"
+          description: "kubelet in {{$labels.address}} is {{$labels.error}"

--- a/prometheus/prometheus-alert/k8s.rules
+++ b/prometheus/prometheus-alert/k8s.rules
@@ -28,6 +28,7 @@ groups:
         annotations:
           summary: "api server in {{$labels.address}} is not ok"
           description: "api server in {{$labels.address}} is {{$labels.error}"
+
       - alert: k8sEtcdNotOk
         expr: k8s_etcd_count{error!="ok"} > 0
         for: 1m
@@ -36,6 +37,7 @@ groups:
         annotations:
           summary: "etcd server in {{$labels.address}} is not ok"
           description: "etcd server in {{$labels.address}} is {{$labels.error}"
+
       - alert: k8sKubeletNotOk
         expr: k8s_kubelet_count{error!="ok"} > 0
         for: 1m
@@ -44,3 +46,12 @@ groups:
         annotations:
           summary: "kubelet in {{$labels.address}} is not ok"
           description: "kubelet in {{$labels.address}} is {{$labels.error}"
+
+      - alert: k8sDockerDaemonNotOk
+        expr: docker_daemon_count{error!="ok"} > 0
+        for: 1m
+        labels:
+          type: docker_daemon
+        annotations:
+          summary: "docker daemon in {{$labels.ip}} is not ok"
+          description: "docker daemon in {{$labels.ip}} is {{$labels.error}"

--- a/prometheus/prometheus-alert/node.rules
+++ b/prometheus/prometheus-alert/node.rules
@@ -21,7 +21,7 @@ groups:
     - name: node-rules
       rules:
       - alert: NodeFilesystemUsage
-        expr: (node_filesystem_size{device="rootfs"} - node_filesystem_free{device="rootfs"}) / node_filesystem_size{device="rootfs"} * 100 > 80
+        expr: (node_filesystem_size_bytes{device="rootfs"} - node_filesystem_free_bytes{device="rootfs"}) / node_filesystem_size_bytes{device="rootfs"} * 100 > 80
         for: 2m
         labels:
           type: node
@@ -29,7 +29,7 @@ groups:
           summary: "{{$labels.instance}}: High Filesystem usage detected"
           description: "{{$labels.instance}}: Filesystem usage is above 80% (current value is: {{ $value }})"
       - alert: NodeMemoryUsage
-        expr: (node_memory_MemTotal - (node_memory_MemFree+node_memory_Buffers+node_memory_Cached )) / node_memory_MemTotal * 100 > 80
+        expr: (node_memory_MemTotal_bytes - (node_memory_MemFree_bytes+node_memory_Buffers_bytes+node_memory_Cached_bytes )) / node_memory_MemTotal_bytes * 100 > 80
         for: 2m
         labels:
           type: node
@@ -37,10 +37,19 @@ groups:
           summary: "{{$labels.instance}}: High Memory usage detected"
           description: "{{$labels.instance}}: Memory usage is above 80% (current value is: {{ $value }})"
       - alert: NodeCPUUsage
-        expr: (100 - (avg by (instance) (irate(node_cpu{job="kubernetes-node-exporter",mode="idle"}[5m])) * 100)) > 80
+        expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{job="kubernetes-node-exporter",mode="idle"}[5m])) * 100)) > 80
         for: 2m
         labels:
           type: node
         annotations:
           summary: "{{$labels.instance}}: High CPU usage detected"
           description: "{{$labels.instance}}: CPU usage is above 80% (current value is: {{ $value }})"
+
+      - alert: NodeDiskPressure
+        expr: pai_node_count{disk_pressure="true"} > 1
+        for: 1m
+        labels:
+          type: node
+        annotations:
+          summary: "node {{$labels.instance}} is under disk pressure"
+          description: "node {{$labels.instance}} is under disk pressure"

--- a/prometheus/prometheus-alert/node.rules
+++ b/prometheus/prometheus-alert/node.rules
@@ -21,7 +21,7 @@ groups:
     - name: node-rules
       rules:
       - alert: NodeFilesystemUsage
-        expr: (node_filesystem_size_bytes{device="rootfs"} - node_filesystem_free_bytes{device="rootfs"}) / node_filesystem_size_bytes{device="rootfs"} * 100 > 80
+        expr: (node_filesystem_size_bytes - node_filesystem_free_bytes) / node_filesystem_size_bytes * 100 > 80
         for: 2m
         labels:
           type: node
@@ -37,7 +37,7 @@ groups:
           summary: "{{$labels.instance}}: High Memory usage detected"
           description: "{{$labels.instance}}: Memory usage is above 80% (current value is: {{ $value }})"
       - alert: NodeCPUUsage
-        expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{job="kubernetes-node-exporter",mode="idle"}[5m])) * 100)) > 80
+        expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 80
         for: 2m
         labels:
           type: node

--- a/prometheus/prometheus-alert/node.rules
+++ b/prometheus/prometheus-alert/node.rules
@@ -36,6 +36,7 @@ groups:
         annotations:
           summary: "{{$labels.instance}}: High Memory usage detected"
           description: "{{$labels.instance}}: Memory usage is above 80% (current value is: {{ $value }})"
+
       - alert: NodeCPUUsage
         expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 80
         for: 2m

--- a/prometheus/prometheus-alert/pai-services.rules
+++ b/prometheus/prometheus-alert/pai-services.rules
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Rule Syntax Reference: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+
+groups:
+    - name: pai-services
+      rules:
+      - alert: PaiServicePodNotRunning
+        expr: pai_pod_count{phase!="running"} > 0
+        for: 1m
+        labels:
+          type: pai_service
+        annotations:
+          summary: "{{$labels.name}} in {{$labels.host_ip}} not running detected"
+          description: "{{$labels.name}} in {{$labels.host_ip}} is not running"
+      - alert: PaiServicePodNotReady
+        expr: pai_pod_count{phase="running", ready="false"} > 0
+        for: 1m
+        labels:
+          type: pai_service
+        annotations:
+          summary: "{{$labels.name}} in {{$labels.host_ip}} not ready detected"
+          description: "{{$labels.name}} in {{$labels.host_ip}} not ready detected"

--- a/prometheus/test/data/no_condtion_pod.json
+++ b/prometheus/test/data/no_condtion_pod.json
@@ -1,0 +1,185 @@
+{
+    "apiVersion": "v1",
+    "kind": "PodList",
+    "items": [
+        {
+            "metadata": {
+                "name": "frameworklauncher-ds-2684q",
+                "generateName": "frameworklauncher-ds-",
+                "namespace": "default",
+                "selfLink": "/api/v1/namespaces/default/pods/frameworklauncher-ds-2684q",
+                "uid": "b492b284-8a77-11e8-a8fc-000d3ab25bb6",
+                "resourceVersion": "87290",
+                "creationTimestamp": "2018-07-18T10:45:37Z",
+                "labels": {
+                    "controller-revision-hash": "2698008918",
+                    "pod-template-generation": "1",
+                    "app": "frameworklauncher"
+                },
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "DaemonSet",
+                        "name": "frameworklauncher-ds",
+                        "uid": "b4918fda-8a77-11e8-a8fc-000d3ab25bb6",
+                        "controller": true,
+                        "blockOwnerDeletion": true
+                    }
+                ]
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "launcher-log",
+                        "hostPath": {
+                            "path": "/datastorage/launcherlogs",
+                            "type": ""
+                        }
+                    },
+                    {
+                        "name": "hadoop-nm-config-volume",
+                        "configMap": {
+                            "name": "hadoop-node-manager-configuration",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "hadoop-dn-config-volume",
+                        "configMap": {
+                            "name": "hadoop-data-node-configuration",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "frameworklauncher-config-volume",
+                        "configMap": {
+                            "name": "frameworklauncher-configmap",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "gpu-confg-volume",
+                        "configMap": {
+                            "name": "gpu-configuration",
+                            "defaultMode": 420
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "frameworklauncher",
+                        "image": "docker.io/xudifsd/frameworklauncher:latest",
+                        "env": [
+                            {
+                                "name": "RESOURCEMANAGER_ADDRESS",
+                                "value": "10.151.40.4"
+                            },
+                            {
+                                "name": "ZOOKEEPER_ADDRESS",
+                                "value": "10.151.40.4"
+                            },
+                            {
+                                "name": "HDFS_ADDRESS",
+                                "value": "10.151.40.4"
+                            },
+                            {
+                                "name": "LOGSERVER_ADDRESS",
+                                "value": "10.151.40.4"
+                            },
+                            {
+                                "name": "TIMELINE_SERVER_ADDRESS",
+                                "value": "10.151.40.4"
+                            },
+                            {
+                                "name": "GENERATE_CONFIG",
+                                "value": "frameworklauncher-generate-config.sh"
+                            },
+                            {
+                                "name": "FRAMEWORKLAUNCHER_VIP",
+                                "value": "10.151.40.4"
+                            },
+                            {
+                                "name": "FRAMEWORKLAUNCHER_PORT",
+                                "value": "9086"
+                            }
+                        ],
+                        "resources": {
+
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "hadoop-nm-config-volume",
+                                "mountPath": "/hadoop-nm-configuration"
+                            },
+                            {
+                                "name": "hadoop-dn-config-volume",
+                                "mountPath": "/hadoop-dn-configuration"
+                            },
+                            {
+                                "name": "frameworklauncher-config-volume",
+                                "mountPath": "/frameworklauncher-configuration"
+                            },
+                            {
+                                "name": "launcher-log",
+                                "mountPath": "/usr/local/launcher/logs"
+                            },
+                            {
+                                "name": "gpu-confg-volume",
+                                "mountPath": "/gpu-configuration"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "nodeSelector": {
+                    "launcher": "true"
+                },
+                "nodeName": "10.151.40.4",
+                "hostNetwork": true,
+                "hostPID": true,
+                "securityContext": {
+
+                },
+                "imagePullSecrets": [
+                    {
+                        "name": "pai-secret"
+                    }
+                ],
+                "schedulerName": "default-scheduler",
+                "tolerations": [
+                    {
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "effect": "NoExecute"
+                    },
+                    {
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    },
+                    {
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists",
+                        "effect": "NoSchedule"
+                    }
+                ]
+            },
+            "status": {
+                "message": "The node was low on resource: nodefs.",
+                "phase": "Failed",
+                "reason": "Evicted",
+                "startTime": "2018-07-19T02:48:45Z"
+            }
+        }
+    ]
+}

--- a/prometheus/test/data/pods_list.json
+++ b/prometheus/test/data/pods_list.json
@@ -7,66 +7,15 @@
   "items": [
     {
       "metadata": {
-        "name": "batch-job-hadoop-jsfwl",
-        "generateName": "batch-job-hadoop-",
-        "namespace": "default",
-        "creationTimestamp": "2018-07-18T10:45:32Z"
-      },
-      "status": {
-        "phase": "Succeeded",
-        "conditions": [
-          {
-            "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2018-07-18T10:45:32Z",
-            "reason": "PodCompleted"
-          },
-          {
-            "type": "Ready",
-            "status": "False",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2018-07-18T10:45:36Z",
-            "reason": "PodCompleted"
-          },
-          {
-            "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2018-07-18T10:45:32Z"
-          }
-        ],
-        "hostIP": "10.151.40.4",
-        "podIP": "10.151.40.4",
-        "startTime": "2018-07-18T10:45:32Z",
-        "containerStatuses": [
-          {
-            "name": "one-time-job-hadoop",
-            "state": {
-              "terminated": {
-                "exitCode": 0,
-                "reason": "Completed",
-                "startedAt": "2018-07-18T10:45:34Z",
-                "finishedAt": "2018-07-18T10:45:36Z",
-                "containerID": "docker://556dcda1bb1b64474a87ecbc1f3d6e6b3a484807a87368322bbe98192747cb26"
-              }
-            },
-            "ready": false,
-            "restartCount": 0,
-            "image": "xudifsd/hadoop-run:latest",
-            "imageID": "docker-pullable://xudifsd/hadoop-run@sha256:b62638fe25a9b5cd510df650c1cd50daa76c64f7fb760f1bae11a7645e107ca2",
-            "containerID": "docker://556dcda1bb1b64474a87ecbc1f3d6e6b3a484807a87368322bbe98192747cb26"
-          }
-        ],
-        "qosClass": "BestEffort"
-      }
-    },
-    {
-      "metadata": {
         "name": "drivers-one-shot-ndldh",
         "generateName": "drivers-one-shot-",
         "namespace": "default",
-        "creationTimestamp": "2018-07-18T06:27:22Z"
+        "creationTimestamp": "2018-07-18T06:27:22Z",
+        "labels": {
+            "app": "drivers-one-shot",
+            "controller-revision-hash": "2607302775",
+            "pod-template-generation": "1"
+        }
       },
       "status": {
         "phase": "Running",

--- a/prometheus/test/test_watchdog.py
+++ b/prometheus/test/test_watchdog.py
@@ -69,7 +69,12 @@ class TestJobExporter(unittest.TestCase):
         obj = json.loads(self.get_data_test_input("data/nodes_list.json"))
 
         metrics = watchdog.parse_nodes_status(obj)
-        log.info(metrics)
+        self.assertTrue(len(metrics) > 0)
+
+    def test_parse_pods_with_no_condition(self):
+        obj = json.loads(self.get_data_test_input("data/no_condtion_pod.json"))
+
+        metrics = watchdog.parse_pods_status(obj)
         self.assertTrue(len(metrics) > 0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix #350 , also fix #972 

refactored previous service metric:
from `pod_current_probe_not_ready 1` to `pai_pod_count{ready="false", name="node_exporter"} 1`

for pai service pod, it will emit metric like:
```
pai_pod_count{host_ip="10.151.40.4",initialized="true",instance="10.151.40.4",job="node_exporter",name="zookeeper",phase="running",podscheduled="true",ready="true"}
```

pai_pod_count relays on all pai service labeled as `app: $service_name`, I found grafana not satisfy this, so I changed grafana's label.

for node, it will emit metric like:
```
pai_node_count{disk_pressure="false",instance="10.151.40.4",job="node_exporter",memory_pressure="false",name="10.151.40.4",out_of_disk="false",ready="true"}
```

this refactoring will make alert rule much simpler.

Also added some rule we frequently encountered when operating our cluster. Will then deployed in INT bed to ease the burden of DRI.