### PR TITLE
Yuqian/unstable example fix

### DIFF
--- a/examples/auto-test/job_manage.py
+++ b/examples/auto-test/job_manage.py
@@ -14,6 +14,7 @@ class JobManager(object):
             # output: token
             # Get the token from rest server API
             ###
+            rest_server_url_without_namespace = '/'.join(self.rest_server_url.split('/')[:-3]) + '/'
             token_ready = False
             loop_count = 0
             while not token_ready:
@@ -21,7 +22,7 @@ class JobManager(object):
                 loop_count += 1
                 http_object = self.http.request(
                     'POST',
-                    self.rest_server_url + 'token',
+                    rest_server_url_without_namespace + 'token',
                     headers={
                         'Content-Type': 'application/x-www-form-urlencoded',
                     },

--- a/examples/auto-test/readme.md
+++ b/examples/auto-test/readme.md
@@ -32,7 +32,7 @@ Copy the project into the container.
 4. Execute the container. `sudo docker exec -it my-autotest /bin/bash`
 5. Run the start.sh script file and use your own parameters of mode, hdfs_socket, webhdfs_socket, PAI_username,PAI_password and rest_server_socket.
 Pay attention to the order, you must give the 6 parameters in the above order. Refer to [Parameters of the start.sh](#Parameters_of_the_start.sh).
-`/bin/bash auto-test/start.sh normal 10.20.30.40:9000 http://10.20.30.40:9186/api/v1/ 10.20.30.40:50070 test test`
+`/bin/bash auto-test/start.sh normal 10.20.30.40:9000 http://10.20.30.40:9186/api/v1/user/your_username 10.20.30.40:50070 test test`
 6. When you run the script, you should choice the examples you want to test.
 See [Parameters of the start.sh](#Parameters_of_the_start.sh) to get the reference.
 7. Wait until all jobs are finished.
@@ -69,6 +69,5 @@ Use "release" as the first parameter of start.sh to enter this mode.
 3. **normal mode**: If the job can run correctly within 30 minutes, the project will regards it succeeded.
 Use "normal" as the first parameter of start.sh to enter this mode.
 ## Note <a name="Note"></a>
-If the **sklearn-mnist, keras_cntk_backend_mnist, keras_tensorflow_backend_mnist, mxnet-autoencoder or tensorflow-cifar10** job failed,
 it may due to the official data downloading source being unstable. Just try again!
 Now(27th September, 2018), the mpi examples are still unready. Ignore them!

--- a/examples/auto-test/start.sh
+++ b/examples/auto-test/start.sh
@@ -2,7 +2,7 @@ echo "Run with 6 parameters: ci/release/normal, rest_server_url, hdfs_url, webhd
 echo "During the runtime, you should select the jobs you want to run, you can also input the jobs' name you want to run."
 cd /tmp
 if [ ! -d "pai/" ]; then
-    git clone https://github.com/Microsoft/pai.git
+    git clone -b yuqian/unstable_example_fix https://github.com/Microsoft/pai.git
     mv pai/examples/ . && rm -rf pai/
     mv examples/ ~/
     cd ~/

--- a/examples/auto-test/start.sh
+++ b/examples/auto-test/start.sh
@@ -2,7 +2,7 @@ echo "Run with 6 parameters: ci/release/normal, rest_server_url, hdfs_url, webhd
 echo "During the runtime, you should select the jobs you want to run, you can also input the jobs' name you want to run."
 cd /tmp
 if [ ! -d "pai/" ]; then
-    git clone -b yuqian/unstable_example_fix https://github.com/Microsoft/pai.git
+    git clone https://github.com/Microsoft/pai.git
     mv pai/examples/ . && rm -rf pai/
     mv examples/ ~/
     cd ~/

--- a/examples/auto-test/start.sh
+++ b/examples/auto-test/start.sh
@@ -14,8 +14,8 @@ if [ ! -d "pai/" ]; then
         threshold=30
     fi
     full="cntk-mpi,tensorflow-mpi,sklearn-mnist,sklearn-text-vectorizers,tensorflow-cifar10,tensorflow-tensorboard,tensorflow-distributed-cifar10,kafka,mxnet-image-classification,mxnet-autoencoder,jupyter_example,tensorflow-serving,xgboost_gpu_hist,cntk-g2p,keras_cntk_backend_mnist,keras_tensorflow_backend_mnist,caffe-mnist,pytorch-regression,pytorch-mnist,chainer-cifar,caffe2-resnet50"
-    stable="sklearn-text-vectorizers,tensorflow-tensorboard,tensorflow-distributed-cifar10,kafka,mxnet-image-classification,jupyter_example,tensorflow-serving,xgboost_gpu_hist,cntk-g2p,keras_tensorflow_backend_mnist,caffe-mnist,pytorch-regression,pytorch-mnist,caffe2-resnet50"
-    echo "If the sklearn-mnist, keras_cntk_backend_mnist, keras_tensorflow_backend_mnist, mxnet-autoencoder or tensorflow-cifar10 job failed, it may due to the official data downloading source being unstable. Just try again!"
+    stable="sklearn-mnist,sklearn-text-vectorizers,tensorflow-cifar10,tensorflow-tensorboard,tensorflow-distributed-cifar10,kafka,mxnet-image-classification,mxnet-autoencoder,jupyter_example,tensorflow-serving,xgboost_gpu_hist,cntk-g2p,keras_cntk_backend_mnist,keras_tensorflow_backend_mnist,caffe-mnist,pytorch-regression,pytorch-mnist,chainer-cifar,caffe2-resnet50"
+    echo "There are some error within the mpi example, so, just ignore them!"
     read -p "Please input name of the examples you want to run with ',' between two names, or you can just input F/S to run full jobs or only stable jobs:" mode
     if [[ $mode =~ ^[a-zA-Z0-9_,]+$ ]]; then
         echo "Run the job of "$mode

--- a/examples/auto-test/test_all_examples.json.igr
+++ b/examples/auto-test/test_all_examples.json.igr
@@ -8,7 +8,7 @@
       "cpuNumber": 2,
       "memoryMB": 8192,
       "gpuNumber": 0,
-      "command": "git clone https://github.com/Microsoft/pai.git && mv pai pai_tmp && /bin/bash pai_tmp/examples/auto-test/start.sh parameters && rm -rf pai_tmp"
+      "command": "git clone https://github.com/Microsoft/pai.git && mv pai pai_tmp && echo \"S\" | /bin/bash pai_tmp/examples/auto-test/start.sh normal http://10.20.30.40:9186/api/v1/user/your_username/ 10.20.30.40:9000 http://10.20.30.40:50070 username password && rm -rf pai_tmp"
     }
   ]
 }

