### PR TITLE
Web portal: refine status sort order, closes #876

### DIFF
--- a/webportal/src/app/job/job-view/job-view.component.js
+++ b/webportal/src/app/job/job-view/job-view.component.js
@@ -138,6 +138,28 @@ const convertState = (humanizedJobStateString) => {
   return `<span class="label ${className}">${humanizedJobStateString}</span>`;
 };
 
+const getStateOrder = (jobInfo) => {
+  const UNKNOWN = -1;
+  const WAITING = 0;
+  const RUNNING = 1;
+  const STOPPING = 2;
+  const STOPPED = 3;
+  const SUCCEEDED = 4;
+  const FAILED = 5;
+
+  if (jobInfo.state === 'WAITING') {
+    return jobInfo.executionType === 'STOP' ? STOPPING : WAITING;
+  }
+  if (jobInfo.state === 'RUNNING') {
+    return jobInfo.executionType === 'STOP' ? STOPPING : RUNNING;
+  }
+  if (jobInfo.state === 'SUCCEEDED') return SUCCEEDED;
+  if (jobInfo.state === 'FAILED') return FAILED;
+  if (jobInfo.state === 'STOPPED') return STOPPED;
+
+  return UNKNOWN;
+};
+
 const convertGpu = (gpuAttribute) => {
   const bitmap = (+gpuAttribute).toString(2);
   const gpuList = [];
@@ -211,8 +233,9 @@ const loadJobs = (specifiedVc) => {
       }},
       {title: 'Retries', data: 'retries'},
       {title: 'Status', data: null, render(data, type) {
-        if (type !== 'display') return getHumanizedJobStateString(data);
-        return convertState(getHumanizedJobStateString(data));
+        if (type === 'display') return convertState(getHumanizedJobStateString(data));
+        if (type === 'sort') return getStateOrder(data);
+        return getHumanizedJobStateString(data);
       }},
       {title: 'Stop', data: null, render(job, type) {
         let hjss = getHumanizedJobStateString(job);


### PR DESCRIPTION
Order by:
- `UNKNOWN`
- `WAITING`
- `RUNNING`
- `STOPPING`
- `STOPPED`
- `SUCCEEDED`
- `FAILED`