### PR TITLE
fix driver bug

### DIFF
--- a/src/rest-server/deploy/rest-server.yaml.template
+++ b/src/rest-server/deploy/rest-server.yaml.template
@@ -52,8 +52,6 @@ spec:
           value: {{ cluster_cfg['rest-server']['default-pai-admin-password'] }}
         - name: ETCD_URI
           value: {{ cluster_cfg['rest-server']['etcd-uris'] }}
-        - name: NV_DRIVER
-          value: /var/drivers/nvidia/current
 {% if cluster_cfg['rest-server']['github-owner'] %}
         - name: GITHUB_OWNER
           value: {{ cluster_cfg['rest-server']['github-owner'] }}

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -280,7 +280,7 @@ docker run --name $docker_name \
   --volume /tmp/pai-root/log/$APP_ID/$CONTAINER_ID:/pai/log \
   --volume $container_local_dir/$bootstrap_dir:/pai/bootstrap:ro \
   --volume $container_local_dir/$code_dir:/pai/code:ro \
-  --volume ${NV_DRIVER}:/usr/local/nvidia:ro \
+  --volume /var/drivers/nvidia/current:/usr/local/nvidia:ro \
   --volume $container_local_dir/$hadoop_config_dir:/etc/hadoop \
   --volume $container_local_dir/$ssh_config_file:/pai/ssh_config/:ro \
   --label GPU_ID=$gpu_id \


### PR DESCRIPTION
it seems rest-server will not pass environment variable into yarn-script. just hardcode in yarn-script since it is hardcoded anyway.