### PR TITLE
[JDK] Remove JDK version hardcode and add print in pai_build for debuging

### DIFF
--- a/build/core/build_center.py
+++ b/build/core/build_center.py
@@ -158,7 +158,3 @@ class BuildCenter:
                 self.docker_cli.docker_image_tag(image,self.build_config['dockerRegistryInfo']['dockerTag'])
                 self.docker_cli.docker_image_push(image,self.build_config['dockerRegistryInfo']['dockerTag'])
                 self.logger.info("Push image:{0} successfully".format(image))
-
-
-
-

--- a/build/core/build_center.py
+++ b/build/core/build_center.py
@@ -23,6 +23,7 @@ from . import build_handler
 
 import os
 import sys
+import traceback
 import logging
 import logging.config
 
@@ -122,8 +123,9 @@ class BuildCenter:
                     build_worker.build_single_component(self.graph.services[item])
             self.logger.info("Build all components succeed")
 
-        except:
+        except Exception, err:
             self.logger.error("Build all components failed")
+            traceback.print_exc()
             sys.exit(1)
 
         finally:

--- a/deployment/k8sPaiLibrary/maintaintool/restart-etcd-server.sh
+++ b/deployment/k8sPaiLibrary/maintaintool/restart-etcd-server.sh
@@ -18,3 +18,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 cp etcd-reconfiguration-restart/etcd.yaml /etc/kubernetes/manifests/
+

--- a/paictl.py
+++ b/paictl.py
@@ -99,4 +99,3 @@ if __name__ == "__main__":
 
     setup_logging()
     main(sys.argv[1:])
-

--- a/src/base-image/build/base-image.dockerfile
+++ b/src/base-image/build/base-image.dockerfile
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1 \
-      openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1 \
+      openjdk-8-jre \
+      openjdk-8-jdk \
       openssh-server \
       openssh-client \
       git \

--- a/src/base-image/build/base-image.dockerfile
+++ b/src/base-image/build/base-image.dockerfile
@@ -39,7 +39,7 @@ RUN apt-get -y update && \
       python-pip \
       python-mysqldb \
       openjdk-8-jre \
-      openjdk-8-jdk \
+      openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \
       git \

--- a/src/base-image/build/base-image.dockerfile
+++ b/src/base-image/build/base-image.dockerfile
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre=8u191-b12-2ubuntu0.16.04.1 \
-      openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
+      openjdk-8-jre \
+      openjdk-8-jdk \
       openssh-server \
       openssh-client \
       git \

--- a/src/base-image/build/base-image.dockerfile
+++ b/src/base-image/build/base-image.dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre \
+      openjdk-8-jre=8u191-b12-2ubuntu0.16.04.1 \
       openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \

--- a/src/dev-box/build/dev-box.dockerfile
+++ b/src/dev-box/build/dev-box.dockerfile
@@ -39,8 +39,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1 \
-      openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1 \
+      openjdk-8-jre \
+      openjdk-8-jdk \
       openssh-server \
       openssh-client \
       git \

--- a/src/dev-box/build/dev-box.dockerfile
+++ b/src/dev-box/build/dev-box.dockerfile
@@ -39,8 +39,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre=8u191-b12-2ubuntu0.16.04.1 \
-      openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
+      openjdk-8-jre \
+      openjdk-8-jdk \
       openssh-server \
       openssh-client \
       git \

--- a/src/dev-box/build/dev-box.dockerfile
+++ b/src/dev-box/build/dev-box.dockerfile
@@ -39,8 +39,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre \
-      openjdk-8-jdk \
+      openjdk-8-jre=8u191-b12-2ubuntu0.16.04.1 \
+      openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \
       git \

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre \
-      openjdk-8-jdk \
+      openjdk-8-jre=8u191-b12-2ubuntu0.16.04.1 \
+      openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
       openssh-server \
       openssh-client \
       git \

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1 \
-      openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1 \
+      openjdk-8-jre \
+      openjdk-8-jdk \
       openssh-server \
       openssh-client \
       git \

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -38,8 +38,8 @@ RUN apt-get -y update && \
       python-dev \
       python-pip \
       python-mysqldb \
-      openjdk-8-jre=8u191-b12-2ubuntu0.16.04.1 \
-      openjdk-8-jdk=8u191-b12-2ubuntu0.16.04.1 \
+      openjdk-8-jre \
+      openjdk-8-jdk \
       openssh-server \
       openssh-client \
       git \


### PR DESCRIPTION
Find the old version in apt is overwrited. And build image failed with the error message following. 


```
Get:15 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8532 B]
Get:16 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]
Get:17 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [534 kB]
Get:18 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6119 B]
Fetched 15.6 MB in 1s (10.3 MB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '8u191-b12-0ubuntu0.16.04.1' for 'openjdk-8-jre' was not found
E: Version '8u191-b12-0ubuntu0.16.04.1' for 'openjdk-8-jdk' was not found
The command '/bin/sh -c apt-get -y update &&     apt-get -y install       nano       vim       joe       wget       curl       jq       gawk       psmisc       python       python-yaml       python-jinja2       python-paramiko       python-urllib3       python-tz       python-nose       python-prettytable       python-netifaces       python-dev       python-pip       python-mysqldb       openjdk-8-jre=8u191-b12-0ubuntu0.16.04.1       openjdk-8-jdk=8u191-b12-0ubuntu0.16.04.1       openssh-server       openssh-client       git       bash-completion       inotify-tools       rsync       realpath       net-tools &&     mkdir -p /cluster-configuration &&    git clone https://github.com/Microsoft/pai.git &&    pip install python-etcd docker kubernetes GitPython' returned a non-zero code: 100
2019-02-02 03:54:27,660 - core.build_utility - INFO - Executing command failed: docker build -t dev-box -f src/dev-box/build/dev-box.dockerfile src/dev-box
2019-02-02 03:54:27,660 - core.build_center - ERROR - Build all components failed
2019-02-02 03:54:27,660 - core.build_center - INFO - Begin to clean all temp folder
2019-02-02 03:54:27,667 - core.build_center - INFO - Clean all temp folder succeed
xxxx@xxxxxxxxxxxxx:~/pai/build$ sudo apt-cache madison openjdk-8-jre
openjdk-8-jre | 8u191-b12-2ubuntu0.16.04.1 | http://azure.archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages
openjdk-8-jre | 8u191-b12-2ubuntu0.16.04.1 | http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages
openjdk-8-jre | 8u77-b03-3ubuntu3 | http://azure.archive.ubuntu.com/ubuntu xenial/main amd64 Packages
 openjdk-8 | 8u77-b03-3ubuntu3 | http://azure.archive.ubuntu.com/ubuntu xenial/main Sources
 openjdk-8 | 8u191-b12-2ubuntu0.16.04.1 | http://azure.archive.ubuntu.com/ubuntu xenial-updates/main Sources
 openjdk-8 | 8u191-b12-2ubuntu0.16.04.1 | http://security.ubuntu.com/ubuntu xenial-security/main Sources

```