### PR TITLE
collect network metrics for containers

### DIFF
--- a/deployment/k8sPaiLibrary/template/apiserver.yaml.template
+++ b/deployment/k8sPaiLibrary/template/apiserver.yaml.template
@@ -15,6 +15,11 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# enable recommended admission-control and DenyEscalatingExec which is required to secure job-exporter
+# see https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use
+# NOTE: do not enable ServiceAccount in admission-control, this may cause dashboard not available,
+# which I do not know why.
+
 apiVersion: v1
 kind: Pod
 metadata:
@@ -27,6 +32,7 @@ spec:
     name: apiserver-container
     command:
     - /usr/local/bin/kube-apiserver
+    - --admission-control=NamespaceLifecycle,LimitRanger,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,DenyEscalatingExec
     - --insecure-bind-address
     - {{ hostcofig['hostip'] }}
     - --storage-backend

--- a/src/drivers/deploy/drivers.yaml.template
+++ b/src/drivers/deploy/drivers.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: drivers-one-shot
     spec:
       hostNetwork: true
-      hostPID: true      
+      hostPID: false
       containers:
       - name: nvidia-drivers
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}drivers:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/end-to-end-test/deploy/end-to-end-test.yaml.template
+++ b/src/end-to-end-test/deploy/end-to-end-test.yaml.template
@@ -38,8 +38,6 @@ spec:
       - name: end-to-end-test
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}end-to-end-test:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}
         imagePullPolicy: Always
-        securityContext:
-          privileged: true
         env:
         - name: HDFS_URI
           value: {{ clusterinfo['restserverinfo']['hdfs_uri'] }}

--- a/src/grafana/deploy/grafana.yaml.template
+++ b/src/grafana/deploy/grafana.yaml.template
@@ -30,7 +30,7 @@ spec:
         app: grafana
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       volumes:
       - name: grafana-confg-volume
         configMap:

--- a/src/hadoop-batch-job/deploy/one-time-job-hadoop.yaml.template
+++ b/src/hadoop-batch-job/deploy/one-time-job-hadoop.yaml.template
@@ -28,7 +28,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name:  one-time-job-hadoop
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}hadoop-run:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-data-node/deploy/delete.yaml.template
+++ b/src/hadoop-data-node/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-hadoop-data-node
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-data-node/deploy/hadoop-data-node.yaml.template
+++ b/src/hadoop-data-node/deploy/hadoop-data-node.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: hadoop-data-node
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name:  hadoop-data-node
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}hadoop-run:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-jobhistory/deploy/delete.yaml.template
+++ b/src/hadoop-jobhistory/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-hadoop-jobhistory
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-jobhistory/deploy/hadoop-jobhistory.yaml.template
+++ b/src/hadoop-jobhistory/deploy/hadoop-jobhistory.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: hadoop-jobhistory-service
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name:  hadoop-jobhistory-service
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}hadoop-run:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-name-node/deploy/delete.yaml.template
+++ b/src/hadoop-name-node/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-hadoop-name-node
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-name-node/deploy/hadoop-name-node.yaml.template
+++ b/src/hadoop-name-node/deploy/hadoop-name-node.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: hadoop-name-node
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name:  hadoop-name-node
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}hadoop-run:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-node-manager/deploy/delete.yaml.template
+++ b/src/hadoop-node-manager/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-hadoop-node-manager
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager.yaml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: hadoop-node-manager
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: hadoop-node-manager
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}hadoop-run:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-resource-manager/deploy/delete.yaml.template
+++ b/src/hadoop-resource-manager/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-hadoop-resource-manager
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -33,7 +33,7 @@ spec:
         prometheus.io/port: '{{ clusterinfo['prometheusinfo']['yarn_exporter_port'] }}'
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: hadoop-resource-manager
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}hadoop-run:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/job-exporter/build/job-exporter.dockerfile
+++ b/src/job-exporter/build/job-exporter.dockerfile
@@ -22,11 +22,16 @@ ENV NV_DRIVER=/var/drivers/nvidia/$NVIDIA_VERSION
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NV_DRIVER/lib:$NV_DRIVER/lib64
 ENV PATH=$PATH:$NV_DRIVER/bin
 
