### PR TITLE
Clean dependencies

### DIFF
--- a/src/cleaner/deploy/service.yaml
+++ b/src/cleaner/deploy/service.yaml
@@ -15,7 +15,7 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-# to avoid possible race condition, start cleaner after all service is ready
+# to avoid possible race condition, start cleaner after all services are ready
 prerequisite:
   - cluster-configuration
   - alert-manager

--- a/src/cleaner/deploy/service.yaml
+++ b/src/cleaner/deploy/service.yaml
@@ -15,8 +15,28 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# to avoid possible race condition, start cleaner after all service is ready
 prerequisite:
   - cluster-configuration
+  - alert-manager
+  - drivers
+  - end-to-end-test
+  - grafana
+  - hadoop-batch-job
+  - hadoop-data-node
+  - hadoop-jobhistory
+  - hadoop-name-node
+  - hadoop-node-manager
+  - hadoop-resource-manager
+  - node-exporter
+  - prometheus
+  - pylon
+  - rest-server
+  - watchdog
+  - webportal
+  - yarn-exporter
+  - yarn-fremeworklauncher
+  - zookeeper
 
 template-list:
   - cleaner.yaml

--- a/src/cleaner/scripts/clean_docker_cache.py
+++ b/src/cleaner/scripts/clean_docker_cache.py
@@ -37,7 +37,8 @@ def get_cache_size():
 
 def check_and_clean(threshold):
     if get_cache_size() > threshold:
-        common.run_cmd("docker system prune -af", logger)
+        # to avoid possible race condition, only clean the containers, images and networks created 1h ago
+        common.run_cmd("docker system prune -af --filter until=1h", logger)
 
 
 if __name__ == "__main__":

--- a/src/cleaner/worker.py
+++ b/src/cleaner/worker.py
@@ -60,7 +60,8 @@ class Worker(LoggerMixin, multiprocessing.Process):
 
         if self.long_run:
             while True:
-                self._exec()
+                # allow a delay before the cleaning
                 time.sleep(self.cool_down_time)
+                self._exec()
         else:
             self._exec()


### PR DESCRIPTION
during deployment, in rare case if cleaner is started and begin to clean docker cache. Some newly pulled image ready to deploy will be deleted, this can cause problems. So make cleaner the last service to start and add delay before its first cleaning. 