### PR TITLE
Pylon: Disable the checking of request body size.

### DIFF
--- a/src/pylon/src/nginx.conf.template
+++ b/src/pylon/src/nginx.conf.template
@@ -42,7 +42,7 @@ http {
   server {
     listen      80;
     server_name localhost;
-    client_max_body_size 256M;
+    client_max_body_size 0; # Disable checking of client request body size.
     client_body_buffer_size 256M;
     proxy_connect_timeout 60m;
     proxy_send_timeout 60m;


### PR DESCRIPTION
Fixes #1597

Ref: <http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size>