### PR TITLE
[Docker] Add docker-data-root configuration into cluster-configuration

### DIFF
--- a/deployment/clusterObjectModel/mainParser/machine.py
+++ b/deployment/clusterObjectModel/mainParser/machine.py
@@ -141,8 +141,10 @@ class Machine:
                     host["keyfile-path"] = com_machine["default-machine-properties"]["keyfile-path"]
             if "nodename" not in host:
                 host["nodename"] = host["hostip"]
-            if "docker-data" not in host:
+            if "docker-data" not in host and "docker-data-root" not in com_machine["machine-sku"][host["machine-type"]]:
                 host["docker-data"] = "/var/lib/docker"
+            elif "docker-data-root" in com_machine["machine-sku"][host["machine-type"]]:
+                host["docker-data"] = com_machine["machine-sku"][host["machine-type"]]["docker-data-root"]
             com_machine["machine-list"][host["hostname"]] = host
 
         return com_machine

--- a/examples/cluster-configuration/cluster-configuration.yaml
+++ b/examples/cluster-configuration/cluster-configuration.yaml
@@ -35,7 +35,7 @@ machine-sku:
       count: 4
     cpu:
       vcore: 24
-    #dataFolder: "/mnt"
+    #docker-data-root: "/var/lib/docker"
     #Note: Up to now, the only supported os version is Ubuntu16.04. Please do not change it here.
     os: ubuntu16.04
 
@@ -43,7 +43,7 @@ machine-sku:
     mem: 32
     cpu:
       vcore: 8
-    #dataFolder: "/mnt"
+    #docker-data-root: "/var/lib/docker"
     #Note: Up to now, the only supported os version is Ubuntu16.04. Pls don't change it here.
     os: ubuntu16.04
 


### PR DESCRIPTION
Add docker-data-root configuration into cluster-configuration.machine-sku

Priority, from high to low.
1) cluster-configuration.machine-sku.${machine-type}.docker-data-root
2) cluster-configuraiton.machine-list.${hostname}.docker-data
3) Default value: /var/lib/docker