### PR TITLE
increase job-exporter memory limit

### DIFF
--- a/src/job-exporter/deploy/job-exporter.yaml.template
+++ b/src/job-exporter/deploy/job-exporter.yaml.template
@@ -54,7 +54,7 @@ spec:
         {%- if cluster_cfg['cluster']['common']['qos-switch'] == "true" %}
         resources:
           limits:
-            memory: "128Mi"
+            memory: "512Mi"
         {%- endif %}
         securityContext:
           privileged: true # this is required since job-exporter will call setns to other containers

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -248,12 +248,12 @@ class DockerCollector(Collector):
         except subprocess.CalledProcessError as e:
             logger.exception("command '%s' return with error (code %d): %s",
                     cmd, e.returncode, e.output)
-            error = e.strerror()
+            error = str(e)
         except subprocess.TimeoutExpired as e:
             logger.warning("check docker active timeout")
             error = "timeout"
         except Exception as e:
-            error = e.strerror()
+            error = e.message
 
         counter = gen_docker_daemon_counter()
         counter.add_metric([error], 1)


### PR DESCRIPTION
`k8s_job-exporter_job-exporter-l4ptn_default_d804d9e9-1d74-11e9-b630-000d3ab7e6d6_0 126.6MiB / 128MiB`.

increase memory limit for job-exporter and fix some code error.