### PR TITLE
fix alert manager rule

### DIFF
--- a/src/alert-manager/deploy/alert-configmap.yaml.template
+++ b/src/alert-manager/deploy/alert-configmap.yaml.template
@@ -24,7 +24,7 @@ data:
     - name: "pai-alert"
       email_configs:
         - to: {{ alert_info["receiver"] }}
-          html: "{{ "{{" }} template "email.pai.html" . {{ "}}" }}"
+          html: '{{ "{{" }} template "email.pai.html" . {{ "}}" }}'
           headers:
-            subject: "{{ cluster_cfg["cluster"]["common"]["cluster-id"] }}: {{ "{{" }} template "__subject" . {{ "}}" }}"
+            subject: '{{ cluster_cfg["cluster"]["common"]["cluster-id"] }}: {{ "{{" }} template "__subject" . {{ "}}" }}'
 {% endif %}


### PR DESCRIPTION
will cause `did not find expected key`. Since generated file will be `"{{ template "email.pai.html" . }}"`.