### PR TITLE
add avg to singlestate panel

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -163,7 +163,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "yarn_nodes_active",
+              "expr": "avg(yarn_nodes_active)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -321,7 +321,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "yarn_gpus_used",
+              "expr": "avg(yarn_gpus_used)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,


### PR DESCRIPTION
clusterview dashboard uses many singlestate panel, two of them are yarn related and did not use aggregation expression. So whenever yarn service get restarted, there will be multiple time series returned by prometheus(one is from older yarn, another is from newly started yarn). This will make home page of Pai displaying error in these two panel.

Use `avg` aggregation expression to address the issue, although the code reader may be confused.