### PR TITLE
fix deadlock in job-exporter by disabling GCCollector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ matrix:
         - python -m unittest discover test/
 
     - language: python
-      python: 2.7
+      python: 3.6
       before_install:
         - cd src/watchdog/test
       install:
-        - pip install paramiko pyyaml requests prometheus_client
+        - pip install paramiko pyyaml requests prometheus_client twisted
       script:
         - python -m unittest discover .
 

--- a/src/job-exporter/deploy/job-exporter.yaml.template
+++ b/src/job-exporter/deploy/job-exporter.yaml.template
@@ -36,7 +36,7 @@ spec:
       containers:
       - image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}job-exporter:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always
-        livenessProbe: # we found python may have deadlock and http server can not accept new conn, so use liveness probe to check if it is alive, and kill if it has deadlock. Temporary solution
+        livenessProbe: # in case job-exporter hangs
           httpGet:
             path: '/healthz'
             port: {{ cluster_cfg["job-exporter"]["port"] }}

--- a/src/watchdog/build/watchdog.dockerfile
+++ b/src/watchdog/build/watchdog.dockerfile
@@ -15,8 +15,8 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM python:2.7
+FROM python:3.7
 
-RUN pip install PyYAML requests paramiko prometheus_client
+RUN pip3 install PyYAML requests paramiko prometheus_client twisted
 
 COPY src/watchdog.py /

--- a/src/watchdog/deploy/watchdog.yaml.template
+++ b/src/watchdog/deploy/watchdog.yaml.template
@@ -31,7 +31,7 @@ spec:
         app: watchdog
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/path: "/"
+        prometheus.io/path: "/metrics"
         prometheus.io/port: "9101"
     spec:
       containers:
@@ -39,7 +39,8 @@ spec:
         image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}watchdog:{{cluster_cfg["cluster"]["docker-registry"]["tag"]}}
         imagePullPolicy: Always
         readinessProbe:
-          tcpSocket: # because http get will trigger job-exporter abandom old metrics, so we use tcp instead of http
+          httpGet:
+            path: '/healthz'
             port: 9101
           initialDelaySeconds: 3
           periodSeconds: 30


### PR DESCRIPTION
fix #2104 by disable GCCollector. Use twisted as http server. Also add signal handler for dumping stack trace to facilitate future debug for hanging.