### PR TITLE
make it more clear in service not up

### DIFF
--- a/src/prometheus/deploy/alerting/pai-services.rules
+++ b/src/prometheus/deploy/alerting/pai-services.rules
@@ -40,7 +40,7 @@ groups:
         labels:
           type: pai_service
         annotations:
-          summary: "{{$labels.job}} in {{$labels.instance}} not up detected"
+          summary: "{{$labels.pai_service_name}} in {{$labels.instance}} not up detected"
 
       - alert: JobExporterHangs
         expr: irate(collector_iteration_count_total[5m]) == 0


### PR DESCRIPTION
this was fixed in pai-0.9 along with job-exporter fix. But since job-exporter fix is a temporary fix, so I only add this fix to master, and fix job-exporter in master when we find out the root cause.