### PR TITLE
Add liveness probe for yarn-exporter container

### DIFF
--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -87,8 +87,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 8088
-            host: 127.0.0.1
+            port: {{ clusterinfo['prometheusinfo']['yarn_exporter_port'] }}"
             scheme: HTTPS
           initialDelaySeconds: 5
           timeoutSeconds: 1

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -87,7 +87,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: {{ clusterinfo['prometheusinfo']['yarn_exporter_port'] }}"
+            port: {{ clusterinfo['prometheusinfo']['yarn_exporter_port'] }}
             scheme: HTTPS
           initialDelaySeconds: 5
           timeoutSeconds: 1

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -84,6 +84,14 @@ spec:
           - "/usr/local/yarn_exporter.py"
           - "http://127.0.0.1:8088"
           - "-p {{ clusterinfo['prometheusinfo']['yarn_exporter_port'] }}"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8088
+            host: 127.0.0.1
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
       imagePullSecrets:
       - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
       volumes:


### PR DESCRIPTION
In case that if the RM hasn't ready the yarn-exporter container will exit, add liveness probe for yarn-exporter container will fix it.