### PR TITLE
Jenkins CI: support multiple slashes in branch name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ echo ${labels[0]} > ${WORKSPACE}/BED.txt
           sh '''#!/bin/bash
 set -ex
 
-echo ${GIT_BRANCH/\\//-}-$(git rev-parse --short HEAD)-${BUILD_ID} > ${WORKSPACE}/IMAGE_TAG.txt
+echo ${GIT_BRANCH//\\//-}-$(git rev-parse --short HEAD)-${BUILD_ID} > ${WORKSPACE}/IMAGE_TAG.txt
 '''
           env.IMAGE_TAG = readFile("${WORKSPACE}/IMAGE_TAG.txt").trim()
           echo "Image tag: ${IMAGE_TAG}"


### PR DESCRIPTION
Reviewing after CI passed is OK.