--- a/examples/keras/Dockerfile.example.keras.cntk_backend
+++ b/examples/keras/Dockerfile.example.keras.cntk_backend
@@ -8,9 +8,12 @@ RUN pip install keras cntk-gpu
 
 WORKDIR /root
 
+ENV KERAS_BACKEND cntk
+
 # clone Keras examples
 RUN git clone https://github.com/keras-team/keras.git 
 
-ENV KERAS_BACKEND cntk
+#if you want to build the docker image with data, please prepare the data first and remove the '#' in next line
+#ADD data /root/.keras/ 
 
 WORKDIR /root/keras/examples

--- a/examples/keras/Dockerfile.example.keras.tensorflow_backend
+++ b/examples/keras/Dockerfile.example.keras.tensorflow_backend
@@ -13,4 +13,7 @@ RUN git clone https://github.com/keras-team/keras.git
 
 ENV KERAS_BACKEND tensorflow
 
+#if you want to build the docker image with data, please prepare the data first and remove the '#' in next line
+#ADD data /root/.keras/
+
 WORKDIR /root/keras/examples

--- a/examples/keras/README.md
+++ b/examples/keras/README.md
@@ -55,7 +55,7 @@ Here're some configuration file examples:
 ### [mnist_cntk_backend](https://github.com/keras-team/keras/blob/master/examples/mnist_cnn.py)
 ```json
 {
-    "jobName": "keras_tensorflow_backend_mnist",
+    "jobName": "keras_cntk_backend_mnist",
     "image": "openpai/pai.example.keras.cntk",
     "taskRoles": [
         {
@@ -76,3 +76,4 @@ For more details on how to write a job configuration file, please refer to [job 
 
 Since PAI runs Keras jobs in Docker, the trainning speed on PAI should be similar to speed on host.
 
+We provide two stable docker images by adding the data to the images. If you want to use them, add `stable` tag to the image name: `openpai/pai.example.keras.cntk:stable` or `openpai/pai.example.keras.tensorflow:stable`.

--- a/examples/keras/keras.cntk_backend.mnist.json
+++ b/examples/keras/keras.cntk_backend.mnist.json
@@ -1,6 +1,6 @@
 {
     "jobName": "keras_cntk_backend_mnist",
-    "image": "openpai/pai.example.keras.cntk",
+    "image": "openpai/pai.example.keras.cntk:stable",
     "taskRoles": [
         {
             "name": "mnist",

--- a/examples/keras/keras.tensorflow_backend.mnist.json
+++ b/examples/keras/keras.tensorflow_backend.mnist.json
@@ -1,6 +1,6 @@
 {
     "jobName": "keras_tensorflow_backend_mnist",
-    "image": "openpai/pai.example.keras.tensorflow:v1.10",
+    "image": "openpai/pai.example.keras.tensorflow:stable",
     "taskRoles": [
         {
             "name": "mnist",

--- a/examples/mxnet/Dockerfile.example.mxnet
+++ b/examples/mxnet/Dockerfile.example.mxnet
@@ -8,3 +8,6 @@ RUN pip install mxnet-cu80
 
 # clone MXNet examples
 RUN git clone https://github.com/apache/incubator-mxnet.git
+
+#if you want to build the docker image with data, please prepare the data first and remove the '#' in next line
+#ADD ./mnist-original.mat /root/incubator-mxnet/data/mldata/

--- a/examples/mxnet/README.md
+++ b/examples/mxnet/README.md
@@ -80,3 +80,5 @@ For more details on how to write a job configuration file, please refer to [job 
 ### Note:
 
 Since PAI runs MXNet jobs in Docker, the trainning speed on PAI should be similar to speed on host.
+
+We provide a stable docker image by adding the data to the image. If you want to use it, add `stable` tag to the image name: `openpai/pai.example.mxnet:stable`.

--- a/examples/mxnet/mxnet.autoencoder.json
+++ b/examples/mxnet/mxnet.autoencoder.json
@@ -1,6 +1,6 @@
 {
   "jobName": "mxnet-autoencoder",
-  "image": "openpai/pai.example.mxnet",
+  "image": "openpai/pai.example.mxnet:stable",
   "taskRoles": [
     {
       "name": "main",

--- a/examples/scikit-learn/Dockerfile.example.sklearn
+++ b/examples/scikit-learn/Dockerfile.example.sklearn
@@ -8,3 +8,8 @@ RUN pip install numpy pandas scipy scikit-learn
 
 # clone scikit-learn examples
 RUN git clone https://github.com/scikit-learn/scikit-learn.git
+
+#if you want to build the docker image with data, please prepare the data first and remove the '#' in next line
+#ADD ./scikit_learn_data /root/scikit_learn_data
+
+WORKDIR /root

--- a/examples/scikit-learn/README.md
+++ b/examples/scikit-learn/README.md
@@ -80,3 +80,5 @@ For more details on how to write a job configuration file, please refer to [job 
 ### Note:
 
 Since PAI runs PyTorch jobs in Docker, the trainning speed on PAI should be similar to speed on host.
+
+We provide a stable docker image by adding the data to the image. If you want to use it, add `stable` tag to the image name: `openpai/pai.example.sklearn:stable`.

--- a/examples/scikit-learn/sklearn.mnist.json
+++ b/examples/scikit-learn/sklearn.mnist.json
@@ -1,6 +1,6 @@
 {
   "jobName": "sklearn-mnist",
-  "image": "openpai/pai.example.sklearn",
+  "image": "openpai/pai.example.sklearn:stable",
   "taskRoles": [
     {
       "name": "main",

--- a/examples/tensorflow/Dockerfile.example.tensorflow
+++ b/examples/tensorflow/Dockerfile.example.tensorflow
@@ -34,4 +34,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get -y install git
 
 ENV LC_ALL C
 
+#if you want to build the docker image with data, please prepare the data first and remove the '#' in next line
+#ADD ./data /tmp/data
+
 WORKDIR /root

--- a/examples/tensorflow/README.md
+++ b/examples/tensorflow/README.md
@@ -30,6 +30,7 @@ The following contents show some basic TensorFlow examples, other customized Ten
 2. [TensorFlow ImageNet image classification](#tensorflow-imagenet-image-classification)
 3. [Distributed TensorFlow CIFAR-10 image classification](#distributed-tensorflow-cifar-10-image-classification )
 4. [TensorFlow Tensorboard](#tensorflow-tensorboard)
+5. [Note](#Note)
 
 # TensorFlow examples
 
@@ -167,3 +168,6 @@ Here're some configuration file examples:
 
 For more details on how to write a job configuration file, please refer to [job tutorial](../../docs/job_tutorial.md#json-config-file-for-job-submission).
 
+### Note
+
+We provide a stable docker image by adding the cifar-10 data to the image. If you want to use it, add `stable` tag to the image name: `openpai/pai.example.tensorflow:stable`.

--- a/examples/tensorflow/prepare.sh
+++ b/examples/tensorflow/prepare.sh
@@ -116,3 +116,27 @@ fi
 rm -rf cifar-10-batches-py*/ benchmarks*/
 echo "Removed local cifar-10 code and data succeeded!"
 echo "Prepare tensorflow cifar-10 example done!"
+
+#Tensorboard prepare
+
+function tensorboard_prepare_code(){
+    #download the code
+    wget https://github.com/Microsoft/pai/raw/master/examples/tensorflow/tensorflow-tensorboard.sh
+
+    #upload the code to HDFS
+    echo "Uploading tensorboard code, waiting..."
+    hdfs dfs -put tensorflow-tensorboard.sh hdfs://$1/examples/tensorflow/tensorboard/code/
+}
+
+
+echo "Prepare tensorboard example!"
+echo "Make tensorboard directory, waiting..."
+hdfs dfs -test -e hdfs://$1/examples/tensorflow/tensorboard/code/tensorflow-tensorboard.sh
+if [ $? -eq 0 ] ;then
+    echo "Code exists on HDFS!"
+else
+    hdfs dfs -mkdir -p hdfs://$1/examples/tensorflow/tensorboard/code/
+    tensorboard_prepare_code $1
+    echo "Have prepared code!"
+fi
+

--- a/examples/tensorflow/tensorflow.cifar10.json
+++ b/examples/tensorflow/tensorflow.cifar10.json
@@ -1,6 +1,6 @@
 {
   "jobName": "tensorflow-cifar10",
-  "image": "openpai/pai.example.tensorflow",
+  "image": "openpai/pai.example.tensorflow:stable",
 
   "dataDir": "/tmp/data",
   "outputDir": "/tmp/output",


### PR DESCRIPTION
1. fix all unstable examples: sklearn-mnist, keras_cntk_backend_mnist, keras_tensorflow_backend_mnist, mxnet-autoencoder or tensorflow-cifar10

2. make the example auto-test project support the rest-server with namespace

3. add tensorboard preparation in prepare.sh.