### PR TITLE
add nvidia gpu support for pai-lite

### DIFF
--- a/deployment/k8sPaiLibrary/maintaintool/docker-ce-install.sh
+++ b/deployment/k8sPaiLibrary/maintaintool/docker-ce-install.sh
@@ -56,7 +56,7 @@ else
 
     apt-get -y install docker-ce
 
-    sudo docker run hello-world
+    docker run hello-world
 
     if command -v docker >/dev/null 2>&1; then
         echo Successfully install docker
@@ -64,6 +64,12 @@ else
         echo Failed install docker
         exit 1
     fi
+fi
+
+if command -v nvidia-container-runtime >/dev/null 2>&1; then
+    echo nvidia container runtime has been installed. Skip this.
+else
+    apt-get -y install nvidia-container-runtime
 fi
 
 [[ ! -d "/etc/docker" ]] &&

--- a/deployment/k8sPaiLibrary/template/docker-daemon.json.template
+++ b/deployment/k8sPaiLibrary/template/docker-daemon.json.template
@@ -4,5 +4,11 @@
     "max-size": "100m",
     "max-file": "10"
   },
-  "data-root": "{{ hostcofig["docker-data"] }}"
+  "data-root": "{{ hostcofig["docker-data"] }}",
+  "runtimes": {
+      "nvidia": {
+          "path": "/usr/bin/nvidia-container-runtime",
+          "runtimeArgs": []
+      }
+  }
 }

--- a/deployment/k8sPaiLibrary/template/kubelet.sh.template
+++ b/deployment/k8sPaiLibrary/template/kubelet.sh.template
@@ -69,4 +69,5 @@ docker run \
   --eviction-hard="memory.available<1Gi,nodefs.available<5%,imagefs.available<5%,nodefs.inodesFree<5%,imagefs.inodesFree<5%" \
   --healthz-bind-address="0.0.0.0" \
   --healthz-port="10248" \
+  --feature-gates="DevicePlugins=true" \
   --v=2

--- a/deployment/paiLibrary/clusterObjectModel/paiObjectModel.py
+++ b/deployment/paiLibrary/clusterObjectModel/paiObjectModel.py
@@ -293,6 +293,15 @@ class paiObjectModel:
 
             serviceDict["machinelist"][hostname] = host
 
+        # section: drivers
+
+        serviceDict["clusterinfo"]["drivers"] = {"set-nvidia-runtime": False}
+        if self.rawData["serviceConfiguration"].get("drivers") is not None:
+            driver_conf = self.rawData["serviceConfiguration"]["drivers"]
+            if driver_conf.get("set-nvidia-runtime") is not None:
+                serviceDict["clusterinfo"]["drivers"]["set-nvidia-runtime"] = \
+                        driver_conf["set-nvidia-runtime"]
+
         return serviceDict
 
 

--- a/deployment/quick-start/services-configuration.yaml.template
+++ b/deployment/quick-start/services-configuration.yaml.template
@@ -98,7 +98,8 @@ grafana:
   # port for grafana
   grafana-port: 3000
 
-
+drivers:
+  set-nvidia-runtime: false
 
 prometheus:
   # port for prometheus port

--- a/examples/cluster-configuration/services-configuration.yaml
+++ b/examples/cluster-configuration/services-configuration.yaml
@@ -98,6 +98,8 @@ grafana:
   # port for grafana
   grafana-port: 3000
 
+drivers:
+  set-nvidia-runtime: false
 
 prometheus:
   # port for prometheus port

--- a/paictl.py
+++ b/paictl.py
@@ -673,5 +673,8 @@ def main(args):
 
 
 if __name__ == "__main__":
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(script_dir)
+
     setup_logging()
     main(sys.argv[1:])

--- a/src/drivers/build/clean.sh
+++ b/src/drivers/build/clean.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+if [ -f /etc/docker/daemon.json ] ; then
+    cat /etc/docker/daemon.json | jq 'del(."default-runtime")' | jq 'del(.runtimes.nvidia)' > tmp
+    mv tmp /etc/docker/daemon.json
+    pkill -SIGHUP dockerd
+fi
+
+touch /finished
+
+while true; do sleep 3600; done

--- a/src/drivers/build/docker-config-with-nvidia-runtime.json
+++ b/src/drivers/build/docker-config-with-nvidia-runtime.json
@@ -1,0 +1,3 @@
+{
+  "default-runtime": "nvidia"
+}

--- a/src/drivers/build/drivers.dockerfile
+++ b/src/drivers/build/drivers.dockerfile
@@ -46,9 +46,8 @@ RUN apt-get -y update && \
         python-prettytable \
         python-netifaces \
         python-pip \
