### PR TITLE
[WIP]Web portal: optimize service view

### DIFF
--- a/webportal/src/app/cluster-view/services/service-info.js
+++ b/webportal/src/app/cluster-view/services/service-info.js
@@ -22,14 +22,13 @@ const getServiceView = (kubeURL, namespace, callback) => {
     type: 'GET',
     url: kubeURL + '/api/v1/nodes',
     dataType: 'json',
-    success: function(data) {
-      let items = data.items;
-      let nodeList = [];
-      for (let item of items) {
-        nodeList.push(item);
-      }
-      getNodePods(kubeURL, namespace, nodeList, callback);
-    },
+  }).then(function(data) {
+    let items = data.items;
+    let nodeList = [];
+    for (let item of items) {
+      nodeList.push(item);
+    }
+    getNodePods(kubeURL, namespace, nodeList, callback);
   });
 };
 
@@ -38,26 +37,25 @@ const getNodePods = (kubeURL, namespace, nodeList, callback) => {
     type: 'GET',
     url: kubeURL + '/api/v1/namespaces/' + namespace + '/pods/',
     dataType: 'json',
-    success: function(pods) {
-      let podsItems = pods.items;
-      let nodeDic = [];
+  }).then(function(pods) {
+    let podsItems = pods.items;
+    let nodeDic = [];
 
-      for (let pod of podsItems) {
-        let nodeName = pod.spec.nodeName;
-        if (nodeDic[nodeName] == null) {
-          nodeDic[nodeName] = [];
-        }
-        nodeDic[nodeName].push(pod);
+    for (let pod of podsItems) {
+      let nodeName = pod.spec.nodeName;
+      if (nodeDic[nodeName] == null) {
+        nodeDic[nodeName] = [];
       }
-      let resultDic = [];
-      for (let node of nodeList) {
-        if (nodeDic[node.metadata.name] == undefined) {
-          nodeDic[node.metadata.name] = [];
-        }
-        resultDic.push({'node': node, 'podList': nodeDic[node.metadata.name]});
+      nodeDic[nodeName].push(pod);
+    }
+    let resultDic = [];
+    for (let node of nodeList) {
+      if (nodeDic[node.metadata.name] == undefined) {
+        nodeDic[node.metadata.name] = [];
       }
-      callback(resultDic);
-    },
+      resultDic.push({'node': node, 'podList': nodeDic[node.metadata.name]});
+    }
+    callback(resultDic);
   });
 };
 

--- a/webportal/src/app/cluster-view/services/service-info.js
+++ b/webportal/src/app/cluster-view/services/service-info.js
@@ -17,8 +17,8 @@
 
 // This function will call kubernetes restful api to get node - podlist - label info, to support service view monitor page.
 
-const getServiceView = (kubeURL, namespace, callback) => {
-  $.ajax({
+const getNodeList = (kubeURL) => {
+  return $.ajax({
     type: 'GET',
     url: kubeURL + '/api/v1/nodes',
     dataType: 'json',
@@ -28,16 +28,23 @@ const getServiceView = (kubeURL, namespace, callback) => {
     for (let item of items) {
       nodeList.push(item);
     }
-    getNodePods(kubeURL, namespace, nodeList, callback);
+    return nodeList;
   });
 };
 
-const getNodePods = (kubeURL, namespace, nodeList, callback) => {
-  $.ajax({
+const getNodePods = (kubeURL, namespace) => {
+  return $.ajax({
     type: 'GET',
     url: kubeURL + '/api/v1/namespaces/' + namespace + '/pods/',
     dataType: 'json',
-  }).then(function(pods) {
+  }).then((pods) => pods);
+};
+
+const getServiceView = (kubeURL, namespace, callback) => {
+  $.when(
+    getNodeList(kubeURL),
+    getNodePods(kubeURL, namespace)
+  ).done(function(nodeList, pods) {
     let podsItems = pods.items;
     let nodeDic = [];
 


### PR DESCRIPTION
Fixes #605 

Currently `/api/v1/nodes` & `/api/v1/namespaces/{namespace}/pods` API of K8S are requested in sequence, this PR make them requested in parallel.

Sequence:
![image](https://user-images.githubusercontent.com/2500247/43501969-d8ca6178-958a-11e8-94a7-8a8b13b0fb85.png)

Parallel:
![image](https://user-images.githubusercontent.com/2500247/43502026-3245c558-958b-11e8-8119-8a0e6e1745f2.png)

There is a request slowdown when in parallel, may caused by limited bandwidth or service performance.

Since `nodes` response has less size than `pods` but costs more time, I think service performance issue may be more likely.

Ping @ydye @YitongFeng for some help, thank you.