### PR TITLE
use yarn's metrics in cluster view

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -83,7 +83,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "100 * sum(yarn_gpus_used) / sum(configured_gpu_count)",
+              "expr": "100 * sum(yarn_gpus_used) / sum(yarn_total_gpu_num)",
               "format": "time_series",
               "hide": false,
               "instant": false,


### PR DESCRIPTION
make the front page consistently use yarn's gpu view.

Will add a page about all sort of gpu count in future.