### PR TITLE
calculate configured gpu in job-exporter

### DIFF
--- a/src/cluster-configuration/deploy/gpu-configuration/gpu-configuration.json.template
+++ b/src/cluster-configuration/deploy/gpu-configuration/gpu-configuration.json.template
@@ -2,7 +2,8 @@
   "nodes" : {
 {% for host in machinelist if 'gpu' in machineinfo[ machinelist[ host ][ 'machinetype' ] ] %}
     "{{machinelist[ host ]['nodename']}}" : {
-        "gpuType" : "{{ machineinfo[ machinelist[ host ][ 'machinetype' ] ]['gpu']['type'] }}"
+        "gpuType" : "{{ machineinfo[ machinelist[ host ][ 'machinetype' ] ]['gpu']['type'] }}",
+        "gpuCount" : {{ machineinfo[ machinelist[ host ][ 'machinetype' ] ]['gpu']['count'] }}
     }{% if not loop.last %},{% endif %}
 {% endfor %}
   }

--- a/src/job-exporter/build/job-exporter.dockerfile
+++ b/src/job-exporter/build/job-exporter.dockerfile
@@ -17,21 +17,20 @@
 
 FROM python:2.7
 
-ENV NVIDIA_VERSION=current
-ENV NV_DRIVER=/var/drivers/nvidia/$NVIDIA_VERSION
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NV_DRIVER/lib:$NV_DRIVER/lib64
-ENV PATH=$PATH:$NV_DRIVER/bin
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential git && \
+    git clone https://github.com/yadutaf/infilter --depth 1 && \
+    cd infilter && make
+
+FROM python:2.7
 
 RUN curl -SL https://download.docker.com/linux/static/stable/x86_64/docker-17.06.2-ce.tgz \
