### PR TITLE
[hotfix] remove memory limits for k8s services and increase it for rm, zookeeper

### DIFF
--- a/deployment/k8sPaiLibrary/template/apiserver.yaml.template
+++ b/deployment/k8sPaiLibrary/template/apiserver.yaml.template
@@ -48,6 +48,6 @@ spec:
     - --cors-allowed-origins
     - .*
     resources:
-      limits:
+      requests:
         memory: "1Gi"
         cpu: "1000m"

--- a/deployment/k8sPaiLibrary/template/controller-manager.yaml.template
+++ b/deployment/k8sPaiLibrary/template/controller-manager.yaml.template
@@ -39,6 +39,6 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 1
     resources:
-      limits:
+      requests:
         memory: "1Gi"
         cpu: "1000m"

--- a/deployment/k8sPaiLibrary/template/dashboard-deployment.yaml.template
+++ b/deployment/k8sPaiLibrary/template/dashboard-deployment.yaml.template
@@ -45,11 +45,8 @@ spec:
           - --apiserver-host=http://{{ clusterconfig['api-servers-ip'] }}:8080
         resources:
           # the ideal cpu setting will be 3.5, according to our experiment. If the server hosting k8s dashboard has enough resource, user can change this setting to a larger value.
-          limits:
-            cpu: "1000m"
-            memory: 3000Mi
           requests:
-            cpu: "0.5"
+            cpu: "1000m"
             memory: 1000Mi
         ports:
         - containerPort: 9090

--- a/deployment/k8sPaiLibrary/template/etcd.yaml.template
+++ b/deployment/k8sPaiLibrary/template/etcd.yaml.template
@@ -54,6 +54,8 @@ spec:
       name: varetcd
     resources:
       limits:
+        memory: "8Gi"
+      requests:
         memory: "1Gi"
         cpu: "1000m"
   volumes:

--- a/deployment/k8sPaiLibrary/template/etcd.yaml.template
+++ b/deployment/k8sPaiLibrary/template/etcd.yaml.template
@@ -53,8 +53,6 @@ spec:
     - mountPath: /var/etcd
       name: varetcd
     resources:
-      limits:
-        memory: "8Gi"
       requests:
         memory: "1Gi"
         cpu: "1000m"

--- a/deployment/k8sPaiLibrary/template/kubelet.sh.template
+++ b/deployment/k8sPaiLibrary/template/kubelet.sh.template
@@ -66,5 +66,5 @@ docker run \
   --image-pull-progress-deadline=10m \
   --docker-root=${DOCKER_ROOT_DIR_FOR_KUBELET} \
   --system-reserved=memory=3Gi \
-  --eviction-hard="memory.available<1Gi,nodefs.available<5%,imagefs.available<5%,nodefs.inodesFree<5%,imagefs.inodesFree<5%" \
+  --eviction-hard="memory.available<5%,nodefs.available<5%,imagefs.available<5%,nodefs.inodesFree<5%,imagefs.inodesFree<5%" \
   --v=2

--- a/deployment/k8sPaiLibrary/template/scheduler.yaml.template
+++ b/deployment/k8sPaiLibrary/template/scheduler.yaml.template
@@ -37,6 +37,6 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 1
     resources:
-      limits:
+      requests:
         memory: "1Gi"
         cpu: "1000m"

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -72,6 +72,8 @@ spec:
         resources:
           limits:
             memory: "36Gi"
+          request:
+            memory: "8Gi"
       - name: yarn-exporter
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}yarn-exporter:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}
         imagePullPolicy: Always

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -64,14 +64,14 @@ spec:
         - name: TIMELINE_SERVER_ADDRESS
           value: {{ clusterinfo[ 'hadoopinfo' ][ 'hadoop_vip' ] }}
         - name: YARN_RESOURCEMANAGER_HEAPSIZE
-          value: "6144"
+          value: "32768"
         - name: GENERATE_CONFIG
           value: resourcemanager-generate-script.sh
         - name: START_SERVICE
           value: resourcemanager-start-service.sh
         resources:
           limits:
-            memory: "8Gi"
+            memory: "36Gi"
       - name: yarn-exporter
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}yarn-exporter:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}
         imagePullPolicy: Always

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager.yaml.template
@@ -72,7 +72,7 @@ spec:
         resources:
           limits:
             memory: "36Gi"
-          request:
+          requests:
             memory: "8Gi"
       - name: yarn-exporter
         image: {{ clusterinfo['dockerregistryinfo']['prefix'] }}yarn-exporter:{{ clusterinfo['dockerregistryinfo']['docker_tag'] }}

--- a/src/zookeeper/deploy/zookeeper.yaml.template
+++ b/src/zookeeper/deploy/zookeeper.yaml.template
@@ -48,10 +48,10 @@ spec:
           periodSeconds: 3
         env:
         - name: JAVA_OPTS
-          value: "-server -Xmx1536m"
+          value: "-server -Xmx8192m"
         resources:
           limits:
-            memory: "2Gi"
+            memory: "10Gi"
             cpu: "1000m"
           requests:
             memory: "1Gi"


### PR DESCRIPTION
Remove memory limits for k8s services.

Increase memory limits of rm to 36G, max heap size 32G.
Increase memory limits of zookeeper to 10G, max heap size 8G.