### PR TITLE
expose zombie count and add alert

### DIFF
--- a/src/job-exporter/test/test_job_exporter.py
+++ b/src/job-exporter/test/test_job_exporter.py
@@ -22,6 +22,7 @@ import unittest
 import yaml
 import logging
 import logging.config
+import datetime
 
 sys.path.append(os.path.abspath("../src/"))
 
@@ -62,6 +63,42 @@ class TestJobExporter(unittest.TestCase):
         copied.pop("container_label_GPU_ID")
         self.assertEqual(copied, otherLabels)
 
+    def test_generate_zombie_count_type1(self):
+        zombies = {}
+
+        start = datetime.datetime.now()
+
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"}, start))
+        self.assertEqual(2, len(zombies))
+
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"}, start + datetime.timedelta(seconds=59)))
+        self.assertEqual(2, len(zombies))
+
+        self.assertEqual(2,
+                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"}, start + datetime.timedelta(seconds=61)))
+        self.assertEqual(2, len(zombies))
+
+        self.assertEqual(1,
+                job_exporter.generate_zombie_count_type1(zombies, {"a"}, start + datetime.timedelta(seconds=62)))
+        self.assertEqual(1, len(zombies))
+
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type1(zombies, {}, start + datetime.timedelta(seconds=63)))
+        self.assertEqual(0, len(zombies))
+
+
+    def test_generate_zombie_count_type2(self):
+        stats = {"43ffe701d883":
+                    {"name": "core-caffe2_resnet50_20181012040921.586-container_e03_1539312078880_0780_01_000002"},
+                "8de2f53e64cb":
+                    {"name": "container_e03_1539312078880_0780_01_000002"}}
+
+        self.assertEqual(0, job_exporter.generate_zombie_count_type2(stats))
+
+        stats.pop("8de2f53e64cb")
+        self.assertEqual(1, job_exporter.generate_zombie_count_type2(stats))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/job-exporter/test/test_job_exporter.py
+++ b/src/job-exporter/test/test_job_exporter.py
@@ -64,41 +64,70 @@ class TestJobExporter(unittest.TestCase):
         self.assertEqual(copied, otherLabels)
 
     def test_generate_zombie_count_type1(self):
-        zombies = {}
+        zombies = job_exporter.ZombieRecorder()
 
         start = datetime.datetime.now()
+
+        one_sec = datetime.timedelta(seconds=1)
 
         self.assertEqual(0,
                 job_exporter.generate_zombie_count_type1(zombies, {"a", "b"}, start))
         self.assertEqual(2, len(zombies))
 
         self.assertEqual(0,
-                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"}, start + datetime.timedelta(seconds=59)))
+                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"},
+                    start + zombies.decay_time - one_sec))
         self.assertEqual(2, len(zombies))
 
         self.assertEqual(2,
-                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"}, start + datetime.timedelta(seconds=61)))
+                job_exporter.generate_zombie_count_type1(zombies, {"a", "b"},
+                    start + zombies.decay_time + one_sec))
         self.assertEqual(2, len(zombies))
 
         self.assertEqual(1,
-                job_exporter.generate_zombie_count_type1(zombies, {"a"}, start + datetime.timedelta(seconds=62)))
+                job_exporter.generate_zombie_count_type1(zombies, {"a"},
+                    start + zombies.decay_time + 2 *one_sec))
         self.assertEqual(1, len(zombies))
 
         self.assertEqual(0,
-                job_exporter.generate_zombie_count_type1(zombies, {}, start + datetime.timedelta(seconds=63)))
+                job_exporter.generate_zombie_count_type1(zombies, {},
+                    start + zombies.decay_time + 3 * one_sec))
         self.assertEqual(0, len(zombies))
 
 
     def test_generate_zombie_count_type2(self):
+        zombies = job_exporter.ZombieRecorder()
+
+        start = datetime.datetime.now()
+
+        one_sec = datetime.timedelta(seconds=1)
+
         stats = {"43ffe701d883":
                     {"name": "core-caffe2_resnet50_20181012040921.586-container_e03_1539312078880_0780_01_000002"},
                 "8de2f53e64cb":
                     {"name": "container_e03_1539312078880_0780_01_000002"}}
 
-        self.assertEqual(0, job_exporter.generate_zombie_count_type2(stats))
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type2(zombies, stats, start))
 
         stats.pop("8de2f53e64cb")
-        self.assertEqual(1, job_exporter.generate_zombie_count_type2(stats))
+
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type2(zombies, stats, start + one_sec))
+
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type2(zombies, stats,
+                    start + zombies.decay_time))
+
+        self.assertEqual(1,
+                job_exporter.generate_zombie_count_type2(zombies, stats,
+                    start + zombies.decay_time + 2 * one_sec))
+
+        stats.pop("43ffe701d883")
+
+        self.assertEqual(0,
+                job_exporter.generate_zombie_count_type2(zombies, stats,
+                    start + zombies.decay_time + 3 * one_sec))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/prometheus/deploy/alerting/jobs.rules
+++ b/src/prometheus/deploy/alerting/jobs.rules
@@ -15,23 +15,13 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM python:2.7
+# Rule Syntax Reference: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
 
-ENV NVIDIA_VERSION=current
-ENV NV_DRIVER=/var/drivers/nvidia/$NVIDIA_VERSION
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NV_DRIVER/lib:$NV_DRIVER/lib64
-ENV PATH=$PATH:$NV_DRIVER/bin
-
-RUN curl -SL https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz \
-    | tar -xzvC /usr/local \
-    && mv /usr/local/docker/* /usr/bin
-RUN apt-get update && apt-get install -y build-essential git iftop lsof
-
-RUN git clone https://github.com/yadutaf/infilter --depth 1
-RUN cd infilter && make
-RUN cp infilter/infilter /usr/bin
-
-RUN mkdir -p /job_exporter
-COPY src/* /job_exporter/
-
-CMD python /job_exporter/job_exporter.py /datastorage/prometheus 30
+groups:
+    - name: pai-jobs
+      rules:
+      - alert: PaiJobsZombie
+        expr: zombie_container_count > 0
+        for: 1h # only when it exceed 1 hour
+        annotations:
+          summary: "zombie container in {{$labels.instance}} detected"

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -182,7 +182,7 @@ function run_user_command()
 {
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
   {{{ taskData.command }}} || exit $?
-  printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END"
+  printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END" # job_exporter relay on this exact output, if you are going to change this, remember to change job_exporter also
   exit 0
 }
 


### PR DESCRIPTION
Monitor two types of zombie container:
1. container with log displaying `USER COMMAND END` but still exist for a long period.
2. those containers whose yarn container not exist but job container still exist.

We only send out alert email when the count above 0 for 1 hour, because we just want to find out the root cause of zombie container.