### PR TITLE
Enable kubelet healtz port and address.

### DIFF
--- a/deployment/k8sPaiLibrary/template/kubelet.sh.template
+++ b/deployment/k8sPaiLibrary/template/kubelet.sh.template
@@ -67,4 +67,6 @@ docker run \
   --docker-root=${DOCKER_ROOT_DIR_FOR_KUBELET} \
   --system-reserved=memory=3Gi \
   --eviction-hard="memory.available<1Gi,nodefs.available<5%,imagefs.available<5%,nodefs.inodesFree<5%,imagefs.inodesFree<5%" \
+  --healthz-bind-address=0.0.0.0 \
+  --healthz-port=10248 \
   --v=2

--- a/deployment/k8sPaiLibrary/template/kubelet.sh.template
+++ b/deployment/k8sPaiLibrary/template/kubelet.sh.template
@@ -67,6 +67,6 @@ docker run \
   --docker-root=${DOCKER_ROOT_DIR_FOR_KUBELET} \
   --system-reserved=memory=3Gi \
   --eviction-hard="memory.available<1Gi,nodefs.available<5%,imagefs.available<5%,nodefs.inodesFree<5%,imagefs.inodesFree<5%" \
-  --healthz-bind-address=0.0.0.0 \
-  --healthz-port=10248 \
+  --healthz-bind-address="0.0.0.0" \
+  --healthz-port="10248" \
   --v=2


### PR DESCRIPTION
```
--healthz-bind-address 0.0.0.0
The IP address for the healthz server to serve on (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces) (default 127.0.0.1)

--healthz-port int32
The port of the localhost healthz endpoint (set to 0 to disable) (default 10248)
```

REF Link: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/

