### PR TITLE
[Pylon] WebHDFS library compatibility

### DIFF
--- a/src/pylon/src/nginx.conf.template
+++ b/src/pylon/src/nginx.conf.template
@@ -105,14 +105,15 @@ http {
     location ~ ^/webhdfs/api(.*)$ {
       proxy_pass {{WEBHDFS_URI}}/webhdfs$1$is_args$args;
       proxy_intercept_errors on;
-      error_page 307 = @handle_webhdfs_api_redirect;
+      error_page 307 @handle_webhdfs_api_redirect;
     }
     location ~ ^/webhdfs/webhdfs {
       rewrite ^/webhdfs/webhdfs(.*)$ /webhdfs/api$1 last;
     }
     location @handle_webhdfs_api_redirect {
       if ($upstream_http_location ~ ^http://([^/]+):(\d+)/(.*)$) {
-        return 307 $scheme://$http_host/a/$1:$2/$3;
+        add_header Location $scheme://$http_host/a/$1:$2/$3;
+        return 300 "";
       }
     }
 

--- a/src/pylon/src/nginx.conf.template
+++ b/src/pylon/src/nginx.conf.template
@@ -107,6 +107,9 @@ http {
       proxy_intercept_errors on;
       error_page 307 = @handle_webhdfs_api_redirect;
     }
+    location ~ ^/webhdfs/webhdfs {
+      rewrite ^/webhdfs/webhdfs(.*)$ /webhdfs/api$1 last;
+    }
     location @handle_webhdfs_api_redirect {
       if ($upstream_http_location ~ ^http://([^/]+):(\d+)/(.*)$) {
         return 307 $scheme://$http_host/a/$1:$2/$3;


### PR DESCRIPTION
Fixed #1674

- [Python HDFS client](https://github.com/jingw/pyhdfs/blob/fab8bcf4966f894a7114665875b258536534749d/pyhdfs.py#L51)  and [HdfsCLI](https://github.com/mtth/hdfs/blob/master/hdfs/client.py#L62) hard-coded the webhdfs prefix (/webhdfs/v1) and do not provide documented way to change them, we make (/webhdfs **/webhdfs/v1** ) alias of (/webhdfs **/api/v1** ) for easier use.
- Python HDFS client have an [assertion](https://github.com/jingw/pyhdfs/blob/fab8bcf4966f894a7114665875b258536534749d/pyhdfs.py#L424) of empty response body in 307 response, but nginx automatically adds a simple html in 307 response, we cleared it to be compatible to the library.