### PR TITLE
fix can not start prometheus with quick start

### DIFF
--- a/pai-management/bootstrap/prometheus/alert-deployment.yaml.template
+++ b/pai-management/bootstrap/prometheus/alert-deployment.yaml.template
@@ -15,6 +15,13 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+{% set prom_info = clusterinfo['prometheusinfo'] %}
+{% if 'alerting' in prom_info and 'alert_manager_port' in prom_info['alerting'] %}
+{% set port = clusterinfo['prometheusinfo']['alerting']['alert_manager_port'] %}
+{% else %}
+{% set port = 9093 %}
+{% endif %}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,7 +49,7 @@ spec:
           - '--storage.path=/alertmanager'
         ports:
         - name: alertmanager
-          containerPort: {{ clusterinfo['prometheusinfo']['alerting']['alert_manager_port']|default(9093) }}
+          containerPort: {{ port }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/alertmanager

--- a/pai-management/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/pai-management/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -15,6 +15,13 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+{% set prom_info = clusterinfo['prometheusinfo'] %}
+{% if 'alerting' in prom_info and 'alert_manager_port' in prom_info['alerting'] %}
+{% set port = clusterinfo['prometheusinfo']['alerting']['alert_manager_port'] %}
+{% else %}
+{% set port = 9093 %}
+{% endif %}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,12 +44,12 @@ data:
         regex: '([^:]+)(:\d*)?'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__
-{% if clusterinfo['prometheusinfo']['alert-manager-hosts'] %}
+{% if clusterinfo['prometheusinfo']['alerting'] %}
     alerting:
       alertmanagers:
         - static_configs:
           - targets:
-            {% for host in clusterinfo['prometheusinfo']['alert-manager-hosts'] %}
-            - {{ host }}:{{ clusterinfo['prometheusinfo']['alerting']['alert_manager_port']|default(9093) }}
+            {% for host in clusterinfo['prometheusinfo']['alerting']['alert-manager-hosts'] %}
+            - {{ host }}:{{ port }}
             {% endfor %}
 {% endif %}

--- a/pai-management/bootstrap/prometheus/service.yaml
+++ b/pai-management/bootstrap/prometheus/service.yaml
@@ -24,6 +24,7 @@ template-list:
   - node-exporter-ds.yaml
   - prometheus-configmap.yaml
   - prometheus-deployment.yaml
+  - start.sh
   - stop.sh
   - refresh.sh
   - delete.yaml

--- a/pai-management/bootstrap/prometheus/start.sh.template
+++ b/pai-management/bootstrap/prometheus/start.sh.template
@@ -30,8 +30,9 @@ kubectl create configmap prometheus-alert --from-file=../../../prometheus/promet
 kubectl create -f node-exporter-ds.yaml
 kubectl create -f prometheus-deployment.yaml
 kubectl create -f watchdog-ds.yaml
-kubectl create -f watchdog-ds.yaml
+{% if clusterinfo['prometheusinfo']['alerting'] %}
 kubectl create -f alert-configmap.yaml
 kubectl create -f alert-deployment.yaml
+{% endif %}
 
 popd > /dev/null

--- a/pai-management/paiLibrary/clusterObjectModel/paiObjectModel.py
+++ b/pai-management/paiLibrary/clusterObjectModel/paiObjectModel.py
@@ -285,7 +285,10 @@ class paiObjectModel:
 
             alert_manager_hosts.append(host["hostip"])
 
-        serviceDict["clusterinfo"]["prometheusinfo"]["alert-manager-hosts"] = alert_manager_hosts
+        # template can check clusterinfo['prometheusinfo']['alerting'] to see if alert is enabled
+        if serviceDict["clusterinfo"]["prometheusinfo"].get("alerting") is not None:
+            serviceDict["clusterinfo"]["prometheusinfo"]["alerting"]["alert-manager-hosts"] = \
+                    alert_manager_hosts
 
         # section
 


### PR DESCRIPTION
fix #1007

quick start script will not generate alerting in configuration. Modified code to accommodate  this: will not deploy alert manager if no alerting config present.

With this fix, both enabled/disabled alert manager can works.