### PR TITLE
[Launcher]: Revise the definition of Framework running state

### DIFF
--- a/subprojects/frameworklauncher/yarn/src/main/java/com/microsoft/frameworklauncher/common/model/AggregatedFrameworkStatus.java
+++ b/subprojects/frameworklauncher/yarn/src/main/java/com/microsoft/frameworklauncher/common/model/AggregatedFrameworkStatus.java
@@ -48,4 +48,15 @@ public class AggregatedFrameworkStatus implements Serializable {
   public void setAggregatedTaskRoleStatuses(Map<String, AggregatedTaskRoleStatus> aggregatedTaskRoleStatuses) {
     this.aggregatedTaskRoleStatuses = aggregatedTaskRoleStatuses;
   }
+
+  public boolean existsRunningTask() {
+    for (AggregatedTaskRoleStatus aggTaskRoleStatus : aggregatedTaskRoleStatuses.values()) {
+      for (TaskStatus taskStatus : aggTaskRoleStatus.getTaskStatuses().getTaskStatusArray()) {
+        if (taskStatus.getTaskState() == TaskState.CONTAINER_RUNNING) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/subprojects/frameworklauncher/yarn/src/main/java/com/microsoft/frameworklauncher/webserver/StatusManager.java
+++ b/subprojects/frameworklauncher/yarn/src/main/java/com/microsoft/frameworklauncher/webserver/StatusManager.java
@@ -120,6 +120,7 @@ public class StatusManager extends AbstractService { // THREAD SAFE
     Map<String, AggregatedFrameworkStatus> newAggFrameworkStatuses = new HashMap<>();
     newAggFrameworkStatuses.putAll(reusableAggFrameworkStatuses);
     newAggFrameworkStatuses.putAll(nonreusableAggFrameworkStatuses);
+    reviseAggregatedFrameworkStatuses(newAggFrameworkStatuses);
     aggFrameworkStatuses = CommonExts.asReadOnly(newAggFrameworkStatuses);
 
     LOGGER.logDebug("Pulled AggregatedLauncherStatus: " +
@@ -167,6 +168,38 @@ public class StatusManager extends AbstractService { // THREAD SAFE
     return reusableAggFrameworkStatuses;
   }
 
+  private static void reviseAggregatedFrameworkStatuses(
+      Map<String, AggregatedFrameworkStatus> newAggFrameworkStatuses) {
+    for (AggregatedFrameworkStatus aggFrameworkStatus : newAggFrameworkStatuses.values()) {
+      FrameworkStatus frameworkStatus = aggFrameworkStatus.getFrameworkStatus();
+      String frameworkName = frameworkStatus.getFrameworkName();
+
+      // Revise FrameworkState:
+      // Framework is running <-> Exists running Task.
+      // This makes the Launcher APIs reflect the real Framework running state, instead of just the
+      // raw AM running state.
+      // It is hard to make sure the FrameworkStatus is consistent with the TaskStatuses outside
+      // WebServer.
+      // However, this will make the exposed FrameworkState is not consistent with the backend,
+      // but it is fine because the revised state, i.e. APPLICATION_RUNNING and APPLICATION_WAITING
+      // are generally exchangeable even in the backend.
+      FrameworkState frameworkState = frameworkStatus.getFrameworkState();
+      if (frameworkState == FrameworkState.APPLICATION_WAITING ||
+          frameworkState == FrameworkState.APPLICATION_RUNNING) {
+        FrameworkState revisedFrameworkState =
+            aggFrameworkStatus.existsRunningTask() ?
+                FrameworkState.APPLICATION_RUNNING :
+                FrameworkState.APPLICATION_WAITING;
+
+        if (frameworkState != revisedFrameworkState) {
+          frameworkStatus.setFrameworkState(revisedFrameworkState);
+          LOGGER.logDebug("Revised Framework [%s] from [%s] to [%s]",
+              frameworkName, frameworkState, revisedFrameworkState);
+        }
+      }
+    }
+  }
+
   private void updateCompletedFrameworkStatuses() throws Exception {
     Map<String, FrameworkStatus> completedFrameworkStatuses = new HashMap<>();
     for (Map.Entry<String, AggregatedFrameworkStatus> aggFrameworkStatusKV : aggFrameworkStatuses.entrySet()) {
@@ -204,7 +237,7 @@ public class StatusManager extends AbstractService { // THREAD SAFE
       // If the real Status has not yet appeared, return the inferred Status according to the Request.
       // So, from the Launcher APIs' view, the Status's life cycle is consistent with the Request.
       // This makes the Launcher APIs more convenient for Client to use.
-      // However, we only infer the FrameworkStatus if it does not exist, for other Status, such as the TaskStatuses, 
+      // However, we only infer the FrameworkStatus if it does not exist, for other Status, such as the TaskStatuses,
       // Client still needs to poll the API to check whether the Status has been updated according to the Request.
       return AggregatedFrameworkStatus.newInstance(frameworkRequest);
     }


### PR DESCRIPTION
**Solve Issues:**
#2022 
#2051 
#2099 

**New Definition:**

    Framework is running <-> Exists running Task
This makes the Launcher APIs reflect the real Framework running state, instead of just the raw AM running state. (Since We always want to best effort hide AM concept to end user).
The definition works for both Incremental and Gang Scheduling, because even for Gang Scheduling, “Exists running Task” means the Framework has already satisfied Gang Allocation, and all its Tasks has already been launched before.

**Why not implement in RestServer?**
To revise state, RestServer List operation need to also read all TaskStatuses, which is too heavy.

**Why implement in LauncherWebServer instead of LauncherService?**
It is hard to make sure the FrameworkStatus is consistent with the TaskStatuses outside WebServer.
However, this will make the exposed FrameworkState is not consistent with the backend, but it is fine because the revised state, i.e. APPLICATION_RUNNING and APPLICATION_WAITING are generally exchangeable even in the backend.

**How about K8S Launcher?**
K8S Launcher treat the whole Framework spec and status as a single CRD object, it is easy to make it consistent even in the backend.
Will add a new state FrameworkAttemptPreparing to indicate there is no running Task (such as during Gang Allocation Phase) even if FrameworkAttempt object is already created.

**Long Term Plan: Generalize Scheduling Policy**
1.	Abstract Framework and Task States which is independent from YARN or K8S platform
2.	Inter-TaskRole Dependency (A Ready -> B Start, A Produced -> B Start)
3.	Per-TaskRole Gang Scheduling
4.	Etc

