### PR TITLE
add init option in docker run, help reaping zombie processes

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -251,6 +251,7 @@ docker pull {{{ jobData.image }}} \
 ## ATTENTION: do not specify `--pid=host` when run job, otherwise job-exporter can not get right
 ## network consumption
 docker run --name $docker_name \
+  --init \
   --rm \
   --tty \
   --privileged=false \

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -276,6 +276,6 @@ docker run --name $docker_name \
   --label PAI_USER_NAME={{{ jobData.userName }}} \
   --label PAI_CURRENT_TASK_ROLE_NAME={{{ taskData.name }}} \
   --env-file $ENV_LIST \
-  --entrypoint '/bin/bash' {{{ jobData.image }}} \
-  '/pai/bootstrap/docker_bootstrap.sh'
+   {{{ jobData.image }}} \
+  '/bin/bash /pai/bootstrap/docker_bootstrap.sh'
 

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -277,5 +277,5 @@ docker run --name $docker_name \
   --label PAI_CURRENT_TASK_ROLE_NAME={{{ taskData.name }}} \
   --env-file $ENV_LIST \
    {{{ jobData.image }}} \
-  '/bin/bash /pai/bootstrap/docker_bootstrap.sh'
+  /bin/bash '/pai/bootstrap/docker_bootstrap.sh'
 


### PR DESCRIPTION
hanging container, keep alive after `exit_handle`
![image](https://user-images.githubusercontent.com/11887940/46054346-86b4ce80-c179-11e8-9ad9-775f0b823a65.png)

only script process and 2 zombie processes. `/bin/bash` doesn't reap them correctly.
![image](https://user-images.githubusercontent.com/11887940/46054328-7270d180-c179-11e8-9ce6-f0398539531b.png)

`--init` will overwrite `entrypoint` with `/dev/init`, thus the pid 1 process looks like `/dev/init -- /bin/bash dockerboostrap.sh`. `init` process have a right behavior in reaping zombie processes.