### PR TITLE
REST Server: Refine error message transfering from upstream.

### DIFF
--- a/src/rest-server/src/util/error.js
+++ b/src/rest-server/src/util/error.js
@@ -19,6 +19,13 @@ const httpErrors = require('http-errors');
 const statuses = require('statuses');
 
 const createError = exports = module.exports = (status, code, message) => {
+    if (typeof message === 'object') {
+        if ('message' in message) {
+            message = message.message;
+        } else {
+            message = JSON.stringify(message);
+        }
+    }
     const error = httpErrors(statuses(status), message, {code});
     Error.captureStackTrace(error, createError);
     return error;


### PR DESCRIPTION
As [unirest](https://github.com/Kong/unirest-nodejs) document says:

> - raw_body (Mixed) - Unprocessed body data

but it still processed body data, from string to object, which is unacceptable in [http-errors](https://github.com/jshttp/http-errors)

This PR will convert transferred raw_body back to JSON if no message field in it.