### PR TITLE
retry get_auth_token if token_file empty

### DIFF
--- a/pai-management/src/end-to-end-test/start.sh
+++ b/pai-management/src/end-to-end-test/start.sh
@@ -36,7 +36,7 @@ get_auth_token() {
 while true; do
   printf "\nStarting end to end tests:\n"
 
-  if [ ! -f $token_file ] || [ $(( $(date +%s) - $(stat -c %Y $token_file) )) -gt $expiration ]; then
+  if [ ! -f $token_file ] || [ ! -s $token_file ] || [ $(( $(date +%s) - $(stat -c %Y $token_file) )) -gt $expiration ]; then
     get_auth_token
   fi
 


### PR DESCRIPTION
If `$token_file` is empty, retry run `get_auth_token`.