### PR TITLE
refine refresh

### DIFF
--- a/deployment/paiLibrary/paiService/service_management_refresh.py
+++ b/deployment/paiLibrary/paiService/service_management_refresh.py
@@ -25,6 +25,7 @@ from . import service_template_clean
 
 from ..common import directory_handler
 from ..common import file_handler
+from ..common import linux_shell
 
 
 class service_management_refresh:
@@ -40,7 +41,7 @@ class service_management_refresh:
         else:
             self.service_list = service_list
 
-        self.role_map = dict()
+        self.label_map = dict()
 
     def get_service_list(self):
 
@@ -60,34 +61,31 @@ class service_management_refresh:
 
 
     def refresh_all_label(self):
-        service_conf = file_handler.load_yaml_config("src/{0}/deploy/service.yaml".format(serv))
+        self.logger.info("Begin to refresh all the nodes' labels")
         machinelist = self.cluster_object_model['machinelist']
-        service_refresher = service_refresh.service_refresh(service_conf, serv, machinelist)
-
-        roles = ['pai-master', 'pai-worker']
-        err_msg_prefix = "Error refreshing service " + self.service_name + " when execute: "
-
-
-        for role in roles:
-            self.role_map[role] = list()
-
-        for host self.machinelist:
-            nodename = self.machinelist[host]['nodename']
-            for role in roles:
-                cmd_checklabel = "kubectl describe node " + nodename + " | grep -q " + role + "='true'"
+        
+        labels = ['pai-master', 'pai-worker', 'no-driver', 'no-nodeexporter']
+        for label in labels:
+            self.label_map[label] = list()
+            
+        err_msg_prefix = "Error refreshing all label when execute: "
+        for host in machinelist:
+            nodename = machinelist[host]['nodename']
+            for label in labels:
+                cmd_checklabel = "kubectl describe node " + nodename + " | grep -q " + label + "='true'"
                 has_label = linux_shell.execute_shell_return(cmd_checklabel, "")
                 # If machinelist config has defined the label, but the node did't have, label it
-                if role in self.machinelist[host]:  
-                    self.role_map[role].append(nodename)                    
+                if label in machinelist[host]:  
+                    self.label_map[label].append(nodename)                    
                     if not has_label:
-                        self.logger.info("Role defined in cluster-configuration machinelist, label the node " + str(nodename) + " of " + role)                 
-                        cmd = "kubectl label --overwrite=true nodes " + nodename + " " + role +"='true' || exit $?"
+                        self.logger.info("Label defined in cluster-configuration machinelist, label the node " + str(nodename) + " of " + label)                 
+                        cmd = "kubectl label --overwrite=true nodes " + nodename + " " + label +"='true' || exit $?"
                         linux_shell.execute_shell(cmd, err_msg_prefix + cmd)
                 # If machinelist config has not define the label, but the node has the label, remove it
                 else:
                     if has_label:
-                        self.logger.info("Remove Node " + nodename + " label " + role + ", due to the cluster-configuration machinelist doesn't specify this label")
-                        cmd = "kubectl label nodes " + nodename + " " + role +"- || exit $?"
+                        self.logger.info("Remove Node " + nodename + " label " + label + ", due to the cluster-configuration machinelist doesn't specify this label")
+                        cmd = "kubectl label nodes " + nodename + " " + label +"- || exit $?"
                         linux_shell.execute_shell(cmd, err_msg_prefix + " when kubectl label nodes")
 
 
@@ -99,7 +97,7 @@ class service_management_refresh:
 
         service_conf = file_handler.load_yaml_config("src/{0}/deploy/service.yaml".format(serv))
         machinelist = self.cluster_object_model['machinelist']
-        service_refresher = service_refresh.service_refresh(service_conf, serv, self.role_map)
+        service_refresher = service_refresh.service_refresh(service_conf, serv, self.label_map)
 
         dependency_list = service_refresher.get_dependency()
         if dependency_list != None:

--- a/deployment/paiLibrary/paiService/service_management_refresh.py
+++ b/deployment/paiLibrary/paiService/service_management_refresh.py
@@ -65,9 +65,10 @@ class service_management_refresh:
         machinelist = self.cluster_object_model['machinelist']
         
         labels = ['pai-master', 'pai-worker', 'no-driver', 'no-nodeexporter']
+        logging.info("Currently supported labels: " + str(labels))
         for label in labels:
             self.label_map[label] = list()
-            
+
         err_msg_prefix = "Error refreshing all label when execute: "
         for host in machinelist:
             nodename = machinelist[host]['nodename']

--- a/deployment/paiLibrary/paiService/service_refresh.py
+++ b/deployment/paiLibrary/paiService/service_refresh.py
@@ -44,7 +44,7 @@ class service_refresh:
                 if 'in' in rule:
                     # If service not runnning on labeled node, start the service
                     if rule['in'] not in self.label_map:
