### PR TITLE
label watchdog:true in cluster-object-model

### DIFF
--- a/cluster-configuration/cluster-configuration.yaml
+++ b/cluster-configuration/cluster-configuration.yaml
@@ -61,7 +61,6 @@ machine-list:
       dashboard: "true"
       zkid: "1"
       pai-master: "true"
-      watchdog: "true"
       alert-manager: "true"
 
 
@@ -73,7 +72,6 @@ machine-list:
       #username: username (Optional)
       #password: password (Optional)
       k8s-role: master
-      node-exporter: "true"
 
 
     - hostname: hostname
@@ -84,7 +82,6 @@ machine-list:
       #username: username (Optional)
       #password: password (Optional)
       k8s-role: master
-      node-exporter: "true"
 
 
     - hostname: hostname

--- a/pai-management/paiLibrary/clusterObjectModel/paiObjectModel.py
+++ b/pai-management/paiLibrary/clusterObjectModel/paiObjectModel.py
@@ -157,6 +157,7 @@ class paiObjectModel:
             host["prometheus"] = "true"
             host["grafana"] = "true"
             host["pylon"] = "true"
+            host["watchdog"] = "true"
             host["node-exporter"] = "true"
 
         if "pai-worker" in host and host["pai-worker"] == "true":

--- a/pai-management/quick-start/cluster-configuration.yaml.template
+++ b/pai-management/quick-start/cluster-configuration.yaml.template
@@ -51,5 +51,4 @@ machine-list:
   {%- if loop.length == 1 %}
     pai-worker: "true"
   {%- endif %}
-    node-exporter: "true"
 {%- endfor %}


### PR DESCRIPTION
fixed #1120 

Watchdog requires node with label watchdog:true to be deployed. Previously, we requires this label written in config and quick start will not generate this. After we upgrade into k8s 1.9.9 deployment select no node will marked as failed, so #1120 failed.

This PR move watchdog:true label into cluster object model like other service, instead of requires user label node manually.