### PR TITLE
minify grafana config and exclude template files to avoid too large configmap

### DIFF
--- a/pai-management/bootstrap/grafana/minify.py
+++ b/pai-management/bootstrap/grafana/minify.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python
 
 # Copyright (c) Microsoft Corporation
 # All rights reserved.
@@ -17,14 +17,13 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-# minify json files
-tmp="$(mktemp)"
-for i in `find grafana-configuration/ -type f -regex ".*json" ` ; do
-    cat $i | python minify.py > $tmp
-    mv $tmp $i
-done
+import json
+import sys
 
-# create configmap
-for i in `find grafana-configuration/ -type f -regex ".*json" ` ; do
-    echo --from-file=$i
-done | xargs kubectl create configmap grafana-configuration --dry-run -o yaml | kubectl apply -f - || exit $?
+def minify(raw):
+    """ minify json file """
+    obj = json.loads(raw)
+    return json.dumps(obj, separators=(",", ":"))
+
+if __name__ == '__main__':
+    sys.stdout.write(minify(sys.stdin.read()))


### PR DESCRIPTION
fixed #1147

with following observation:
* previous method of creating grafana configmap puts all files under grafana-configuration directory, including template files. This doubles configMap size.
* json files can be easily compressed using minify tools.

This PR reduced configMap size from 277920 byte to 61082.