### PR TITLE
support PersistentVolume

### DIFF
--- a/pai-management/k8sPaiLibrary/template/kubelet.sh.template
+++ b/pai-management/k8sPaiLibrary/template/kubelet.sh.template
@@ -26,7 +26,7 @@ docker run \
     --volume=/sys:/sys:rw \
     --volume=/dev:/dev:rw \
     --volume=/var/lib/docker/:/var/lib/docker:rw \
-    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw,shared \
     --volume=/etc/resolv.conf:/etc/resolv.conf:rw \
     --volume=/var/run:/var/run:rw \
     --volume=/var/log:/var/log:rw \


### PR DESCRIPTION
We start kubelet with hypekube image, if we want to use nfs PersistentVolume, kubelet will first mount nfs in dir `/var/lib/kubelet` and then instruct docker mount that dir into container.

If we start hypekube with `rw`, this will prevent [mount point propagation](https://lwn.net/Articles/690679/). In other words, mount happend in hypekube will not visible to out side world and hence this setting can not support PersistentVolume.

To allow mount point propagation, just change `rw` option to `shared`. Already tested in INT bed.