### PR TITLE
[hotfix]increase prometheus memory limits (data keep 1 week)

### DIFF
--- a/src/prometheus/deploy/prometheus-deployment.yaml.template
+++ b/src/prometheus/deploy/prometheus-deployment.yaml.template
@@ -39,6 +39,8 @@ spec:
         image: prom/prometheus:v2.1.0
         resources:
           limits:
+            memory: "10Gi"
+          requests:
             memory: "256Mi"
         args:
           - '--config.file=/etc/prometheus/prometheus.yml'


### PR DESCRIPTION
Increase prometheus memory limits to 10, keep data for one week.