### PR TITLE
Webportal plugin: Use native loadScript instead of jQuery.getScript

### DIFF
--- a/src/webportal/src/app/plugin/plugin.component.js
+++ b/src/webportal/src/app/plugin/plugin.component.js
@@ -19,6 +19,19 @@ require('@webcomponents/custom-elements');
 
 const url = require('url');
 
+function loadScript(uri, callback) {
+  const script = document.createElement('script');
+  script.addEventListener('load', loadHandler);
+  script.src = uri;
+  document.head.appendChild(script);
+
+  function loadHandler() {
+    script.removeEventListener('load', loadHandler);
+    document.head.removeChild(script);
+    callback();
+  }
+}
+
 $(document).ready(function() {
   const query = url.parse(window.location.href, true).query;
   const index = Number(query['index']);
@@ -31,7 +44,7 @@ $(document).ready(function() {
 
   $('.sidebar-menu .plugin-' + index).addClass('active');
 
-  $.getScript(plugin.uri).then(function() {
+  loadScript(plugin.uri, function() {
     const $plugin = $('<pai-plugin>')
       .attr('pai-rest-server-uri', window.ENV.restServerUri);
     $('#content-wrapper').empty().append($plugin);


### PR DESCRIPTION
Will hotfix to pai-0.9.y

jQuery version could not provide the document.currentScript property, which make the plugin cannot get the plugin configuration.