### PR TITLE
optimization: Replace the url module with the querystring module

### DIFF
--- a/src/webportal/src/app/cluster-view/hardware/hardware-detail.component.js
+++ b/src/webportal/src/app/cluster-view/hardware/hardware-detail.component.js
@@ -20,7 +20,7 @@
 const hardwareDetailComponent = require('./hardware-detail.component.ejs');
 const breadcrumbComponent = require('../../job/breadcrumb/breadcrumb.component.ejs');
 const webportalConfig = require('../../config/webportal.config.js');
-const url = require('url');
+const querystring = require('querystring');
 
 //
 
@@ -35,7 +35,7 @@ $(document).ready(() => {
   $('#sidebar-menu--cluster-view').addClass('active');
   $('#sidebar-menu--cluster-view--hardware').addClass('active');
   let instance = '';
-  const query = url.parse(window.location.href, true).query;
+  const query = querystring.parse(window.location.search.replace(/^\?+/, ''));
   if (query['instance']) {
     instance = query['instance'];
   } else {

--- a/src/webportal/src/app/job/job-submit/job-submit.component.js
+++ b/src/webportal/src/app/job/job-submit/job-submit.component.js
@@ -26,7 +26,7 @@ const loading = require('../loading/loading.component');
 const webportalConfig = require('../../config/webportal.config.js');
 const userAuth = require('../../user/user-auth/user-auth.component');
 const jobSchema = require('./job-submit.schema.js');
-const url = require('url');
+const querystring = require('querystring');
 const stripJsonComments = require('strip-json-comments');
 
 const jobSubmitHtml = jobSubmitComponent({
@@ -159,7 +159,7 @@ $(document).ready(() => {
     window.onresize = function() {
       resize();
     };
-    const query = url.parse(window.location.href, true).query;
+    const query = querystring.parse(window.location.search.replace(/^\?+/, ''));
     const op = query.op;
     const type = query.type;
     const username = query.user;

--- a/src/webportal/src/app/marketplace/job-submit/job-submit.component.js
+++ b/src/webportal/src/app/marketplace/job-submit/job-submit.component.js
@@ -24,7 +24,7 @@ const common = require('../template-common/template-search.component.js');
 const userAuth = require('../../user/user-auth/user-auth.component');
 const submitComponent = require('./job-submit.component.ejs');
 const userTemplate = require('./sub-components/user-template.js');
-const url = require('url');
+const querystring = require('querystring');
 
 require('./job-submit.component.scss');
 require('./sub-components/task-format.scss');
@@ -122,7 +122,7 @@ $(document).ready(() => {
       }
     }, false);
 
-    const query = url.parse(window.location.href, true).query;
+    const query = querystring.parse(window.location.search.replace(/^\?+/, ''));
     const type = query.type;
     const name = query.name;
     const username = query.user;

--- a/src/webportal/src/app/user/user-login/user-login.component.js
+++ b/src/webportal/src/app/user/user-login/user-login.component.js
@@ -17,7 +17,7 @@
 
 
 // module dependencies
-const url = require('url');
+const querystring = require('querystring');
 const breadcrumbComponent = require('../../job/breadcrumb/breadcrumb.component.ejs');
 const userLoginComponent = require('./user-login.component.ejs');
 const webportalConfig = require('../../config/webportal.config.js');
@@ -54,7 +54,7 @@ $(document).ready(() => {
           cookies.set('token', data.token, {expires: expiration});
           cookies.set('admin', data.admin, {expires: expiration});
           cookies.set('hasGitHubPAT', data.hasGitHubPAT, {expires: expiration});
-          const query = url.parse(window.location.href, true).query;
+          const query = querystring.parse(window.location.search.replace(/^\?+/, ''));
           window.location.replace(query.origin ? query.origin : '/');
         }
       },


### PR DESCRIPTION
This optimization replaces all code in the webprotal that uses the url module with the querystring module and ensures consistent functionality. The result of this optimization is to reduce the total webprotal size from 478.4MB to 477.4MB.
The url module is built using the punycode and querystring modules, which are larger than the query string module. Webprotal uses the "url.parse().query" function of the url module to get the query type parameter of the address bar. However, this feature can be replaced by the "querystring.parse()" function in the smaller querystring module.
The reason is in lines 143 to 151 of url.js `this.query = querystring.parse(this.search.substr(1));`
 used the parse method in querystring.  Both “url.parse().query” and "querystring.parse()" return an object, but "querystring.parse()" does not directly separate the domain name from the query parameter. You need to change it to `querystring.parse(window.location.href.slice(window.location.href.indexOf) ('?') +1)); `will return the same object as "url.parse().query".
The size of url.js, punycode.js, and querystring.js are 23KB, 18KB, and 6KB respectively. After the webpack is packaged, the size of all optimized JavaScript files will be reduced about 100KB. The specific changes are listed below:
login.bundle.js:937KB(before) 826KB(after)
hardwareDetail.bundle.js: 920KB(before) 810KB(after)
templateList.bundle.js:928KB(before) 818KB(after)
templateDetail.bundle.js:932KB(before) 822KB(after)
templateView.bundle.js:3.1MB(before) 3MB(after)
jobSubmit.bundle.js:16.3MB(before) 16.2MB(after)
submit.bundle.js:  1.6MB(before) 1.5MB(after)