-        git \
         realpath \
-        dos2unix \
+        gawk \
         module-init-tools && \
     pip install subprocess32 && \
     add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
@@ -58,12 +57,6 @@ RUN apt-get -y update && \
 
 WORKDIR $STAGE_DIR
 
-COPY build/install-* build/enable-nvidia-persistenced-mode.sh $STAGE_DIR/
-RUN chmod u+x install-nvidia-drivers
-RUN chmod u+x install-all-drivers
-RUN chmod u+x enable-nvidia-persistenced-mode.sh
-RUN dos2unix *
-
 ENV NVIDIA_VERSION=384.111
 
 RUN wget --no-verbose http://us.download.nvidia.com/XFree86/Linux-x86_64/$NVIDIA_VERSION/NVIDIA-Linux-x86_64-$NVIDIA_VERSION.run && \
@@ -71,9 +64,10 @@ RUN wget --no-verbose http://us.download.nvidia.com/XFree86/Linux-x86_64/$NVIDIA
     ./NVIDIA-Linux-x86_64-$NVIDIA_VERSION.run --extract-only && \
     rm ./NVIDIA-Linux-x86_64-$NVIDIA_VERSION.run
 
-
 ENV NV_DRIVER=/var/drivers/nvidia/$NVIDIA_VERSION
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NV_DRIVER/lib:$NV_DRIVER/lib64
 ENV PATH=$PATH:$NV_DRIVER/bin
