### PR TITLE
add /usr/local/cuda/extras/CUPTI/lib64 to LD_LIBRARY_PATH

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,6 +76,23 @@ The limitation is because we only reserve so much memory resource for `PAI servi
 For example, user may have hundreds jobs running, thousands jobs waiting, and tens of thousands jobs finished.
 
 
+### Q: How to solve `failed call to cuInit: CUresult(-1)`
+
+You should check `LD_LIBRARY_PATH` in your job container by using `export` command. It should have one of following:
+
+* `/usr/local/nvidia/lib`
+* `/usr/local/nvidia/lib64`
+* `/usr/local/cuda/extras/CUPTI/lib`
+* `/usr/local/cuda/extras/CUPTI/lib64`
+
+You can add path to `LD_LIBRARY_PATH` in your Dockerfile like:
+```
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/extras/CUPTI/lib:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+```
+
+If probelm remains, you can try [this script](https://gist.github.com/f0k/63a664160d016a491b2cbea15913d549) to self diagnose the problem.
+
+
 ## Deploy and maintenance related FAQs
 
 ### Q: Why not recommend deploying the master node to the GPU server and running the job?

--- a/examples/Dockerfiles/cuda8.0-cudnn6/Dockerfile.build.base
+++ b/examples/Dockerfiles/cuda8.0-cudnn6/Dockerfile.build.base
@@ -76,6 +76,6 @@ ENV HADOOP_PREFIX=${HADOOP_INSTALL} \
     HADOOP_OPTS="-Djava.library.path=${HADOOP_INSTALL}/lib/native"
 
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${HADOOP_BIN_DIR}:${HADOOP_SBIN_DIR} \
-    LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib/stubs:${JAVA_HOME}/jre/lib/amd64/server
+    LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib/stubs:${JAVA_HOME}/jre/lib/amd64/server
 
 WORKDIR /root

--- a/examples/Dockerfiles/cuda9.0-cudnn7/Dockerfile.build.base
+++ b/examples/Dockerfiles/cuda9.0-cudnn7/Dockerfile.build.base
@@ -74,6 +74,6 @@ ENV HADOOP_PREFIX=${HADOOP_INSTALL} \
     HADOOP_OPTS="-Djava.library.path=${HADOOP_INSTALL}/lib/native"
 
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${HADOOP_BIN_DIR}:${HADOOP_SBIN_DIR} \
-    LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib/stubs:${JAVA_HOME}/jre/lib/amd64/server
+    LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib/stubs:${JAVA_HOME}/jre/lib/amd64/server
 
 WORKDIR /root


### PR DESCRIPTION
We found `nvidia-container-runtime` inject cuda related .so file into dir under `/usr/local/cuda/extras/CUPTI/lib64`. So some of our example can not load cuda and report `tensorflow/stream_executor/cuda/cuda_driver.cc:406] failed call to cuInit: CUresult(-1)` because they do not have the path in `LD_LIBRARY_PATH`.

Current solution is add it in our example, and tell user to add in FAQ.