### PR TITLE
[AKS] add cascade deletion scripts for replicaset pods

### DIFF
--- a/src/end-to-end-test/deploy/stop.sh.template
+++ b/src/end-to-end-test/deploy/stop.sh.template
@@ -23,4 +23,12 @@ if kubectl get deployments | grep -q "end-to-end-test-deployment"; then
     kubectl delete deployment end-to-end-test-deployment || exit $?
 fi
 
+if kubectl get rs | grep -q "end-to-end-test-deployment"; then
+    kubectl delete rs -l app=end-to-end-test || exit $?
+fi
+
+if kubectl get pods | grep -q "end-to-end-test-deployment"; then
+    kubectl delete pods -l app=end-to-end-test || exit $?
+fi
+
 popd > /dev/null

--- a/src/grafana/deploy/stop.sh
+++ b/src/grafana/deploy/stop.sh
@@ -23,10 +23,16 @@ if kubectl get deployments | grep -q "grafana"; then
     kubectl delete deployment grafana || exit $?
 fi
 
+if kubectl get rs | grep -q "grafana"; then
+    kubectl delete rs -l app=grafana || exit $?
+fi
+
+if kubectl get pods | grep -q "grafana"; then
+    kubectl delete pods -l app=grafana || exit $?
+fi
 
 if kubectl get configmap | grep -q "grafana-configuration"; then
     kubectl delete configmap grafana-configuration || exit $?
 fi
-
 
 popd > /dev/null

--- a/src/prometheus/deploy/stop.sh
+++ b/src/prometheus/deploy/stop.sh
@@ -19,6 +19,8 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+pushd $(dirname "$0") > /dev/null
+
 INSTANCES="
 deployment/prometheus-deployment
 configmap/prometheus-configmap
@@ -26,6 +28,15 @@ configmap/prometheus-alert
 "
 
 for instance in ${INSTANCES}; do
-  kubectl delete --ignore-not-found --now ${instance}
+  kubectl delete --ignore-not-found --now ${instance} || exit $?
 done
 
+if kubectl get rs | grep -q "prometheus-deployment"; then
+    kubectl delete rs -l app=prometheus || exit $?
+fi
+
+if kubectl get pods | grep -q "prometheus-deployment"; then
+    kubectl delete pods -l app=prometheus || exit $?
+fi
+
+popd > /dev/null

--- a/src/watchdog/deploy/stop.sh
+++ b/src/watchdog/deploy/stop.sh
@@ -19,6 +19,18 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl delete --ignore-not-found --now daemonset/watchdog
-kubectl delete --ignore-not-found --now deployment/watchdog
-kubectl delete --ignore-not-found --now configmap/watchdog
+pushd $(dirname "$0") > /dev/null
+
+kubectl delete --ignore-not-found --now daemonset/watchdog || exit $?
+kubectl delete --ignore-not-found --now deployment/watchdog || exit $?
+kubectl delete --ignore-not-found --now configmap/watchdog || exit $?
+
+if kubectl get rs | grep -q "watchdog"; then
+    kubectl delete rs -l app=watchdog || exit $?
+fi
+
+if kubectl get pods | grep -q "watchdog"; then
+    kubectl delete pods -l app=watchdog || exit $?
+fi
+
+popd > /dev/null


### PR DESCRIPTION
At Azure kubernetes service env (version 1.9), when delete deployment use previous stop scripts. The replicaset and pods not cascade delete, need add cascade deletion script to clean them up.

This is also general for other existing k8s env and not affect current pai env