+
+COPY build/* build/enable-nvidia-persistenced-mode.sh $STAGE_DIR/
 
 CMD ./install-all-drivers

--- a/src/drivers/build/install-all-drivers
+++ b/src/drivers/build/install-all-drivers
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 if lspci | grep -qE "[0-9a-fA-F][0-9a-fA-F]:[0-9a-fA-F][0-9a-fA-F].[0-9] (3D|VGA compatible) controller: NVIDIA Corporation.*"; then
-    ./install-nvidia-drivers || exit $?
+    ./install-nvidia-drivers "$@" || exit $?
     echo NVIDIA gpu detected, drivers installed
 
     ./enable-nvidia-persistenced-mode.sh || exit $?

--- a/src/drivers/build/install-nvidia-drivers
+++ b/src/drivers/build/install-nvidia-drivers
@@ -17,6 +17,13 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+CONFIG_RUNTIME=false
+
+if [ "$#" -eq "1" -a "$1" == "--config-runtime" ] ; then
+    CONFIG_RUNTIME=true
+fi
+
+echo CONFIG_RUNTIME is $CONFIG_RUNTIME
 
 KERNEL_FULL_VERSION=`uname -r`
 CURRENT_DRIVER=/var/drivers/nvidia/current
@@ -28,6 +35,20 @@ CURRENT_DRIVER=/var/drivers/nvidia/current
 #  exit 1
 #}
 
+function configDockerRuntime {
+    cp /etc/docker/daemon.json /etc/docker/daemon.json.before_config_runtime
+
+    jq -s '.[0] * .[1]' docker-config-with-nvidia-runtime.json /etc/docker/daemon.json > tmp
+    mv tmp /etc/docker/daemon.json
+
+    pkill -SIGHUP dockerd
+}
+
+function dockerRuntimeConfigured {
+    cat /etc/docker/daemon.json | jq -e 'has("default-runtime")' &> /dev/null
+    return $?
+}
+
 function nvidiaPresent {
   [[ -f /proc/driver/nvidia/version ]] || return 1
   grep -q $NVIDIA_VERSION /proc/driver/nvidia/version || return 2
@@ -35,6 +56,11 @@ function nvidiaPresent {
   lsmod | grep -qE "^nvidia_uvm" || return 3
   [[ -e /dev/nvidia0 ]] || return 4
   [[ -e /var/drivers/nvidia/$NVIDIA_VERSION/lib64/libnvidia-ml.so ]] || return 5
+
+  [[ -e /etc/ld.so.conf.d/nvidia-drivers.conf ]] || return 6
+  if test $CONFIG_RUNTIME == "true" && ! dockerRuntimeConfigured ; then
+      return 7
+  fi
   return 0
 }
 
@@ -79,7 +105,7 @@ mkdir -p $NV_DRIVER/lib $NV_DRIVER/lib64 $NV_DRIVER/bin || exit $?
     --utility-libdir=lib64 \
     --x-library-path=lib64 \
     --compat32-libdir=lib \
-    -s -N || exit $?
+    -s -N
 
 echo === Loading NVIDIA UVM module
 modprobe nvidia-uvm || exit $?
@@ -97,6 +123,12 @@ for ((GPU=0; GPU<$GPU_COUNT; GPU++)); do
 done
 
 ls -la /dev/nvidia*
+
+ldconfig
+
+if [ $CONFIG_RUNTIME == "true" ] ; then
+    configDockerRuntime
+fi
 
 echo === Check if everything is loaded
 nvidiaPresent || exit $?

--- a/src/drivers/deploy/clean.yaml.template
+++ b/src/drivers/deploy/clean.yaml.template
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Copyright (c) Microsoft Corporation
 # All rights reserved.
 #
@@ -17,8 +15,44 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pushd $(dirname "$0") > /dev/null
-
-/bin/bash stop.sh || exit $?
-
-popd > /dev/null
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rollback-nvidia-runtime
+spec:
+  selector:
+    matchLabels:
+      app: rollback-nvidia-runtime
+  template:
+    metadata:
+      labels:
+        app: rollback-nvidia-runtime
+    spec:
+      hostNetwork: false
+      hostPID: true # this is required by pkill dockerd
+      containers:
+      - name:  rollback-nvidia-runtime
+        image: {{ clusterinfo["dockerregistryinfo"]["prefix"] }}drivers:{{ clusterinfo["dockerregistryinfo"]["docker_tag"] }}
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true # this is required by pkill dockerd
+        command:
+        - sh
+        - -x
+        - clean.sh
+        volumeMounts:
+        - mountPath: /etc/docker
+          name: docker-config
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /finished
+          initialDelaySeconds: 5
+          periodSeconds: 3
+      imagePullSecrets:
+      - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
+      volumes:
+      - name: docker-config
+        hostPath:
+          path: /etc/docker

--- a/src/drivers/deploy/delete.sh.template
+++ b/src/drivers/deploy/delete.sh.template
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright (c) Microsoft Corporation
 # All rights reserved.
 #
@@ -15,21 +17,21 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-prerequisite:
-  - cluster-configuration
+pushd $(dirname "$0") > /dev/null
 
-template-list:
-  - drivers.yaml
-  - clean.yaml
-  - delete.sh
+{% if clusterinfo['drivers']['set-nvidia-runtime'] %}
+kubectl apply --overwrite=true -f clean.yaml || exit $?
 
-# Note： your script should start all your service dependency. Make sure service has completed the starting process.
-start-script: start.sh
-stop-script: stop.sh
-delete-script: delete.sh
-refresh-script: refresh.sh
-upgraded-script: upgraded.sh
+export PYTHONPATH="../../../deployment"
 
+# wait until all clean finished
+python -m k8sPaiLibrary.monitorTool.check_pod_ready_status -w -k app -v rollback-nvidia-runtime
 
-deploy-rules:
-  - notin: no-drivers
+sleep 30 # SIGHUP in clean container may restart dockerd which will leads to restart of all docker containers include api server
+
+kubectl delete -f clean.yaml
+{% endif %}
+
+/bin/bash stop.sh || exit $?
+
+popd > /dev/null

--- a/src/drivers/deploy/drivers.yaml.template
+++ b/src/drivers/deploy/drivers.yaml.template
@@ -66,8 +66,10 @@ spec:
             memory: "256Mi"
         command:
         - "./install-all-drivers"
+        {% if clusterinfo['drivers']['set-nvidia-runtime'] %}
         args:
         - "--config-runtime"
+        {% endif %}
       imagePullSecrets:
       - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
       volumes:

--- a/src/drivers/deploy/drivers.yaml.template
+++ b/src/drivers/deploy/drivers.yaml.template
@@ -50,6 +50,8 @@ spec:
           name: drivers-log
         - mountPath: /usr/src
           name: kernel-head
+        - mountPath: /etc
+          name: etc-path
         readinessProbe:
           exec:
             command:
@@ -62,6 +64,10 @@ spec:
             memory: "2Gi"
           requests:
             memory: "256Mi"
+        command:
+        - "./install-all-drivers"
+        args:
+        - "--config-runtime"
       imagePullSecrets:
       - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
       volumes:
@@ -80,4 +86,6 @@ spec:
       - name: kernel-head
         hostPath:
           path: /usr/src
-
+      - name: etc-path
+        hostPath:
+          path: /etc


### PR DESCRIPTION
Changed other bootup script to install nvidia-container-runtime and config kubelet with DevicePlugins=true.

With this PR, pai-lite user can use normal way to bootup a k8s cluster, and config `drivers.set-nvidia-runtime = true` and start `drivers` to be able to use gpu as resource.

An document still needed to describe how to setup correctly:
* bootup cluster as in pai
* config `drivers.set-nvidia-runtime = true`
* start drivers service
* start nvidia k8s-device-plugin manually
