### PR TITLE
Update yarnContainerScript.mustache

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -285,6 +285,7 @@ docker run --name $docker_name \
   --label PAI_USER_NAME={{{ jobData.userName }}} \
   --label PAI_CURRENT_TASK_ROLE_NAME={{{ taskData.name }}} \
   --env-file $ENV_LIST \
+  --entrypoint="" \
    {{{ jobData.image }}} \
   /bin/bash '/pai/bootstrap/docker_bootstrap.sh'
 


### PR DESCRIPTION
add entrypoint=""

in #1435 the `entrypoint` was removed.
but in my experiment, the `--init` will not override the `--entrypoint=""` defaultly
so, if the docker image has set ENTRYPOINT (sth. like ls)，the docker run will fail。