-    | tar -xzvC /usr/local \
-    && mv /usr/local/docker/* /usr/bin
-RUN apt-get update && apt-get install -y build-essential git iftop lsof
+    | tar -xzvC /usr/local && \
+    mv /usr/local/docker/* /usr/bin && \
+    apt-get update && apt-get install --no-install-recommends -y iftop lsof && \
+    mkdir -p /job_exporter && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/yadutaf/infilter --depth 1
-RUN cd infilter && make
-RUN cp infilter/infilter /usr/bin
-
-RUN mkdir -p /job_exporter
+COPY --from=0 infilter/infilter /usr/bin
 COPY src/* /job_exporter/
 
 CMD python /job_exporter/job_exporter.py /datastorage/prometheus 30

--- a/src/job-exporter/src/gpu_exporter.py
+++ b/src/job-exporter/src/gpu_exporter.py
@@ -29,30 +29,28 @@ logger = logging.getLogger(__name__)
 
 def parse_smi_xml_result(smi):
     xmldoc = minidom.parseString(smi)
-    gpuList = xmldoc.getElementsByTagName('gpu')
-
-    logger.info("gpu numbers %d", len(gpuList))
+    gpus = xmldoc.getElementsByTagName('gpu')
 
     result = {}
 
-    for gpu in gpuList:
-        minorNumber = gpu.getElementsByTagName('minor_number')[0].childNodes[0].data
+    for gpu in gpus:
+        minor = gpu.getElementsByTagName('minor_number')[0].childNodes[0].data
         utilization = gpu.getElementsByTagName("utilization")[0]
 
-        gpuUtil = utilization.getElementsByTagName('gpu_util')[0].childNodes[0].data.replace("%", "").strip()
-        gpuMemUtil = utilization.getElementsByTagName('memory_util')[0].childNodes[0].data.replace("%", "").strip()
+        gpu_util = utilization.getElementsByTagName('gpu_util')[0].childNodes[0].data.replace("%", "").strip()
+        gpu_mem_util = utilization.getElementsByTagName('memory_util')[0].childNodes[0].data.replace("%", "").strip()
 
-        if gpuUtil == "N/A" or gpuMemUtil == "N/A":
+        if gpu_util == "N/A" or gpu_mem_util == "N/A":
             continue
 
-        result[str(minorNumber)] = {"gpuUtil": gpuUtil, "gpuMemUtil": gpuMemUtil}
+        result[str(minor)] = {"gpu_util": gpu_util, "gpu_mem_util": gpu_mem_util}
 
     return result
 
 def collect_gpu_info():
     """ in some cases, nvidia-smi may block indefinitely, caller should be aware of this """
     try:
-        logger.info("call nvidia-smi to get gpu metrics")
+        logger.info("call nvidia-smi to get gpu metrics") # used to check if nvidia-smi hangs
 
         smi_output = utils.check_output(["nvidia-smi", "-q", "-x"])
 
@@ -68,20 +66,19 @@ def collect_gpu_info():
         if e.errno == os.errno.ENOENT:
             logger.warning("nvidia-smi not found")
 
+    return None
+
+
+def convert_gpu_info_to_metrics(gpu_infos):
+    if gpu_infos is None:
         return None
 
+    result = [Metric("nvidiasmi_attached_gpus", {}, len(gpu_infos))]
 
-
-def convert_gpu_info_to_metrics(gpuInfos):
-    if gpuInfos is None:
-        return None
-
-    result = [Metric("nvidiasmi_attached_gpus", {}, len(gpuInfos))]
-
-    for minorNumber, info in gpuInfos.items():
-        label = {"minor_number": minorNumber}
-        result.append(Metric("nvidiasmi_utilization_gpu", label, info["gpuUtil"]))
-        result.append(Metric("nvidiasmi_utilization_memory", label, info["gpuMemUtil"]))
+    for minor, info in gpu_infos.items():
+        label = {"minor_number": minor}
+        result.append(Metric("nvidiasmi_utilization_gpu", label, info["gpu_util"]))
+        result.append(Metric("nvidiasmi_utilization_memory", label, info["gpu_mem_util"]))
 
     return result
 

--- a/src/job-exporter/src/job_exporter.py
+++ b/src/job-exporter/src/job_exporter.py
@@ -23,6 +23,8 @@ import logging
 import re
 import datetime
 import subprocess
+import os
+import json
 
 import docker_stats
 import docker_inspect
@@ -100,19 +102,19 @@ job_container_reg = re.compile(u"^.+(" + yarn_pattern + u")$")
 
 
 def parse_from_labels(labels):
-    gpuIds = []
-    otherLabels = {}
+    gpu_ids = []
+    other_labels = {}
 
     for key, val in labels.items():
         if "container_label_GPU_ID" == key:
             s2 = val.replace("\"", "").split(",")
             for id in s2:
                 if id:
-                    gpuIds.append(id)
+                    gpu_ids.append(id)
         else:
-            otherLabels[key] = val
+            other_labels[key] = val
 
-    return gpuIds, otherLabels
+    return gpu_ids, other_labels
 
 
 def generate_zombie_count_type1(type1_zombies, exited_containers, now):
@@ -213,25 +215,25 @@ def collect_job_metrics(gpu_infos, all_conns, type1_zombies, type2_zombies):
                     pid, debug_info, lsof_result, net_in, net_out)
 
         if pai_service_name is None:
-            gpuIds, otherLabels = parse_from_labels(inspect_info["labels"])
-            otherLabels.update(inspect_info["env"])
+            gpu_ids, container_labels = parse_from_labels(inspect_info["labels"])
+            container_labels.update(inspect_info["env"])
 
-            for id in gpuIds:
+            for id in gpu_ids:
                 if gpu_infos:
-                    labels = copy.deepcopy(otherLabels)
+                    labels = copy.deepcopy(container_labels)
                     labels["minor_number"] = id
 
-                    result.append(Metric("container_GPUPerc", labels, gpu_infos[id]["gpuUtil"]))
-                    result.append(Metric("container_GPUMemPerc", labels, gpu_infos[id]["gpuMemUtil"]))
+                    result.append(Metric("container_GPUPerc", labels, gpu_infos[id]["gpu_util"]))
+                    result.append(Metric("container_GPUMemPerc", labels, gpu_infos[id]["gpu_mem_util"]))
 
-            result.append(Metric("container_CPUPerc", otherLabels, stats["CPUPerc"]))
-            result.append(Metric("container_MemUsage", otherLabels, stats["MemUsage_Limit"]["usage"]))
-            result.append(Metric("container_MemLimit", otherLabels, stats["MemUsage_Limit"]["limit"]))
-            result.append(Metric("container_NetIn", otherLabels, net_in))
-            result.append(Metric("container_NetOut", otherLabels, net_out))
-            result.append(Metric("container_BlockIn", otherLabels, stats["BlockIO"]["in"]))
-            result.append(Metric("container_BlockOut", otherLabels, stats["BlockIO"]["out"]))
-            result.append(Metric("container_MemPerc", otherLabels, stats["MemPerc"]))
+            result.append(Metric("container_CPUPerc", container_labels, stats["CPUPerc"]))
+            result.append(Metric("container_MemUsage", container_labels, stats["MemUsage_Limit"]["usage"]))
+            result.append(Metric("container_MemLimit", container_labels, stats["MemUsage_Limit"]["limit"]))
+            result.append(Metric("container_NetIn", container_labels, net_in))
+            result.append(Metric("container_NetOut", container_labels, net_out))
+            result.append(Metric("container_BlockIn", container_labels, stats["BlockIO"]["in"]))
+            result.append(Metric("container_BlockOut", container_labels, stats["BlockIO"]["out"]))
+            result.append(Metric("container_MemPerc", container_labels, stats["MemPerc"]))
         else:
             labels = {"name": pai_service_name}
             result.append(Metric("service_cpu_percent", labels, stats["CPUPerc"]))
@@ -269,8 +271,25 @@ def collect_docker_daemon_status():
             logger.warning("systemctl not found")
         error = e.strerror()
 
-    return Metric("docker_daemon_count", {"error": error}, 1)
+    return [Metric("docker_daemon_count", {"error": error}, 1)]
 
+
+def get_gpu_count(path):
+    hostname = os.environ.get("HOSTNAME")
+    ip = os.environ.get("HOST_IP")
+
+    logger.info("hostname is %s, ip is %s", hostname, ip)
+
+    with open(path) as f:
+        gpu_config = json.load(f)
+
+    if hostname is not None and gpu_config["nodes"].get(hostname) is not None:
+        return gpu_config["nodes"][hostname]["gpuCount"]
+    elif ip is not None and gpu_config["nodes"].get(ip) is not None:
+        return gpu_config["nodes"][ip]["gpuCount"]
+    else:
+        logger.warning("failed to find gpu count from config %s", gpu_config)
+        return 0
 
 def main(argv):
     log_dir = argv[0]
@@ -278,6 +297,7 @@ def main(argv):
     job_metrics_path = log_dir + "/job_exporter.prom"
     docker_metrics_path = log_dir + "/docker.prom"
     time_metrics_path = log_dir + "/time.prom"
+    configured_gpu_path = log_dir + "/cofigured_gpu.prom"
     time_sleep_s = int(argv[1])
 
     iter = 0
@@ -288,22 +308,33 @@ def main(argv):
     type1_zombies = ZombieRecorder()
     type2_zombies = ZombieRecorder()
 
+    configured_gpu_count = get_gpu_count("/gpu-config/gpu-configuration.json")
+    logger.info("configured_gpu_count is %s", configured_gpu_count)
+    utils.export_metrics_to_file(configured_gpu_path, [Metric("configured_gpu_count", {},
+        configured_gpu_count)])
+
     while True:
         start = datetime.datetime.now()
         try:
             logger.info("job exporter running {0} iteration".format(str(iter)))
             iter += 1
-            gpu_infos = gpu_singleton.try_get()
 
-            docker_status = docker_status_singleton.try_get()
-            if docker_status is not None:
-                utils.export_metrics_to_file(docker_metrics_path, [docker_status])
-
-            gpu_metrics = gpu_exporter.convert_gpu_info_to_metrics(gpu_infos)
-            utils.export_metrics_to_file(gpu_metrics_path, gpu_metrics)
+            docker_status, is_old = docker_status_singleton.try_get()
+            if not is_old:
+                utils.export_metrics_to_file(docker_metrics_path, docker_status)
+            else:
+                utils.export_metrics_to_file(docker_metrics_path, None)
 
             all_conns = network.iftop()
             logger.debug("iftop result is %s", all_conns)
+
+            gpu_infos, is_old = gpu_singleton.try_get()
+
+            if is_old:
+                gpu_infos = None # ignore old gpu_infos
+
+            gpu_metrics = gpu_exporter.convert_gpu_info_to_metrics(gpu_infos)
+            utils.export_metrics_to_file(gpu_metrics_path, gpu_metrics)
 
             # join with docker stats metrics and docker inspect labels
             job_metrics = collect_job_metrics(gpu_infos, all_conns, type1_zombies, type2_zombies)

--- a/src/job-exporter/src/utils.py
+++ b/src/job-exporter/src/utils.py
@@ -84,59 +84,53 @@ class Singleton(object):
         indefinitely, so we wrap call in thread.
         Also, to avoid having too much threads, use semaphore to ensure only 1
         thread is running """
-    def __init__(self, getter, get_timeout_s=3, old_data_timeout_s=60, name="singleton"):
+    def __init__(self, getter, get_timeout_s=3, name="singleton"):
         self.getter = getter
         self.get_timeout_s = get_timeout_s
-        self.old_data_timeout_s = datetime.timedelta(seconds=old_data_timeout_s)
         self.name = name
 
         self.semaphore = threading.Semaphore(1)
         self.queue = Queue(1)
         self.old_metrics = None
-        self.old_metrics_time = datetime.datetime.now()
+
+    def wrapper(self, semaphore, queue):
+        """ wrapper assume semaphore already acquired, will release semaphore on exit """
+        result = None
+
+        try:
+            try:
+                # remove result put by previous thread but didn't get by main thread
+                queue.get(block=False)
+            except Empty:
+                pass
+
+            start = datetime.datetime.now()
+            result = self.getter()
+        except Exception as e:
+            logger.warn("%s get metrics failed", self.name)
+            logger.exception(e)
+        finally:
+            logger.info("%s get metrics spent %s", self.name, datetime.datetime.now() - start)
+            semaphore.release()
+            queue.put(result)
 
     def try_get(self):
+        """ return value, is_old tuple, if value is not newly getted, return value we get last time,
+        and set is_old to True, otherwise return newly getted value and False """
         if self.semaphore.acquire(False):
-            def wrapper(semaphore, queue):
-                """ wrapper assume semaphore already acquired, will release semaphore on exit """
-                result = None
-
-                try:
-                    try:
-                        # remove result put by previous thread but didn't get by main thread
-                        queue.get(block=False)
-                    except Empty:
-                        pass
-
-                    start = datetime.datetime.now()
-                    result = self.getter()
-                except Exception as e:
-                    logger.warn("%s get metrics failed", self.name)
-                    logger.exception(e)
-                finally:
-                    logger.info("%s get metrics spent %s", self.name, datetime.datetime.now() - start)
-                    semaphore.release()
-                    queue.put(result)
-
-            t = threading.Thread(target=wrapper, name=self.name + "-getter",
-                    args=(self.semaphore, self.queue))
+            t = threading.Thread(target=Singleton.wrapper, name=self.name + "-getter",
+                    args=(self, self.semaphore, self.queue))
             t.start()
         else:
             logger.warn("%s is still running", self.name + "-getter")
 
         try:
             self.old_metrics = self.queue.get(block=True, timeout=self.get_timeout_s)
-            self.old_metrics_time = datetime.datetime.now()
-            return self.old_metrics
+            return self.old_metrics, False
         except Empty:
             pass
 
-        now = datetime.datetime.now()
-        if now - self.old_metrics_time < self.old_data_timeout_s:
-            return self.old_metrics
-
-        logger.info("%s's info is too old", self.name)
-        return None
+        return self.old_metrics, True
 
 
 def camel_to_underscore(label):

--- a/src/job-exporter/test/test_gpu_exporter.py
+++ b/src/job-exporter/test/test_gpu_exporter.py
@@ -57,13 +57,13 @@ class TestGPUExporter(unittest.TestCase):
         file = open(sample_path, "r")
         nvidia_smi_result = file.read()
         nvidia_smi_parse_result = gpu_exporter.parse_smi_xml_result(nvidia_smi_result)
-        target_smi_info = {'1': {'gpuUtil': u'98', 'gpuMemUtil': u'97'},
-                '0': {'gpuUtil': u'100', 'gpuMemUtil': u'99'}}
+        target_smi_info = {'1': {'gpu_util': u'98', 'gpu_mem_util': u'97'},
+                '0': {'gpu_util': u'100', 'gpu_mem_util': u'99'}}
         self.assertEqual(target_smi_info, nvidia_smi_parse_result)
 
     def test_convert_gpu_info_to_metrics(self):
-        info = {'1': {'gpuUtil': u'98', 'gpuMemUtil': u'97'},
-                '0': {'gpuUtil': u'100', 'gpuMemUtil': u'99'}}
+        info = {'1': {'gpu_util': u'98', 'gpu_mem_util': u'97'},
+                '0': {'gpu_util': u'100', 'gpu_mem_util': u'99'}}
         metrics = gpu_exporter.convert_gpu_info_to_metrics(info)
         self.assertEqual(5, len(metrics))
 

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -100,6 +100,11 @@ spec:
             memory: "128Mi"
         securityContext:
           privileged: true # this is required by job-exporter
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         volumeMounts:
         - mountPath: /root/.docker
           name: docker-cred-volume
@@ -113,6 +118,8 @@ spec:
           name: driver-path
         - mountPath: /datastorage/prometheus
           name: collector-mount
+        - mountPath: /gpu-config
+          name: gpu-config
         name: job-exporter
       volumes:
         - name: docker-bin
@@ -142,6 +149,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: gpu-config
+          configMap:
+            name: gpu-configuration
       imagePullSecrets:
       - name: {{ clusterinfo['dockerregistryinfo']['secretname'] }}
       hostNetwork: true


### PR DESCRIPTION
The first step to remove using nvidia-smi to generate gpu count: use configuration as ground truth and expose in job-exporter. Will remove expose of `nvidiasmi_attached_gpus` in another PR.