-                        self.logger.error("Label defined error, " + rule['in'] + " isn't defined in cluster-configuration.yaml machinelist.")
+                        self.logger.error("Label defined error, " + rule['in'] + " isn't supported in cluster-configuration.yaml machinelist.")
                     nodes = self.label_map[rule['in']]
                     for nodename in nodes:                        
                         cmd_checkservice = "kubectl get po -o wide | grep " + nodename + " | grep -q " + self.service_name
@@ -59,16 +59,13 @@ class service_refresh:
                     res = linux_shell.execute_shell_with_output(cmd, "")
                     items = res.split("\n")
                     nodes_has_service = dict()
-                    print(str(len(items)) + "**********************")
                     for item in items:
                         if len(item) > 10:
-                            #print(item)
                             item = item.split()
-                            #print("***************" + item[0])
                             nodes_has_service[item[-1]] = item[0]
                     for n in nodes_has_service:
                         if n not in nodes: 
-                            self.logger.info("Service " + self.service_name + " should not run on " + nodename + 
+                            self.logger.info("Service " + self.service_name + " should not run on " + n + 
                                 " according to its deploy-rules of service.yaml config file. Deleting...")           
                             cmd = "kubectl delete pod " + nodes_has_service[n]
                             linux_shell.execute_shell(cmd, err_msg_prefix + cmd)

--- a/deployment/paiLibrary/paiService/service_refresh.py
+++ b/deployment/paiLibrary/paiService/service_refresh.py
@@ -41,51 +41,59 @@ class service_refresh:
         err_msg_prefix = "Error refreshing service " + self.service_name + " when execute: "
         for host in self.machinelist:
             nodename = self.machinelist[host]['nodename']
-            for rule in self.service_conf['deploy-rules']:
-                if 'in' in rule:
-                    # If machinelist config has defined the label
-                    if rule['in'] in self.machinelist[host]:  
-                        self.logger.info("Role defined in cluster-configuration machinelist, label the node of this role...")                 
-                        cmd = "kubectl label --overwrite=true nodes " + nodename + " " + rule['in'] +"='true' || exit $?"
-                        linux_shell.execute_shell(cmd, err_msg_prefix + cmd)
+            if 'deploy-rules' in self.service_conf:
+                for rule in self.service_conf['deploy-rules']:
+                    if 'in' in rule:
+                        # If machinelist config has defined the label
+                        if rule['in'] in self.machinelist[host]:  
+                            # If the node did't have the label, label it
+                            cmd_checklabel = "kubectl describe node " + nodename + " | grep -q " + rule['in'] + "='true'"
+                            if not linux_shell.execute_shell_return(cmd_checklabel, ""):
+                                self.logger.info("Role defined in cluster-configuration machinelist, label the node " + str(nodename) + " of " + rule['in'])                 
+                                cmd = "kubectl label --overwrite=true nodes " + nodename + " " + rule['in'] +"='true' || exit $?"
+                                linux_shell.execute_shell(cmd, err_msg_prefix + cmd)
 
-                        # If machinelist config has defined label, but service not runnning, start the service
-                        cmd = "kubectl get po -o wide | grep " + nodename + " | grep -q " + self.service_name
-                        if not linux_shell.execute_shell_return(cmd, ""):
-                            self.logger.info("Start service " + self.service_name + " frome Node " + nodename + 
-                                " for its deploy role is labeled on this node according to the cluster-configuration machinelist but service isn't running.")
-                            start_script = "src/{0}/deploy/{1}".format(self.service_name, self.service_conf["start-script"])
-                            linux_shell.execute_shell("/bin/bash " + start_script, err_msg_prefix + cmd)
-                    
-                    else:
-                        cmd = "kubectl describe node " + nodename + " | grep -q " + rule['in'] + "='true'"
-                        if linux_shell.execute_shell_return(cmd, ""):
-                            self.logger.info("Remove Node " + nodename + " label " + rule['in'] + ", due to the cluster-configuration machinelist doesn't specify this label")
-                            cmd = "kubectl label nodes " + nodename + " " + rule['in'] +"- || exit $?"
-                            linux_shell.execute_shell(cmd, err_msg_prefix + " when kubectl label nodes")
+                            # If machinelist config has defined label, but service not runnning, start the service
+                            cmd_checkservice = "kubectl get po -o wide | grep " + nodename + " | grep -q " + self.service_name
+                            if not linux_shell.execute_shell_return(cmd_checkservice, ""):
+                                self.logger.info("Start service " + self.service_name + " frome Node " + nodename + 
+                                    " for its deploy role is labeled on this node according to the cluster-configuration machinelist but service isn't running.")
+                                start_script = "src/{0}/deploy/{1}".format(self.service_name, self.service_conf["start-script"])
+                                linux_shell.execute_shell("/bin/bash " + start_script, err_msg_prefix + " start service " + self.service_name)
+                        
+                        else:
+                            # If the node has the label, remove it
+                            cmd_checklabel = "kubectl describe node " + nodename + " | grep -q " + rule['in'] + "='true'"
+                            if linux_shell.execute_shell_return(cmd_checklabel, ""):
+                                self.logger.info("Remove Node " + nodename + " label " + rule['in'] + ", due to the cluster-configuration machinelist doesn't specify this label")
+                                cmd = "kubectl label nodes " + nodename + " " + rule['in'] +"- || exit $?"
+                                linux_shell.execute_shell(cmd, err_msg_prefix + " when kubectl label nodes")
 
-                        cmd = "kubectl get po -o wide | grep " + nodename + " | grep -q " + self.service_name
-                        if linux_shell.execute_shell_return(cmd, ""):          
-                            # Delete the specific single pod
-                            self.logger.info("Stop service " + self.service_name + " frome Node " +  nodename + 
-                                " for its deploy role isn't labeled on this node according to the cluster-configuration machinelist but service pod is still running on this node")
-                            cmd = "kubectl get po -o wide | grep " + nodename + " | grep " + self.service_name
-                            res = linux_shell.execute_shell_with_output(cmd, "")
-                            pod_name = res.split()[0]
-                            cmd = "kubectl delete pod " + pod_name
-                            linux_shell.execute_shell(cmd, err_msg_prefix + cmd)
+                            cmd_checkservice = "kubectl get po -o wide | grep " + nodename + " | grep -q " + self.service_name
+                            if linux_shell.execute_shell_return(cmd_checkservice, ""):          
+                                # Delete the specific single pod
+                                self.logger.info("Stop service " + self.service_name + " frome Node " +  nodename + 
+                                    " for its deploy role isn't labeled on this node according to the cluster-configuration machinelist but service pod is still running on this node")
+                                cmd = "kubectl get po -o wide | grep " + nodename + " | grep " + self.service_name
+                                res = linux_shell.execute_shell_with_output(cmd, "")
+                                pod_name = res.split()[0]
+                                cmd = "kubectl delete pod " + pod_name
+                                linux_shell.execute_shell(cmd, err_msg_prefix + cmd)
 
-                if 'notin' in rule:
-                    # If machinelist config has defined the label
-                    if rule['notin'] in self.machinelist[host]:
-                        self.logger.info("Role defined in cluster-configuration machinelist, label the node of this role...")
-                        cmd = "kubectl label --overwrite=true nodes " + nodename + " " + rule['notin'] + "='true' || exit $?"
-                        linux_shell.execute_shell(cmd, err_msg_prefix + cmd)     
-                    else:
-                        cmd = "kubectl describe node " + nodename + " | grep -q " + rule['notin'] + "='true'"
-                        if linux_shell.execute_shell_return(cmd, ""):
-                             self.logger.info("Remove Node " + nodename + " label " + rule['notin'] + ", due to the cluster-configuration machinelist doesn't specify this label")
-                             cmd = "kubectl label nodes " + nodename + " " + rule['notin'] +"- || exit $?"
+                    if 'notin' in rule:
+                        cmd_checklabel = "kubectl describe node " + nodename + " | grep -q " + rule['notin'] + "='true'"
+                        # If node has the label
+                        if linux_shell.execute_shell_return(cmd_checklabel, ""):
+                            if not rule['notin'] in self.machinelist[host]: # If machinelist config has not define the label, remove it
+                                self.logger.info("Remove Node " + nodename + " label " + rule['notin'] + ", due to the cluster-configuration machinelist doesn't specify this label")
+                                cmd = "kubectl label nodes " + nodename + " " + rule['notin'] +"- || exit $?"
+                                linux_shell.execute_shell(cmd, err_msg_prefix + cmd)
+                        # If node has not the label
+                        else:
+                            if rule['notin'] in self.machinelist[host]: # If machinelist config has defined the label, label it
+                                self.logger.info("Role defined in cluster-configuration machinelist, label the node " + str(nodename) + " of " + rule['notin'])
+                                cmd = "kubectl label --overwrite=true nodes " + nodename + " " + rule['notin'] + "='true' || exit $?"
+                                linux_shell.execute_shell(cmd, err_msg_prefix + cmd) 
 
         refresh_script = "src/{0}/deploy/{1}".format(self.service_name, self.service_conf["refresh-script"])
         cmd = "/bin/bash {0}".format(refresh_script)


### PR DESCRIPTION
In the past, execute kubectl label node regardless of whether the node has the label, it will output confused log, refine it by check the existence of the label first, if already has label, do nothing.

- [x] Check label globally
Now refresh each service all need to scan the whole machinelist once, if refresh all services and the cluster is big it will take longtime, should change the scan step to global way.