### PR TITLE
mount host path root into node-exporter

### DIFF
--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -80,8 +80,15 @@ spec:
         - containerPort: {{ cluster_cfg["node-exporter"]["port"] }}
           hostPort: {{ cluster_cfg["node-exporter"]["port"] }}
           name: scrape
+        volumeMounts:
+        - name: host-root
+          mountPath: /host-root/
       imagePullSecrets:
       - name: {{ cluster_cfg["cluster"]["docker-registry"]["secret-name"] }}
+      volumes:
+      - name: host-root
+        hostPath:
+          path: /
       hostNetwork: true
       tolerations:
       - key: node.kubernetes.io/memory-pressure

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -83,6 +83,7 @@ spec:
         volumeMounts:
         - name: host-root
           mountPath: /host-root/
+          readOnly: true
       imagePullSecrets:
       - name: {{ cluster_cfg["cluster"]["docker-registry"]["secret-name"] }}
       volumes:

--- a/src/prometheus/deploy/alerting/node.rules
+++ b/src/prometheus/deploy/alerting/node.rules
@@ -21,10 +21,10 @@ groups:
     - name: node-rules
       rules:
       - alert: NodeFilesystemUsage
-        expr: (node_filesystem_size_bytes - node_filesystem_free_bytes) / node_filesystem_size_bytes * 100 > 80
+        expr: node_filesystem_avail_bytes{mountpoint=~"/host-root.*", device=~"/dev.*"} / node_filesystem_size_bytes <= 0.2
         for: 5m
         annotations:
-          summary: "FileSystem usage in {{$labels.instance}} is above 80% (current value is: {{ $value }})"
+          summary: "FileSystem {{$labels.device}} usage in {{$labels.instance}} is above 80% (current value is: {{ $value }})"
 
       - alert: NodeMemoryUsage
         expr: (node_memory_MemTotal_bytes - (node_memory_MemFree_bytes+node_memory_Buffers_bytes+node_memory_Cached_bytes )) / node_memory_MemTotal_bytes * 100 > 80


### PR DESCRIPTION
fix #1766 , mount host-root as volume in node-exporter, so that node-exporter can report usage info about all disk mounted in host. Also changed alerting rule to remove duplicated entry in filesystem usage, this will also alert other disks previous ignored by node-exporter.