### PR TITLE
Add gpu blacklist

### DIFF
--- a/docs/hadoop/yarn.md
+++ b/docs/hadoop/yarn.md
@@ -1,0 +1,29 @@
+# YARN
+
+This guidance provides users instructions to configure YARN.
+
+# Table of Content
+- [ YARN GPU Blacklist ](#YARN_GPU_Blacklist)
+    - [ Kubectl ](#kubectl)
+
+# Configured YARN GPU Blacklist <a name="YARN_GPU_Blacklist"></a>
+
+We enhance YARN to support GPU level blacklist, these GPUs will be excluded from scheduling. 
+It could be configured by following ways:
+
+## Kubectl <a name="kubectl"></a>
+1. create a file called "blacklist", fill it with the blacklist info, as below:
+    ```yaml
+    # host_ip: blacklist bitmap, 1 means unavailable.
+    10.0.0.1: 0010  # blacklist the second GPU
+    10.0.0.3: 1100  # blacklist the third and forth GPU
+    ```
+    
+2. upload it to configmap
+    ```bash
+    kubectl create configmap gpu-blacklist --from-file=blacklist --dry-run -o yaml | kubectl apply --overwrite=true -f -
+    ```
+    
+##Todo:
+by paictl or rest-server
+

--- a/src/hadoop-ai/build/build-pre.sh
+++ b/src/hadoop-ai/build/build-pre.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0") > /dev/null
 hadoopBinaryDir="/hadoop-binary/"
 
 hadoopBinaryPath="${hadoopBinaryDir}hadoop-2.9.0.tar.gz"
-cacheVersion="${hadoopBinaryDir}12940533-12933562-docker_executor-done"
+cacheVersion="${hadoopBinaryDir}gpu_blacklist-12933562-docker_executor-done"
 
 
 echo "hadoopbinarypath:${hadoopBinaryDir}"

--- a/src/hadoop-ai/build/build-pre.sh
+++ b/src/hadoop-ai/build/build-pre.sh
@@ -22,14 +22,14 @@ pushd $(dirname "$0") > /dev/null
 hadoopBinaryDir="/hadoop-binary/"
 
 hadoopBinaryPath="${hadoopBinaryDir}hadoop-2.9.0.tar.gz"
-cacheVersion="${hadoopBinaryDir}gpu_blacklist-12933562-docker_executor-done"
+cacheVersion="${hadoopBinaryDir}gpu_patch-12933562-docker_executor-done"
 
 
 echo "hadoopbinarypath:${hadoopBinaryDir}"
 
 [[ -f $cacheVersion ]] &&
 {
-    echo "Hadoop ai with patch 12940533-12933562-docker_executor has been built"
+    echo "Hadoop ai with patch gpu_patch-12933562-docker_executor has been built"
     echo "Skip this build precess"
     exit 0
 }

--- a/src/hadoop-ai/build/build.sh
+++ b/src/hadoop-ai/build/build.sh
@@ -23,6 +23,7 @@ cd /
 # patch for webhdfs upload issue when using nginx as a reverse proxy
 wget https://issues.apache.org/jira/secure/attachment/12933562/HDFS-13773.patch
 
+# Todo: update patch to jira
 git clone https://github.com/mzmssg/hadoop.git
 
 cd hadoop
@@ -47,5 +48,5 @@ echo "Successfully build hadoop 2.9.0 AI"
 
 # When Changing the patch id, please update the filename here.
 rm /hadoop-binary/*-done
-touch /hadoop-binary/gpu_blacklist-12933562-docker_executor-done
+touch /hadoop-binary/gpu_patch-12933562-docker_executor-done
 

--- a/src/hadoop-ai/build/build.sh
+++ b/src/hadoop-ai/build/build.sh
@@ -19,21 +19,21 @@
 
 cd /
 
-wget https://issues.apache.org/jira/secure/attachment/12940533/hadoop-2.9.0.gpu-port.20180920.patch -O hadoop-2.9.0.gpu-port.patch
+#wget https://issues.apache.org/jira/secure/attachment/12940533/hadoop-2.9.0.gpu-port.20180920.patch -O hadoop-2.9.0.gpu-port.patch
 # patch for webhdfs upload issue when using nginx as a reverse proxy
 wget https://issues.apache.org/jira/secure/attachment/12933562/HDFS-13773.patch
 
-git clone https://github.com/apache/hadoop.git
+git clone https://github.com/mzmssg/hadoop.git
 
 cd hadoop
 
-git checkout branch-2.9.0
+git checkout 2.9.0_gpupatch_blacklist
 
-cp /hadoop-2.9.0.gpu-port.patch /hadoop
+#cp /hadoop-2.9.0.gpu-port.patch /hadoop
 cp /HDFS-13773.patch /hadoop
 cp /docker-executor.patch /hadoop
 
-git apply hadoop-2.9.0.gpu-port.patch
+#git apply hadoop-2.9.0.gpu-port.patch
 git apply HDFS-13773.patch
 git apply docker-executor.patch
 
@@ -47,5 +47,5 @@ echo "Successfully build hadoop 2.9.0 AI"
 
 # When Changing the patch id, please update the filename here.
 rm /hadoop-binary/*-done
-touch /hadoop-binary/12940533-12933562-docker_executor-done
+touch /hadoop-binary/gpu_blacklist-12933562-docker_executor-done
 

--- a/src/hadoop-node-manager/deploy/configmap-create.sh
+++ b/src/hadoop-node-manager/deploy/configmap-create.sh
@@ -18,3 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 kubectl create configmap hadoop-node-manager-configuration --from-file=hadoop-node-manager-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+
+if ! kubectl get configmap gpu_blacklist 1>/dev/null 2>&1; then
+    kubectl create configmap gpu_blacklist
+fi

--- a/src/hadoop-node-manager/deploy/configmap-create.sh
+++ b/src/hadoop-node-manager/deploy/configmap-create.sh
@@ -19,6 +19,6 @@
 
 kubectl create configmap hadoop-node-manager-configuration --from-file=hadoop-node-manager-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
-if ! kubectl get configmap gpu_blacklist 1>/dev/null 2>&1; then
-    kubectl create configmap gpu_blacklist
+if ! kubectl get configmap gpu-blacklist 1>/dev/null 2>&1; then
+    kubectl create configmap gpu-blacklist
 fi

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
@@ -17,6 +17,19 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+function monitor_blacklist()
+{
+    if [ ! -d `dirname $2` ]; then
+        mkdir `dirname $2`
+    fi
+    while true
+    do
+        cat $1 2>/dev/null | grep "$3:" | grep -Eo '(0|1)*$' >$2
+        sleep 60
+    done
+}
+
+
 ip_list=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*'`
 
 host_ip_address=''
@@ -34,6 +47,8 @@ echo "The ip-address of this machine is: $host_ip_address"
 
 echo "$host_ip_address  $host_ip_address" >> /etc/hosts
 
+# monitor blacklist file
+monitor_blacklist /hadoop-gpu-blacklist /usr/local/hadoop/etc/hadoop/gpu_blacklist ${host_ip_address}
 
 cp  /hadoop-configuration/core-site.xml $HADOOP_CONF_DIR/core-site.xml
 cp  /hadoop-configuration/mapred-site.xml $HADOOP_CONF_DIR/mapred-site.xml

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
@@ -24,7 +24,7 @@ function monitor_blacklist()
     fi
     while true
     do
-        cat $1 2>/dev/null | grep "$3:" | grep -Eo '(0|1)*$' >$2
+        cat $1 2>/dev/null | grep -E "^$3:" | grep -Eo '(0|1)*$' >$2
         sleep 60
     done
 }

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
@@ -48,7 +48,7 @@ echo "The ip-address of this machine is: $host_ip_address"
 echo "$host_ip_address  $host_ip_address" >> /etc/hosts
 
 # monitor blacklist file
-monitor_blacklist /hadoop-gpu-blacklist /usr/local/hadoop/etc/hadoop/gpu_blacklist ${host_ip_address} &
+monitor_blacklist /hadoop-gpu-blacklist/blacklist /usr/local/hadoop/etc/hadoop/gpu_blacklist ${host_ip_address} &
 
 cp  /hadoop-configuration/core-site.xml $HADOOP_CONF_DIR/core-site.xml
 cp  /hadoop-configuration/mapred-site.xml $HADOOP_CONF_DIR/mapred-site.xml

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/nodemanager-generate-script.sh
@@ -48,7 +48,7 @@ echo "The ip-address of this machine is: $host_ip_address"
 echo "$host_ip_address  $host_ip_address" >> /etc/hosts
 
 # monitor blacklist file
-monitor_blacklist /hadoop-gpu-blacklist /usr/local/hadoop/etc/hadoop/gpu_blacklist ${host_ip_address}
+monitor_blacklist /hadoop-gpu-blacklist /usr/local/hadoop/etc/hadoop/gpu_blacklist ${host_ip_address} &
 
 cp  /hadoop-configuration/core-site.xml $HADOOP_CONF_DIR/core-site.xml
 cp  /hadoop-configuration/mapred-site.xml $HADOOP_CONF_DIR/mapred-site.xml

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
@@ -256,7 +256,7 @@
   <property>
     <description>the gpu blacklist file</description>
     <name>yarn.nodemanager.gpu_blacklist_file</name>
-    <value>"/blacklist/gpu_blacklist"</value>
+    <value>/blacklist/gpu_blacklist</value>
   </property>
   
   <property>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
@@ -256,7 +256,7 @@
   <property>
     <description>the gpu blacklist file</description>
     <name>yarn.nodemanager.gpu_blacklist_file</name>
-    <value>/blacklist/gpu_blacklist</value>
+    <value>/usr/local/hadoop/etc/hadoop/gpu_blacklist</value>
   </property>
   
   <property>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml
@@ -252,6 +252,12 @@
     <name>yarn.gpu_not_ready_memory_threshold-mb</name>
     <value>20</value>
   </property>
+
+  <property>
+    <description>the gpu blacklist file</description>
+    <name>yarn.nodemanager.gpu_blacklist_file</name>
+    <value>"/blacklist/gpu_blacklist"</value>
+  </property>
   
   <property>
     <name>yarn.resourcemanager.rm.container-allocation.expiry-interval-ms</name>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager.yaml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager.yaml.template
@@ -133,7 +133,7 @@ spec:
           path: {{ cluster_cfg["cluster"]["common"][ "data-path" ] }}/hadooptmp/nodemanager
       - name: hadoop-gpu-blacklist
         configMap:
-          name: gpu_blacklist
+          name: gpu-blacklist
       tolerations:
       - key: node.kubernetes.io/memory-pressure
         operator: "Exists"

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager.yaml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager.yaml.template
@@ -59,6 +59,8 @@ spec:
           name: host-confg-volume
         - mountPath: /var/lib/hadoopdata
           name: hadoop-tmp-storage
+        - mountPath: /hadoop-gpu-blacklist
+          name: hadoop-gpu-blacklist
         readinessProbe:
           exec:
             command:
@@ -129,6 +131,9 @@ spec:
       - name: hadoop-tmp-storage
         hostPath:
           path: {{ cluster_cfg["cluster"]["common"][ "data-path" ] }}/hadooptmp/nodemanager
+      - name: hadoop-gpu-blacklist
+        configMap:
+          name: gpu_blacklist
       tolerations:
       - key: node.kubernetes.io/memory-pressure
         operator: "Exists"


### PR DESCRIPTION
Hadoop change
https://github.com/mzmssg/hadoop/pull/1/files


Known issue
1. when blacklist the higher bit GPU( i.e. black the third and fourth GPU on a 4-GPUs machine), the resouce view will change from `1111` to `11`. Idealy, it should be `0011` .
2. Resource subtraction has bug, which lead YARN get wrong available resource.


