### PR TITLE
[Pylon]Append conf etag to upstream etag.

### DIFF
--- a/src/pylon/src/nginx.conf.template
+++ b/src/pylon/src/nginx.conf.template
@@ -39,6 +39,19 @@ http {
     ~*/static "gzip";
   }
 
+  # Add proxy etag to upstream etag
+  map $http_if_none_match $request_if_none_match {
+    volatile;
+
+    ~^(W/)?"(.+)\|{{PYLON_CONF_ETAG}}"$ $1"$2";
+  }
+
+  map $upstream_http_etag $response_etag {
+    volatile;
+
+    ~^(W/)?"(.+)"$ $1"$2|{{PYLON_CONF_ETAG}}";
+  }
+
   server {
     listen      80;
     server_name localhost;
@@ -94,6 +107,9 @@ http {
         \"appTrackingUrl\":\"http://([^/]*):5070/([^\"]*)\"
         \"appTrackingUrl\":\"$scheme://$http_host/a/$1:5070/$2\"
         r;
+
+      proxy_set_header    If-None-Match    $request_if_none_match;
+      add_header          Etag             $response_etag;
     }
 
     # Kubernetes API server.
@@ -318,6 +334,9 @@ http {
       sub_filter
         '{{GRAFANA_URI}}'
         '/grafana';
+
+      proxy_set_header    If-None-Match    $request_if_none_match;
+      add_header          Etag             $response_etag;
     }
   }
 

--- a/src/pylon/src/render.py
+++ b/src/pylon/src/render.py
@@ -16,6 +16,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os
+from hashlib import md5
 from jinja2 import Template
 
 env = {}
@@ -23,5 +24,8 @@ for key in os.environ:
     env[key] = os.environ[key]
 
 templateString = open('nginx.conf.template', 'r').read()
+
+env.setdefault('PYLON_CONF_ETAG', md5(templateString).hexdigest())
+
 renderedString = Template(templateString).render(env)
 open('nginx.conf', 'w').write(renderedString)


### PR DESCRIPTION
Fixes #468 
Closes #1567

To prevent issue of conf changes but upstream etag matches. Currently, only rest-server & web portal service expose etags. So only apply to routes of these services.

Moreover, proxy etag is set to md5 hash of conf file, and will be set to PAI version when @DongZhaoYu 's version proposal landed.
