### PR TITLE
[Examples] Update TensorFlow MPI Dockerfile

### DIFF
--- a/examples/mpi/Dockerfile.example.tensorflow-mpi
+++ b/examples/mpi/Dockerfile.example.tensorflow-mpi
@@ -26,7 +26,10 @@
 FROM pai.build.mpi:openmpi1.10.4-hadoop2.7.2-cuda8.0-cudnn6-devel-ubuntu16.04
 
 ENV TENSORFLOW_VERSION=1.4.0
-ENV BAZEL_VERSION 0.11.0
+ENV BAZEL_VERSION=0.5.4
+
+RUN apt-get -y update && apt-get -y install git
+RUN pip install numpy
 
 WORKDIR /
 
@@ -44,7 +47,9 @@ RUN mkdir /bazel && \
 
 # Download and build TensorFlow.
 WORKDIR /tensorflow
-RUN git clone --branch=r1.4 --depth=1 https://github.com/tensorflow/tensorflow.git .
+RUN git clone https://github.com/tensorflow/tensorflow.git . && \
+    git checkout r1.4 && \
+    git cherry-pick -n f73d7c
 ENV TF_NEED_CUDA=1 \
     TF_CUDA_COMPUTE_CAPABILITIES=3.0,3.5,5.2,6.0,6.1 \
     TF_CUDA_VERSION=8.0 \
@@ -61,11 +66,11 @@ ENV TF_NEED_CUDA=1 \
     TF_DOWNLOAD_MKL=0
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH} \
-    bazel clean \
-    ./configure \
+    bazel clean && \
+    ./configure && \
     bazel build -c opt --config=cuda \
-	--cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
-        tensorflow/tools/pip_package:build_pip_package && \
+        --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
+        //tensorflow/tools/pip_package:build_pip_package && \
     rm /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/pip && \
     pip --no-cache-dir install --upgrade /tmp/pip/tensorflow-*.whl && \


### PR DESCRIPTION
Fix TensorFlow mpi example Dockerfile buidling bugs.
The image `openpai/pai.example.tensorflow-mpi` has been updated on Docker Hub.

Fixes #1336.