### PR TITLE
[CI/CD] Add error message when image build failed

### DIFF
--- a/build/core/build_center.py
+++ b/build/core/build_center.py
@@ -122,7 +122,8 @@ class BuildCenter:
                     build_worker.build_single_component(self.graph.services[item])
             self.logger.info("Build all components succeed")
 
-        except:
+        except Exception as e:
+            self.logger.error(str(e))
             self.logger.error("Build all components failed")
             sys.exit(1)
 

--- a/build/core/build_utility.py
+++ b/build/core/build_utility.py
@@ -90,7 +90,7 @@ def execute_shell(shell_cmd):
         subprocess.check_call( shell_cmd, shell=True )
         logger.info("Executing command successfully: {0}".format(shell_cmd))
     except subprocess.CalledProcessError:
-        logger.info("Executing command failed: {0}".format(shell_cmd))
+        logger.error("Executing command failed: {0}".format(shell_cmd))
         sys.exit(1)
 
 
@@ -101,7 +101,7 @@ def execute_shell_with_output(shell_cmd):
         res = subprocess.check_output( shell_cmd, shell=True )
         logger.info("Executes command successfully: {0}".format(shell_cmd))
     except subprocess.CalledProcessError:
-        logger.info("Executes command failed: {0}".format(shell_cmd))
+        logger.error("Executes command failed: {0}".format(shell_cmd))
         sys.exit(1)
 
     return res


### PR DESCRIPTION
Add error message when image build failed to help debug.
[Here](http://40.76.53.138:33080/blue/organizations/jenkins/pai/detail/PR-2086/7/pipeline/#step-47-log-1466) is an example. This fixes #2125.