### PR TITLE
[AKS] prometheus config leverage service account access api-server

### DIFF
--- a/deployment/quick-start/services-configuration.yaml.template
+++ b/deployment/quick-start/services-configuration.yaml.template
@@ -41,6 +41,10 @@ cluster:
     # Must be lower case, e.g., regsecret.
     secret-name: pai-secret
 
+  api-server:
+    # use tls for prometheus access
+    tls_access: false
+
 
 hadoop:
   # When needed, hadoop-ai would be downloaded and built under 'custom-hadoop-binary-path'.
@@ -110,8 +114,7 @@ prometheus:
 
   # port for yarn exporter
   yarn_exporter_port: 9459
-  # use tls for prometheus access
-  use_tls: false
+
   # if you want to enable alert manager to send alert email, uncomment following lines and fill
   # right values.
   #  alerting:

--- a/deployment/quick-start/services-configuration.yaml.template
+++ b/deployment/quick-start/services-configuration.yaml.template
@@ -110,7 +110,8 @@ prometheus:
 
   # port for yarn exporter
   yarn_exporter_port: 9459
-
+  # use tls for prometheus access
+  use_tls: false
   # if you want to enable alert manager to send alert email, uncomment following lines and fill
   # right values.
   #  alerting:

--- a/src/prometheus/deploy/prometheus-configmap.yaml.template
+++ b/src/prometheus/deploy/prometheus-configmap.yaml.template
@@ -36,6 +36,9 @@ data:
     scrape_configs:
     - job_name: 'node_exporter'
       scrape_interval: {{ prom_info['scrape_interval']|default(30) }}s
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node
@@ -48,6 +51,9 @@ data:
         target_label: __address__
     - job_name: 'pai_serivce_exporter'
       scrape_interval: {{clusterinfo['prometheusinfo']['scrape_interval']}}s
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: pod

--- a/src/prometheus/deploy/prometheus-configmap.yaml.template
+++ b/src/prometheus/deploy/prometheus-configmap.yaml.template
@@ -36,7 +36,7 @@ data:
     scrape_configs:
     - job_name: 'node_exporter'
       scrape_interval: {{ prom_info['scrape_interval']|default(30) }}s
-      {% if clusterinfo['prometheusinfo']['use_tls'] -%}
+      {% if clusterinfo['api-server']['tls_access'] -%}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -55,7 +55,7 @@ data:
         target_label: __address__
     - job_name: 'pai_serivce_exporter'
       scrape_interval: {{clusterinfo['prometheusinfo']['scrape_interval']}}s
-      {% if clusterinfo['prometheusinfo']['use_tls'] -%}
+      {% if clusterinfo['api-server']['tls_access'] -%}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/src/prometheus/deploy/prometheus-configmap.yaml.template
+++ b/src/prometheus/deploy/prometheus-configmap.yaml.template
@@ -36,9 +36,13 @@ data:
     scrape_configs:
     - job_name: 'node_exporter'
       scrape_interval: {{ prom_info['scrape_interval']|default(30) }}s
+      {% if clusterinfo['prometheusinfo']['use_tls'] -%}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      {% endif -%}
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: node
@@ -51,9 +55,13 @@ data:
         target_label: __address__
     - job_name: 'pai_serivce_exporter'
       scrape_interval: {{clusterinfo['prometheusinfo']['scrape_interval']}}s
+      {% if clusterinfo['prometheusinfo']['use_tls'] -%}
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      {% endif -%}
       kubernetes_sd_configs:
       - api_server: '{{ clusterinfo['webportalinfo']['k8s_api_server_uri'] }}'
         role: pod


### PR DESCRIPTION
prometheus deployment leverage service account. this is maybe useful for deploy pai on existing k8s which api-server access need auth.

when use this on aks:

- user config use_tls
- config api-server url. 
note: this has the dependency with pr (https://github.com/Microsoft/pai/pull/1428)  for api-server url configuration.
