### PR TITLE
extend yarn container token expiry

### DIFF
--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
@@ -255,7 +255,7 @@
   
   <property>
     <name>yarn.resourcemanager.rm.container-allocation.expiry-interval-ms</name>
-    <value>1200000</value>
+    <value>1500000</value>
   </property>
 
   <property>

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager-configuration/yarn-site.xml
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager-configuration/yarn-site.xml
@@ -218,7 +218,7 @@
 
   <property>
     <name>yarn.resourcemanager.rm.container-allocation.expiry-interval-ms</name>
-    <value>1200000</value>
+    <value>1500000</value>
   </property>
 
   <property>


### PR DESCRIPTION
Related configuraion
```
amGangAllocationTimeoutSec: 1100
yarn.resourcemanager.rm.container-allocation.expiry-interval-ms=1200000
```
AM might start container after `$amGangAllocationTimeoutSec` secs, but yarn ask the container should be launched whin `$yarn.resourcemanager.rm.container-allocation.expiry-interval-ms`. If clusters are out of sync, the token might be invalid

