### PR TITLE
Reduce am resource

### DIFF
--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -28,6 +28,16 @@
     </property>
 
     <property>
+        <name>yarn.nodemanager.vmem-pmem-ratio</name>
+        <value>6</value>
+        <description>
+            Ratio between virtual memory to physical memory when setting memory limits for containers.
+            Container allocations are expressed in terms of physical memory, and virtual memory usage
+            is allowed to exceed this allocation by this ratio.
+        </description>
+    </property>
+
+    <property>
         <name>yarn.resourcemanager.max-completed-applications</name>
         <value>1000</value>
         <description>maximum number of completed applications</description>

--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -459,11 +459,11 @@ class Job {
         'queue': virtualCluster,
         'taskNodeGpuType': gpuType,
         'gangAllocation': true,
-        "amResource": {
-          "cpuNumber": 1,
-          "memoryMB": 1024,
-          "diskType": 0,
-          "diskMB": 0
+        'amResource': {
+          'cpuNumber': 1,
+          'memoryMB': 1024,
+          'diskType': 0,
+          'diskMB': 0,
         },
       },
     };

--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -459,6 +459,12 @@ class Job {
         'queue': virtualCluster,
         'taskNodeGpuType': gpuType,
         'gangAllocation': true,
+        "amResource": {
+          "cpuNumber": 1,
+          "memoryMB": 1024,
+          "diskType": 0,
+          "diskMB": 0
+        },
       },
     };
     for (let i = 0; i < data.taskRoles.length; i++) {


### PR DESCRIPTION
1. reduce AM memory to 1G
2. increase YARN virtual memory ratio to 6(1g physical memory with 6g virtual memory), previous value is 2.1. Launcher AM might consume 3G+ virtual memory.

Test case:
A framework with 9 taskroles, 5 tasks per taskrole, 2-node cluster, for one hour.