### PR TITLE
[Issue Fix] Fix OpenJDK version to 8u191-b12-0ubuntu0.16.04.1

### DIFF
--- a/paictl.py
+++ b/paictl.py
@@ -596,3 +596,4 @@ if __name__ == "__main__":
 
     setup_logging()
     main(sys.argv[1:])
+

--- a/src/base-image/build/base-image.dockerfile
+++ b/src/base-image/build/base-image.dockerfile
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre \
-      openjdk-8-jdk \
+      openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1 \
+      openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \
       git \

--- a/src/dev-box/build/dev-box.dockerfile
+++ b/src/dev-box/build/dev-box.dockerfile
@@ -39,8 +39,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre \
-      openjdk-8-jdk \
+      openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1 \
+      openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \
       git \

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre \
-      openjdk-8-jdk \
+      openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1 \
+      openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \
       git \


### PR DESCRIPTION
```
xxx@xxxxxxxxxxxxxxx:~/pai$ sudo apt-cache madison openjdk-8-jre
openjdk-8-jre | 8u191-b12-0ubuntu0.16.04.1 | http://azure.archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages
openjdk-8-jre | 8u191-b12-0ubuntu0.16.04.1 | http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages
openjdk-8-jre | 8u77-b03-3ubuntu3 | http://azure.archive.ubuntu.com/ubuntu xenial/main amd64 Packages
 openjdk-8 | 8u77-b03-3ubuntu3 | http://azure.archive.ubuntu.com/ubuntu xenial/main Sources
 openjdk-8 | 8u191-b12-0ubuntu0.16.04.1 | http://azure.archive.ubuntu.com/ubuntu xenial-updates/main Sources
 openjdk-8 | 8u191-b12-0ubuntu0.16.04.1 | http://security.ubuntu.com/ubuntu xenial-security/main Sources
xxx@xxxxxxxxxxxxxxx:~/pai$ sudo apt-cache madison openjdk-8-jdk
openjdk-8-jdk | 8u191-b12-0ubuntu0.16.04.1 | http://azure.archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages
openjdk-8-jdk | 8u191-b12-0ubuntu0.16.04.1 | http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages
openjdk-8-jdk | 8u77-b03-3ubuntu3 | http://azure.archive.ubuntu.com/ubuntu xenial/main amd64 Packages
 openjdk-8 | 8u77-b03-3ubuntu3 | http://azure.archive.ubuntu.com/ubuntu xenial/main Sources
 openjdk-8 | 8u191-b12-0ubuntu0.16.04.1 | http://azure.archive.ubuntu.com/ubuntu xenial-updates/main Sources
 openjdk-8 | 8u191-b12-0ubuntu0.16.04.1 | http://security.ubuntu.com/ubuntu xenial-security/main Sources

```