### PR TITLE
allow prometheus auto scrape from pod

### DIFF
--- a/pai-management/bootstrap/prometheus/prometheus-configmap.yaml.template
+++ b/pai-management/bootstrap/prometheus/prometheus-configmap.yaml.template
@@ -44,6 +44,27 @@ data:
         regex: '([^:]+)(:\d*)?'
         replacement: '${1}:{{ clusterinfo['prometheusinfo']['node_exporter_port'] }}'
         target_label: __address__
+    - job_name: 'pai_serivce_exporter'
+      scrape_interval: {{clusterinfo['prometheusinfo']['scrape_interval']}}s
+      kubernetes_sd_configs:
+      - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
+        role: pod
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          regex: true
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          regex: (.+)
+          action: replace
+          target_label: __metrics_path__
+        - source_labels: [__meta_kubernetes_pod_host_ip, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          regex: ([^;]+);(\d+)
+          replacement: ${1}:${2}
+          action: replace
+          target_label: __address__
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: k8s_pod_name
 {% if clusterinfo['prometheusinfo']['alerting'] %}
     alerting:
       alertmanagers:


### PR DESCRIPTION
For pods want to be scraped by prometheus should annotated with:
* prometheus.io/scrape
* prometheus.io/path
* prometheus.io/port

for example:
* prometheus.io/scrape: true
* prometheus.io/path: /metrics
* prometheus.io/port: 1234

with this annotation prometheus will scrape from `http://${pod_host_ip}:1234/metrics` to scrape metrics.