### PR TITLE
decouple data-node image from cluster object module

### DIFF
--- a/src/hadoop-data-node/deploy/hadoop-data-node-configuration/datanode-generate-script.sh
+++ b/src/hadoop-data-node/deploy/hadoop-data-node-configuration/datanode-generate-script.sh
@@ -23,7 +23,5 @@ cp  /hadoop-configuration/hadoop-env.sh $HADOOP_CONF_DIR/hadoop-env.sh
 cp  /hadoop-configuration/yarn-env.sh $HADOOP_CONF_DIR/yarn-env.sh
 cp  /hadoop-configuration/mapred-site.xml $HADOOP_CONF_DIR/mapred-site.xml
 
-HOST_NAME=`hostname`
-/usr/local/host-configure.py -c /host-configuration/host-configuration.yaml -f $HADOOP_CONF_DIR/hdfs-site.xml -n $HOST_NAME
-
-sed -i "s/{HDFS_ADDRESS}/${HDFS_ADDRESS}/g" $HADOOP_CONF_DIR/core-site.xml 
+sed -i "s/{POD_IP}/${POD_IP}/g" $HADOOP_CONF_DIR/hdfs-site.xml
+sed -i "s/{HDFS_ADDRESS}/${HDFS_ADDRESS}/g" $HADOOP_CONF_DIR/core-site.xml

--- a/src/hadoop-data-node/deploy/hadoop-data-node-configuration/hdfs-site.xml
+++ b/src/hadoop-data-node/deploy/hadoop-data-node-configuration/hdfs-site.xml
@@ -244,7 +244,7 @@
           rejected. It is recommended that this setting be left on to prevent accidental
           registration of datanodes listed by hostname in the excludes file during a DNS
           outage. Only set this to false in environments where there is no infrastructure
-          to support reverse DNS lookup.  
+          to support reverse DNS lookup.
   </description>
 </property>
 
@@ -268,7 +268,7 @@
 
 <property>
    <name>dfs.datanode.hostname</name>
-   <value>{{ host_config['ip'] }}</value>
+   <value>{POD_IP}</value>
 </property>
 
 <property>

--- a/src/hadoop-data-node/deploy/hadoop-data-node.yaml.template
+++ b/src/hadoop-data-node/deploy/hadoop-data-node.yaml.template
@@ -64,6 +64,10 @@ spec:
           value: datanode-generate-script.sh
         - name: START_SERVICE
           value: datanode-start-service.sh
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              status.podIP
       imagePullSecrets:
       - name: {{ cluster_cfg["cluster"]["docker-registry"]["secret-name"] }}
       volumes:

--- a/src/hadoop-data-node/deploy/hadoop-data-node.yaml.template
+++ b/src/hadoop-data-node/deploy/hadoop-data-node.yaml.template
@@ -67,7 +67,7 @@ spec:
         - name: POD_IP
           valueFrom:
             fieldRef:
-              status.podIP
+              fieldPath: status.podIP
       imagePullSecrets:
       - name: {{ cluster_cfg["cluster"]["docker-registry"]["secret-name"] }}
       volumes:


### PR DESCRIPTION
Passing the POD_IP as data-node hostname.
It should be hostIP when using `docker` host-network mode, and it should also work when using other network modes..