### PR TITLE
rename metrics in webportal

### DIFF
--- a/webportal/src/app/cluster-view/hardware/hardware.component.js
+++ b/webportal/src/app/cluster-view/hardware/hardware.component.js
@@ -82,7 +82,7 @@ const loadCpuUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList,
   $.ajax({
     type: 'GET',
     url: prometheusUri + '/api/v1/query_range?' +
-      'query=100%20-%20(avg%20by%20(instance)(irate(node_cpu%7Bmode%3D%22idle%22%7D%5B' + metricGranularity + '%5D))%20*%20100)' +
+      'query=100%20-%20(avg%20by%20(instance)(irate(node_cpu_seconds_total%7Bmode%3D%22idle%22%7D%5B' + metricGranularity + '%5D))%20*%20100)' +
       '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
     success: function(data) {
       initCells('cpu', instanceList, table);
@@ -108,7 +108,7 @@ const loadMemUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList,
   $.ajax({
     type: 'GET',
     url: prometheusUri + '/api/v1/query_range?' +
-      'query=node_memory_MemTotal+-+node_memory_MemFree+-+node_memory_Buffers+-+node_memory_Cached' +
+      'query=node_memory_MemTotal_bytes+-+node_memory_MemFree_bytes+-+node_memory_Buffers_bytes+-+node_memory_Cached_bytes' +
       '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
     success: function(dataOfMemUsed) {
       let dictOfMemUsed = {};
@@ -120,7 +120,7 @@ const loadMemUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList,
       $.ajax({
         type: 'GET',
         url: prometheusUri + '/api/v1/query_range?' +
-          'query=node_memory_MemTotal' +
+          'query=node_memory_MemTotal_bytes' +
           '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
         success: function(dataOfMemTotal) {
           initCells('mem', instanceList, table);
@@ -205,7 +205,7 @@ const loadDiskUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList
   $.ajax({
     type: 'GET',
     url: prometheusUri + '/api/v1/query_range?' +
-      'query=sum+by+(instance)(rate(node_disk_bytes_read%5B' + metricGranularity + '%5D))' +
+      'query=sum+by+(instance)(rate(node_disk_read_bytes_total%5B' + metricGranularity + '%5D))' +
       '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
     success: function(dataOfDiskBytesRead) {
       let dictOfDiskBytesRead = {};
@@ -217,7 +217,7 @@ const loadDiskUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList
       $.ajax({
         type: 'GET',
         url: prometheusUri + '/api/v1/query_range?' +
-          'query=sum+by+(instance)(rate(node_disk_bytes_written%5B' + metricGranularity + '%5D))' +
+          'query=sum+by+(instance)(rate(node_disk_written_bytes_total%5B' + metricGranularity + '%5D))' +
           '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
         success: function(dataOfDiskBytesWritten) {
           initCells('disk', instanceList, table);
@@ -256,7 +256,7 @@ const loadEthUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList,
   $.ajax({
     type: 'GET',
     url: prometheusUri + '/api/v1/query_range?' +
-      'query=sum+by+(instance)(rate(node_network_receive_bytes%5B' + metricGranularity + '%5D))' +
+      'query=sum+by+(instance)(rate(node_network_receive_bytes_total%5B' + metricGranularity + '%5D))' +
       '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
     success: function(dataOfEthBytesRecieved) {
       let dictOfEthBytesRecieved = {};
@@ -268,7 +268,7 @@ const loadEthUtilData = (prometheusUri, currentEpochTimeInSeconds, instanceList,
       $.ajax({
         type: 'GET',
         url: prometheusUri + '/api/v1/query_range?' +
-          'query=sum+by+(instance)(rate(node_disk_bytes_written%5B' + metricGranularity + '%5D))' +
+          'query=sum+by+(instance)(rate(node_disk_written_bytes_total%5B' + metricGranularity + '%5D))' +
           '&start=' + currentEpochTimeInSeconds + '&end=' + currentEpochTimeInSeconds + '&step=1',
         success: function(dataOfEthBytesSent) {
           initCells('eth', instanceList, table);


### PR DESCRIPTION
previous I upgrade node_exporter to 0.16.0, this release introduced many metrics renaming. I already renamed metrics in grafana in #987 .
