### PR TITLE
Marketplace plugin: remove isConnected judge.

### DIFF
--- a/src/webportal/src/plugins/marketplace/index.js
+++ b/src/webportal/src/plugins/marketplace/index.js
@@ -19,8 +19,6 @@ const querystring = require('querystring');
 
 class MarketplaceElement extends HTMLElement {
   connectedCallback() {
-    if (!this.isConnected) return;
-
     const self = this;
     const qs = location.search.replace(/^\?+/, ''); // Strip leading question marks
     const query = querystring.parse(qs);


### PR DESCRIPTION
`Node#isConnected` is polyfilled in [webcomponents/shadydom](https://github.com/webcomponents/shadydom/blob/7bd0469d9b7fb5a29ee13426d708e1a46dca995b/src/patches/Node.js#L160-L183) library but not [webcomponents/custom-elements](https://github.com/webcomponents/custom-elements/blob/fc3e52bd05774fc1c541dad441316cbbf75c9e40/DEVELOPING.md#to-do) library, which is we imported.

It would cause browser that not support custom elements not rendering the plugin content.