### PR TITLE
Web portal: Fix export job (#1592)

### DIFF
--- a/src/webportal/src/app/job/job-view/job-view.component.js
+++ b/src/webportal/src/app/job/job-view/job-view.component.js
@@ -485,7 +485,7 @@ const showConfigInfo = (jobName) => {
   }));
   $('#configInfoModal').modal('show');
   $(document).on('click', '#fileExport', () => {
-    exportFile(JSON.stringify(configInfo, null, 2), jobName, 'application/json');
+    exportFile(configInfo, jobName, 'application/json');
   });
 };
 


### PR DESCRIPTION
Cherry-picked from #1592 

Closes #1586

As `configInfo` is already a string, there is no need to stringify it again.