### PR TITLE
Web portal: Fix export job

### DIFF
--- a/src/webportal/src/app/job/job-view/job-view.component.js
+++ b/src/webportal/src/app/job/job-view/job-view.component.js
@@ -442,7 +442,7 @@ const showConfigInfo = (jobName) => {
   }));
   $('#configInfoModal').modal('show');
   $(document).on('click', '#fileExport', () => {
-    exportFile(JSON.stringify(configInfo, null, 2), jobName, 'application/json');
+    exportFile(configInfo, jobName, 'application/json');
   });
 };
 


### PR DESCRIPTION
Closes #1586

As `configInfo` is already a string, there is no need to stringify it again.