-RUN mkdir -p /job_exporter
-COPY src/* /job_exporter/
-
 RUN wget https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz
 RUN tar xzvf docker-17.06.2-ce.tgz -C /usr/local/
 RUN mv /usr/local/docker/* /usr/bin/
+RUN apt-get update && apt-get install -y build-essential git iftop lsof
+
+RUN git clone https://github.com/yadutaf/infilter --depth 1
+RUN cd infilter && make
+RUN cp infilter/infilter /usr/bin
+
+RUN mkdir -p /job_exporter
+COPY src/* /job_exporter/
 
 CMD python /job_exporter/job_exporter.py /datastorage/prometheus 30

--- a/src/job-exporter/src/job_exporter.py
+++ b/src/job-exporter/src/job_exporter.py
@@ -24,6 +24,7 @@ import logging
 import docker_stats
 import docker_inspect
 import gpu_exporter
+import network
 import utils
 from utils import Metric
 
@@ -50,7 +51,7 @@ pai_services = map(lambda s: "k8s_" + s, [
     "hadoop-data-node",
     "zookeeper",
     "node-exporter",
-    "gpu-exporter",
+    "job-exporter",
     "yarn-exporter",
     "nvidia-drivers"
 ])
@@ -71,7 +72,7 @@ def parse_from_labels(labels):
     return gpuIds, otherLabels
 
 
-def collect_job_metrics(gpuInfos):
+def collect_job_metrics(gpu_infos, all_conns):
     stats = docker_stats.stats()
     if stats is None:
         logger.warning("docker stats returns None")
@@ -87,28 +88,41 @@ def collect_job_metrics(gpuInfos):
                 pai_service_name = service_name[4:] # remove "k8s_" prefix
                 break
 
-        if pai_service_name is None:
-            inspectInfo = docker_inspect.inspect(container_id)
-            if inspectInfo is None or not inspectInfo["labels"]:
-                continue
+        inspect_info = docker_inspect.inspect(container_id)
+        pid = inspect_info["pid"] if inspect_info is not None else None
+        inspect_labels = utils.walk_json_field_safe(inspect_info, "labels")
 
-            gpuIds, otherLabels = parse_from_labels(inspectInfo["labels"])
-            otherLabels.update(inspectInfo["env"])
+        if not inspect_labels and pai_service_name is None:
+            continue # other container, maybe kubelet or api-server
+
+        # get network consumption, since all our services/jobs running in host network,
+        # network statistic from docker is not specific to that container. We have to
+        # get network statistic by ourselves.
+        lsof_result = network.lsof(pid)
+        net_in, net_out = network.get_container_network_metrics(all_conns, lsof_result)
+        if logger.isEnabledFor(logging.DEBUG):
+            debug_info = utils.check_output("ps -o cmd fp {0} | tail -n 1".format(pid), shell=True)
+
+            logger.debug("pid %s with cmd `%s` has lsof result %s, in %d, out %d",
+                    pid, debug_info, lsof_result, net_in, net_out)
+
+        if pai_service_name is None:
+            gpuIds, otherLabels = parse_from_labels(inspect_info["labels"])
+            otherLabels.update(inspect_info["env"])
 
             for id in gpuIds:
-                if gpuInfos:
-                    logger.info(gpuInfos)
+                if gpu_infos:
                     labels = copy.deepcopy(otherLabels)
                     labels["minor_number"] = id
 
-                    result.append(Metric("container_GPUPerc", labels, gpuInfos[id]["gpuUtil"]))
-                    result.append(Metric("container_GPUMemPerc", labels, gpuInfos[id]["gpuMemUtil"]))
+                    result.append(Metric("container_GPUPerc", labels, gpu_infos[id]["gpuUtil"]))
+                    result.append(Metric("container_GPUMemPerc", labels, gpu_infos[id]["gpuMemUtil"]))
 
             result.append(Metric("container_CPUPerc", otherLabels, stats["CPUPerc"]))
             result.append(Metric("container_MemUsage", otherLabels, stats["MemUsage_Limit"]["usage"]))
             result.append(Metric("container_MemLimit", otherLabels, stats["MemUsage_Limit"]["limit"]))
-            result.append(Metric("container_NetIn", otherLabels, stats["NetIO"]["in"]))
-            result.append(Metric("container_NetOut", otherLabels, stats["NetIO"]["out"]))
+            result.append(Metric("container_NetIn", otherLabels, net_in))
+            result.append(Metric("container_NetOut", otherLabels, net_out))
             result.append(Metric("container_BlockIn", otherLabels, stats["BlockIO"]["in"]))
             result.append(Metric("container_BlockOut", otherLabels, stats["BlockIO"]["out"]))
             result.append(Metric("container_MemPerc", otherLabels, stats["MemPerc"]))
@@ -118,8 +132,8 @@ def collect_job_metrics(gpuInfos):
             result.append(Metric("service_mem_usage_byte", labels, stats["MemUsage_Limit"]["usage"]))
             result.append(Metric("service_mem_limit_byte", labels, stats["MemUsage_Limit"]["limit"]))
             result.append(Metric("service_mem_usage_percent", labels, stats["MemPerc"]))
-            result.append(Metric("service_net_in_byte", labels, stats["NetIO"]["in"]))
-            result.append(Metric("service_net_out_byte", labels, stats["NetIO"]["out"]))
+            result.append(Metric("service_net_in_byte", labels, net_in))
+            result.append(Metric("service_net_out_byte", labels, net_out))
             result.append(Metric("service_block_in_byte", labels, stats["BlockIO"]["in"]))
             result.append(Metric("service_block_out_byte", labels, stats["BlockIO"]["out"]))
 
@@ -144,8 +158,11 @@ def main(argv):
             gpu_metrics = gpu_exporter.convert_gpu_info_to_metrics(gpu_infos)
             utils.export_metrics_to_file(gpu_metrics_path, gpu_metrics)
 
+            all_conns = network.iftop()
+            logger.debug("iftop result is %s", all_conns)
+
             # join with docker stats metrics and docker inspect labels
-            job_metrics = collect_job_metrics(gpu_infos)
+            job_metrics = collect_job_metrics(gpu_infos, all_conns)
             utils.export_metrics_to_file(job_metrics_path, job_metrics)
         except Exception as e:
             logger.exception("exception in job exporter loop")

--- a/src/job-exporter/src/job_exporter.py
+++ b/src/job-exporter/src/job_exporter.py
@@ -172,6 +172,6 @@ def main(argv):
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",
-            level=logging.INFO)
+            level=logging.DEBUG)
 
     main(sys.argv[1:])

--- a/src/job-exporter/src/network.py
+++ b/src/job-exporter/src/network.py
@@ -1,0 +1,183 @@
+#!/usr/bin/python
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import subprocess
+import json
+import sys
+import re
+import time
+import logging
+import collections
+
+import utils
+
+logger = logging.getLogger(__name__)
+
+# We relay on iftop & lsof to implement network consumption statistic. We first get all
+# network consuption by iftop, this command can run in any namespace, it will output
+# connetion & connection's consumption in some duration(40s), this consumption is node wide
+# statistic. We break this statistic down into container level by running lsof, lsof must
+# run in container's PID namespace. This will collect all connection pairs in that namespace.
+# If the container is running in host namespace, then, lsof will output connection pairs in
+# node level instead of container level.
+# So current implementation is not workable for container running in host PID namespace.
+# Also since lsof can not capture most of short-lived connections, this workaround is useful
+# for long-lived connections.
+
+# To bring lsof in container's PID namespace, job exporter needs to be in host PID namespace
+# and is privileged. This has serious security issue since any people can exec into
+# job-exporter container and have root access to system wide resources, we prevent this by
+# enabling DenyEscalatingExec in kubernets,
+# see https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#denyescalatingexec
+
+
+def convert_to_byte(data):
+    number = float(re.findall(r"(\d+(\.\d+)?)", data)[0][0])
+    if "T" in data:
+        return number * 1024 * 1024 * 1024 * 1024
+    elif "G" in data:
+        return number * 1024 * 1024 * 1024
+    elif "M" in data:
+        return number * 1024 * 1024
+    elif "K" in data:
+        return number * 1024
+    else:
+        return number
+
+
+def iftop():
+    try:
+        output = utils.check_output(["iftop", "-t", "-P", "-s", "1", "-L", "10000",
+            "-B", "-n", "-N"])
+        return parse_iftop(output)
+    except:
+        logger.exception("exec iftop error")
+        return None
+
+
+# iftop return 2s, 10s, 40s connection duration data.
+# duration can only could be 2 or 10 or 40.
+def parse_iftop(iftop_output, duration=40):
+    """ parse output of iftop to map which key is ip:port value is map of in/out statistic """
+    result = collections.defaultdict(lambda : {"in": 0, "out": 0})
+    raw = [line.strip() for line in iftop_output.splitlines()]
+    data = []
+
+    # only interested in part two divided by ----
+    part = 0
+    for line in raw:
+        if "------------" in line:
+            part += 1
+            if part == 2:
+                break
+        else:
+            if part == 1:
+                data.append(line)
+
+    for line_no in xrange(0, len(data), 2):
+        line1 = data[line_no].split()
+        line2 = data[line_no + 1].split()
+        src = line1[1]
+        dst = line2[0]
+
+        if duration == 2:
+            col_index = -4
+        elif duration == 10:
+            col_index = -3
+        elif duration == 40:
+            col_index = -2
+        else:
+            col_index = -2
+
+        out_byte = convert_to_byte(line1[col_index])
+        in_byte = convert_to_byte(line2[col_index])
+
+        result[src]["in"] += in_byte
+        result[src]["out"] += out_byte
+
+        result[dst]["in"] += out_byte
+        result[dst]["out"] += in_byte
+
+    return result
+
+
+def lsof(pid):
+    """ use infilter to do setns https://github.com/yadutaf/infilter """
+    if pid is None:
+        return None
+
+    try:
+        output = utils.check_output(["infilter", str(pid), "/usr/bin/lsof", "-i", "-n", "-P"])
+        return parse_lsof(output)
+    except:
+        logger.exception("exec lsof error")
+        return None
+
+
+def parse_lsof(lsof_output):
+    """ parse output by lsof. For each socket link, lsof will output two lines,
+    return a map with string pid as key and list of ip:port that pid is connected from """
+    conns = collections.defaultdict(lambda : set())
+    data = [line.strip() for line in lsof_output.splitlines()[1:]]
+
+    for line in data:
+        if "ESTABLISHED" in line:
+            parts = line.split()
+            pid = parts[1]
+            src = parts[8].split("->")[0]
+            conns[pid].add(src)
+
+    return conns
+
+
+# NOTE: we assume lsof_result contains network consumption only in container,
+# This assumption will be break if container has host pid namespace, in this case
+# the network metrics contains all network consumption in its node.
+def get_container_network_metrics(all_conns, lsof_result):
+    """ return in_byte, out_byte of container """
+    if all_conns is None or lsof_result is None:
+        return 0, 0
+
+    in_byte = 0
+    out_byte = 0
+
+    for container_pid, container_conns in lsof_result.items():
+        for conn in container_conns:
+            if conn in all_conns:
+                in_byte += all_conns[conn]["in"]
+                out_byte += all_conns[conn]["out"]
+
+    return in_byte, out_byte
+
+
+def main(pids):
+    """ test purpose """
+    conns = iftop()
+
+    logger.info("conns is %s", conns)
+    logger.info("lsof_result is %s", lsof_result)
+
+    for pid in pids:
+        lsof_result = lsof(pid)
+        in_byte, out_byte = get_container_network_metrics(conns, lsof_result)
+        logger.info("pid %s in %d out %d", pid, in_byte, out_byte)
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",
+                        level=logging.INFO)
+    main(sys.argv[1:])

--- a/src/job-exporter/src/network.py
+++ b/src/job-exporter/src/network.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 # node level instead of container level.
 # So current implementation is not workable for container running in host PID namespace.
 # Also since lsof can not capture most of short-lived connections, this workaround is useful
-# for long-lived connections.
+# only for long-lived connections.
 
 # To bring lsof in container's PID namespace, job exporter needs to be in host PID namespace
 # and is privileged. This has serious security issue since any people can exec into
@@ -169,8 +169,8 @@ def main(pids):
     """ test purpose """
     conns = iftop()
 
-    logger.info("conns is %s", conns)
-    logger.info("lsof_result is %s", lsof_result)
+    logger.debug("conns is %s", conns)
+    logger.debug("lsof_result is %s", lsof_result)
 
     for pid in pids:
         lsof_result = lsof(pid)
@@ -179,5 +179,5 @@ def main(pids):
 
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",
-                        level=logging.INFO)
+                        level=logging.DEBUG)
     main(sys.argv[1:])

--- a/src/job-exporter/test/test_docker_inspect.py
+++ b/src/job-exporter/test/test_docker_inspect.py
@@ -56,7 +56,7 @@ class TestDockerInspect(unittest.TestCase):
         file = open(sample_path, "r")
         docker_inspect = file.read()
         inspect_info = parse_docker_inspect(docker_inspect)
-        target_inspect_info = {"labels": {"container_label_PAI_USER_NAME": "openmindstudio", "container_label_GPU_ID": "0,1,", "container_label_PAI_HOSTNAME": "paigcr-a-gpu-1058", "container_label_PAI_JOB_NAME": "trialslot_nnimain_d65bc5ac", "container_label_PAI_CURRENT_TASK_ROLE_NAME": "tuner"}, "env": {"container_env_PAI_TASK_INDEX": "0"}}
+        target_inspect_info = {"labels": {"container_label_PAI_USER_NAME": "openmindstudio", "container_label_GPU_ID": "0,1,", "container_label_PAI_HOSTNAME": "paigcr-a-gpu-1058", "container_label_PAI_JOB_NAME": "trialslot_nnimain_d65bc5ac", "container_label_PAI_CURRENT_TASK_ROLE_NAME": "tuner"}, "env": {"container_env_PAI_TASK_INDEX": "0"}, "pid": 95539}
         self.assertEqual(target_inspect_info, inspect_info)
 
 if __name__ == '__main__':

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -99,7 +99,7 @@ spec:
           limits:
             memory: "1Gi"
         securityContext:
-          privileged: true
+          privileged: true # this is required by job-exporter
         volumeMounts:
         - mountPath: /root/.docker
           name: docker-cred-volume
@@ -145,6 +145,7 @@ spec:
       imagePullSecrets:
       - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
       hostNetwork: true
+      hostPID: true # This is required since job-exporter should get list of pid in container
       tolerations:
       - key: node.kubernetes.io/memory-pressure
         operator: "Exists"

--- a/src/prometheus/deploy/delete.yaml.template
+++ b/src/prometheus/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-prometheus
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/rest-server/deploy/rest-server.yaml.template
+++ b/src/rest-server/deploy/rest-server.yaml.template
@@ -35,8 +35,6 @@ spec:
       - name: rest-server
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}rest-server:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}
         imagePullPolicy: Always
-        securityContext:
-          privileged: true
         env:
         - name: LAUNCHER_WEBSERVICE_URI
           value: {{ clusterinfo['restserverinfo']['webservice_uri'] }}

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -247,6 +247,9 @@ container_local_dir=$mounted_path/nm-local-dir/usercache/{{{ jobData.userName }}
 # Pull docker image and run
 docker pull {{{ jobData.image }}} \
   || { echo "Can not pull Docker image"; exit 1; }
+
+## ATTENTION: do not specify `--pid=host` when run job, otherwise job-exporter can not get right
+## network consumption
 docker run --name $docker_name \
   --rm \
   --tty \

--- a/src/yarn-frameworklauncher/deploy/delete.yaml.template
+++ b/src/yarn-frameworklauncher/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-frameworker-launcher
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/yarn-frameworklauncher/deploy/yarn-frameworklauncher.yaml.template
+++ b/src/yarn-frameworklauncher/deploy/yarn-frameworklauncher.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: yarn-frameworklauncher
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: yarn-frameworklauncher
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}yarn-frameworklauncher:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/zookeeper/deploy/delete.yaml.template
+++ b/src/zookeeper/deploy/delete.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: delete-batch-job-zookeeper
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: cleaning-one-shot
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}cleaning-image:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/zookeeper/deploy/zookeeper.yaml.template
+++ b/src/zookeeper/deploy/zookeeper.yaml.template
@@ -29,7 +29,7 @@ spec:
         app: zookeeper
     spec:
       hostNetwork: true
-      hostPID: true
+      hostPID: false
       containers:
       - name: zookeeper
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}zookeeper:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}


### PR DESCRIPTION
almost same with #764 

This functionality requires job-exporter container to be privileged and has host pid namespace. Since this will have security issue, I enabled admission control in api server with recommended policy and `DenyEscalatingExec`. @ydye please verify this.

It also requires other service to have non-host pid namespace to be accurate.