### PR TITLE
bugfix: check nvidia-smi exists before run `nvidia-smi -q -x`

### DIFF
--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -67,8 +67,8 @@ def collect_gpu_info():
     except OSError as e:
         if e.errno == os.errno.ENOENT:
             logger.warning("nvidia-smi not found")
-        else:
-            raise
+
+        return None
 
 
 

--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -23,6 +23,7 @@ import os
 import logging
 
 import utils
+
 from utils import Metric
 
 logger = logging.getLogger(__name__)
@@ -54,12 +55,9 @@ def collect_gpu_info():
     try:
         logger.info("call nvidia-smi to get gpu metrics")
 
-        nvidia_smi_exists = len(utils.check_output(["which", "nvidia-smi"])) > 0
-        if nvidia_smi_exists:
-            smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
-            return parse_smi_xml_result(smi_output)
-        else:
-            logger.info('nvidia-smi not found')
+        smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
+
+        return parse_smi_xml_result(smi_output)
     except subprocess.CalledProcessError as e:
         if e.returncode == 127:
             logger.exception("nvidia cmd error. command '%s' return with error (code %d): %s",
@@ -67,6 +65,8 @@ def collect_gpu_info():
         else:
             logger.exception("command '%s' return with error (code %d): %s",
                     e.cmd, e.returncode, e.output)
+    except OSError:
+        logger.warning("nvidia-smi not found")
 
 def convert_gpu_info_to_metrics(gpuInfos):
     if gpuInfos is None:

--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -23,7 +23,6 @@ import os
 import logging
 
 import utils
-
 from utils import Metric
 
 logger = logging.getLogger(__name__)
@@ -55,6 +54,7 @@ def collect_gpu_info():
     try:
         logger.info("call nvidia-smi to get gpu metrics")
 
+
         smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
 
         return parse_smi_xml_result(smi_output)
@@ -65,8 +65,13 @@ def collect_gpu_info():
         else:
             logger.exception("command '%s' return with error (code %d): %s",
                     e.cmd, e.returncode, e.output)
-    except OSError:
-        logger.warning("nvidia-smi not found")
+   except OSError as e:
+        if e.errno == os.errno.ENOENT:
+            logger.warning("nvidia-smi not found")
+        else:
+            raise
+
+
 
 def convert_gpu_info_to_metrics(gpuInfos):
     if gpuInfos is None:

--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -54,9 +54,12 @@ def collect_gpu_info():
     try:
         logger.info("call nvidia-smi to get gpu metrics")
 
-        smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
-
-        return parse_smi_xml_result(smi_output)
+        nvidia_smi_exists = len(utils.check_output(["which", "nvidia-smi"])) > 0
+        if nvidia_smi_exists:
+            smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
+            return parse_smi_xml_result(smi_output)
+        else:
+            logger.info('nvidia-smi not found')
     except subprocess.CalledProcessError as e:
         if e.returncode == 127:
             logger.exception("nvidia cmd error. command '%s' return with error (code %d): %s",

--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -54,7 +54,6 @@ def collect_gpu_info():
     try:
         logger.info("call nvidia-smi to get gpu metrics")
 
-
         smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
 
         return parse_smi_xml_result(smi_output)

--- a/prometheus/exporter/gpu_exporter.py
+++ b/prometheus/exporter/gpu_exporter.py
@@ -64,7 +64,7 @@ def collect_gpu_info():
         else:
             logger.exception("command '%s' return with error (code %d): %s",
                     e.cmd, e.returncode, e.output)
-   except OSError as e:
+    except OSError as e:
         if e.errno == os.errno.ENOENT:
             logger.warning("nvidia-smi not found")
         else:

--- a/prometheus/exporter/healthy_check.py
+++ b/prometheus/exporter/healthy_check.py
@@ -49,8 +49,6 @@ def main():
         except OSError as e:
             if e.errno == os.errno.ENOENT:
                 logger.warning("nvidia-smi not found")
-            else:
-                raise
 
     try:
         dockerDockerInspect = utils.check_output(["docker", "inspect", "--help"])

--- a/prometheus/exporter/healthy_check.py
+++ b/prometheus/exporter/healthy_check.py
@@ -42,12 +42,15 @@ def main():
 
     if gpuExists:
         try:
-            nvidiaSmiExists = len(utils.check_output(["which", "nvidia-smi"])) > 0
-            if nvidiaSmiExists:
-                smiOutput = utils.check_output(["nvidia-smi", "-q", "-x"])
+            smiOutput = utils.check_output(["nvidia-smi", "-q", "-x"])
         except subprocess.CalledProcessError as e:
             runTimeException.append("nvidia-smi")
             logger.error("command '%s' return with error (code %d): %s", e.cmd, e.returncode, e.output)
+        except OSError as e:
+            if e.errno == os.errno.ENOENT:
+                logger.warning("nvidia-smi not found")
+            else:
+                raise
 
     try:
         dockerDockerInspect = utils.check_output(["docker", "inspect", "--help"])

--- a/prometheus/exporter/healthy_check.py
+++ b/prometheus/exporter/healthy_check.py
@@ -42,7 +42,9 @@ def main():
 
     if gpuExists:
         try:
-            smiOutput = utils.check_output(["nvidia-smi", "-q", "-x"])
+            nvidiaSmiExists = len(utils.check_output(["which", "nvidia-smi"])) > 0
+            if nvidiaSmiExists:
+                smiOutput = utils.check_output(["nvidia-smi", "-q", "-x"])
         except subprocess.CalledProcessError as e:
             runTimeException.append("nvidia-smi")
             logger.error("command '%s' return with error (code %d): %s", e.cmd, e.returncode, e.output)


### PR DESCRIPTION
Bugfix for #1095 

Run command `which nvidia-smi` to check exists of `nvidia-smi`, preventing the health-check error.
