### PR TITLE
Unify PAI runtime environment variable names

### DIFF
--- a/docs/job_tutorial.md
+++ b/docs/job_tutorial.md
@@ -153,33 +153,22 @@ Those environment variables can also be used in the job config file.
 
 Below we show a complete list of environment variables accessible in a Docker container:
 
-| Environment Variable Name          | Description                              |
-| :--------------------------------- | :--------------------------------------- |
-| PAI_WORK_DIR                       | Working directory in Docker container    |
-| PAI_DEFAULT_FS_URI                 | Default file system uri in PAI           |
-| PAI_JOB_NAME                       | `jobName` in config file                 |
-| PAI_JOB_VC_NAME                    | The virtual cluster in which the job is running     |
-| PAI_USER_NAME                      | User who submit the job                  |
-| PAI_DATA_DIR                       | `dataDir` in config file                 |
-| PAI_OUTPUT_DIR                     | `outputDir`in config file or the generated path if `outputDir` is not specified |
-| PAI_CODE_DIR                       | `codeDir` in config file. **Note**: we plan to obsolete PAI_CODE_DIR soon. Users are encouraged to keep their code in Github or any privately managed code repo if the code is not public. When running the Docker image,user can insert some script in the taskRole.command to “git clone …” the code down to the Docker instance.                 |
-| PAI_CURRENT_TASK_ROLE_NAME         | `taskRole.name` of current task role     |
-| PAI_CURRENT_TASK_ROLE_TASK_COUNT   | `taskRole.taskNumber` of current task role |
-| PAI_CURRENT_TASK_ROLE_CPU_COUNT    | `taskRole.cpuNumber` of current task role  |
-| PAI_CURRENT_TASK_ROLE_MEM_MB       | `taskRole.memoryMB` of current task role   |
-| PAI_CURRENT_TASK_ROLE_SHM_MB       | `taskRole.shmMB` of current task role      |
-| PAI_CURRENT_TASK_ROLE_GPU_COUNT    | `taskRole.gpuNumber` of current task role  |
-| PAI_CURRENT_TASK_ROLE_MIN_FAILED_TASK_COUNT    | `taskRole.minFailedTaskCount` of current task role    |
-| PAI_CURRENT_TASK_ROLE_MIN_SUCCEEDED_TASK_COUNT | `taskRole.minSucceededTaskCount` of current task role |
-| PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX | Index of current task in current task role, starting from 0 |
-| PAI_JOB_TASK_COUNT                 | Total tasks' number in config file       |
-| PAI_JOB_TASK_ROLE_COUNT            | Total task roles' number in config file  |
-| PAI_JOB_TASK_ROLE_LIST             | Comma separated all task role names in config file |
-| PAI_CONTAINER_HOST_IP              | Allocated ip for current docker container |
-| PAI_CONTAINER_HOST_PORT_LIST       | Allocated port list for current docker container, in `portLabel0:port0,port1,port2;portLabel1:port3,port4` format |
-| PAI_CONTAINER_HOST\_`$type`\_PORT_LIST | Allocated port list for `portList.label == $type`, comma separated `port` string |
-| PAI_TASK_ROLE\_`$name`\_HOST_LIST  | Host list for `PAI_TASK_ROLE_NAME == $name`, comma separated `ip:port` string, sorted by current task index in task role. Each task role has a host list environment variable with the corresponding task role name |
-| PAI\_`$taskRole`\_`$taskIndex`\_`$type`_PORT | The port for `portList.label == $type, task role name == $taskRole and task index of current task role == $taskIndex`. Each port has corresponding environment variable and is exposed to all tasks. |
+| Category          | Environment Variable Name                 | Description                                                 |
+| :---------------- | :---------------------------------------- | :---------------------------------------------------------- |
+| Job level         | PAI_JOB_NAME                              | `jobName` in config file                                    |
+|                   | PAI_JOB_VC_NAME                           | The virtual cluster in which the job is running             |
+|                   | PAI_USER_NAME                             | User who submit the job                                     |
+|                   | PAI_DEFAULT_FS_URI                        | Default file system uri in PAI                              |
+| Task role level   | PAI_TASK_ROLE_COUNT                       | Total task roles' number in config file                     |
+|                   | PAI_TASK_ROLE_LIST                        | Comma separated all task role names in config file          |
+|                   | PAI_TASK_ROLE_TASK_COUNT\_`$taskRole`     | Task count of the task role                                 |
+|                   | PAI_HOST_IP\_`$taskRole`\_`$taskIndex`    | The host IP for `taskIndex` task in `taskRole`              |
+|                   | PAI_PORT_LIST\_`$taskRole`\_`$taskIndex`\_`$portType` | The `$portType` port list for `taskIndex` task in `taskRole`     |
+|                   | PAI_RESOURCE\_`$taskRole`                 | Resource requirement for the task role in "gpuNumber,cpuNumber,memMB,shmMB" format |
+|                   | PAI_MIN_FAILED_TASK_COUNT\_`$taskRole`    | `taskRole.minFailedTaskCount` of the task role              |
+|                   | PAI_MIN_SUCCEEDED_TASK_COUNT\_`$taskRole` | `taskRole.minSucceededTaskCount` of the task role           |
+| Current task role | PAI_CURRENT_TASK_ROLE_NAME                | `taskRole.name` of current task role                        |
+| Current task      | PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX  | Index of current task in current task role, starting from 0 |
 
 
 ### A deep learning job example <a name="example"></a>

--- a/docs/job_tutorial.md
+++ b/docs/job_tutorial.md
@@ -156,7 +156,6 @@ Below we show a complete list of environment variables accessible in a Docker co
 | Category          | Environment Variable Name                 | Description                                                 |
 | :---------------- | :---------------------------------------- | :---------------------------------------------------------- |
 | Job level         | PAI_JOB_NAME                              | `jobName` in config file                                    |
-|                   | PAI_JOB_VC_NAME                           | The virtual cluster in which the job is running             |
 |                   | PAI_USER_NAME                             | User who submit the job                                     |
 |                   | PAI_DEFAULT_FS_URI                        | Default file system uri in PAI                              |
 | Task role level   | PAI_TASK_ROLE_COUNT                       | Total task roles' number in config file                     |

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -138,7 +138,7 @@ function get_host_list()
         fi
       done
     done < <(echo $taskrole_statuses | jq -r ".${taskrole}.taskStatuses.taskStatusArray[] | .containerIp, .containerPorts, .taskIndex")
-    echo PAI_TASK_ROLE_TASK_COUNT_${taskrole}=$(echo $taskrole_statuses | jq ".${taskrole}.taskStatuses.taskStatusArray[] | length") >> $1
+    echo PAI_TASK_ROLE_TASK_COUNT_${taskrole}=$(echo $taskrole_statuses | jq ".${taskrole}.taskStatuses.taskStatusArray | length") >> $1
     # Backward compatibility
     host_list=$(echo $host_list | sed "s/,$//g")
     echo PAI_TASK_ROLE_${taskrole}_HOST_LIST=$host_list >> $1
@@ -164,7 +164,6 @@ PAI_TEMP={{ jobData.userName }} && echo PAI_USER_NAME=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ hdfsUri }} && echo PAI_DEFAULT_FS_URI=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskRolesNumber }} && echo PAI_TASK_ROLE_COUNT=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskRoleList }} && echo PAI_TASK_ROLE_LIST=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.taskNumber }} && echo PAI_TASK_ROLE_TASK_COUNT_{{ taskData.name }}=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP="{{ taskData.gpuNumber }},{{ taskData.cpuNumber }},{{ taskData.memoryMB }},{{ taskData.shmMB }}" \
   && echo PAI_RESOURCE=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskData.minFailedTaskCount }} && echo PAI_MIN_FAILED_TASK_COUNT_{{ taskData.name }}=$PAI_TEMP >> $ENV_LIST

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -159,7 +159,6 @@ echo PAI_CONTAINER_ID=$CONTAINER_ID >> $ENV_LIST
 
 # PAI environment variables
 PAI_TEMP={{ jobData.jobName }} && echo PAI_JOB_NAME=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ jobData.virtualCluster }} && echo PAI_JOB_VC_NAME=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ jobData.userName }} && echo PAI_USER_NAME=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ hdfsUri }} && echo PAI_DEFAULT_FS_URI=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskRolesNumber }} && echo PAI_TASK_ROLE_COUNT=$PAI_TEMP >> $ENV_LIST

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -117,6 +117,7 @@ function get_host_list()
   for taskrole in $(echo $taskrole_statuses |  jq -r ".|keys[]"); do
     host_list=''
     while read container_ip && read container_ports && read task_index; do
+      echo PAI_HOST_IP_${taskrole}_${task_index}=${container_ip} >> $1
       host_list+=${container_ip}:$(echo $container_ports | grep -o "http:[^,;]*" | cut -f 2 -d":"),
       ssh_port=$(echo $container_ports | grep -o "ssh:[^,;]*" | cut -f 2 -d":")
       printf "%s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n" \
@@ -131,10 +132,14 @@ function get_host_list()
       for port in ${ports_arr[@]}; do
         IFS=':' read -r -a port_info <<< $port
         if [[ ${#port_info[@]} -ge 2 ]]; then
+          echo PAI_PORT_LIST_${taskrole}_${task_index}_${port_info[0]}=${port_info[1]} >> $1
+          # Backward compatibility
           echo PAI_${taskrole}_${task_index}_${port_info[0]}_PORT=${port_info[1]} >> $1
         fi
       done
     done < <(echo $taskrole_statuses | jq -r ".${taskrole}.taskStatuses.taskStatusArray[] | .containerIp, .containerPorts, .taskIndex")
+    echo PAI_TASK_ROLE_TASK_COUNT_${taskrole}=$(echo $taskrole_statuses | jq ".${taskrole}.taskStatuses.taskStatusArray[] | length") >> $1
+    # Backward compatibility
     host_list=$(echo $host_list | sed "s/,$//g")
     echo PAI_TASK_ROLE_${taskrole}_HOST_LIST=$host_list >> $1
   done
@@ -143,6 +148,7 @@ function get_host_list()
 # Prepare env file
 ENV_LIST=env.list
 
+# Yarn container environment variables
 echo APP_ID=$APP_ID >> $ENV_LIST
 echo FRAMEWORK_NAME=$FRAMEWORK_NAME >> $ENV_LIST
 echo HADOOP_USER_NAME=$HADOOP_USER_NAME >> $ENV_LIST
@@ -150,25 +156,21 @@ echo PAI_TASK_INDEX=$TASK_INDEX >> $ENV_LIST
 echo PAI_CONTAINER_HOST_IP=$CONTAINER_IP >> $ENV_LIST
 echo PAI_CONTAINER_HOST_PORT_LIST=$CONTAINER_PORTS >> $ENV_LIST
 echo PAI_CONTAINER_ID=$CONTAINER_ID >> $ENV_LIST
-PAI_TEMP={{ hdfsUri }} && echo PAI_DEFAULT_FS_URI=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ jobData.jobName }} && echo PAI_JOB_NAME=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ jobData.userName }} && echo PAI_USER_NAME=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ jobData.dataDir }} && echo PAI_DATA_DIR=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ jobData.outputDir }} && echo PAI_OUTPUT_DIR=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ jobData.codeDir }} && echo PAI_CODE_DIR=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.name }} && echo PAI_CURRENT_TASK_ROLE_NAME=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.taskNumber }} && echo PAI_CURRENT_TASK_ROLE_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.cpuNumber }} && echo PAI_CURRENT_TASK_ROLE_CPU_COUNT=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.memoryMB }} && echo PAI_CURRENT_TASK_ROLE_MEM_MB=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.shmMB }} && echo PAI_CURRENT_TASK_ROLE_SHM_MB=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.gpuNumber }} && echo PAI_CURRENT_TASK_ROLE_GPU_COUNT=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.minFailedTaskCount }} && echo PAI_CURRENT_TASK_ROLE_MIN_FAILED_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskData.minSucceededTaskCount }} && echo PAI_CURRENT_TASK_ROLE_MIN_SUCCEEDED_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
-echo PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX=$TASK_INDEX >> $ENV_LIST
-PAI_TEMP={{ tasksNumber }} && echo PAI_JOB_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskRolesNumber }} && echo PAI_JOB_TASK_ROLE_COUNT=$PAI_TEMP >> $ENV_LIST
-PAI_TEMP={{ taskRoleList }} && echo PAI_JOB_TASK_ROLE_LIST=$PAI_TEMP >> $ENV_LIST
 
+# PAI environment variables
+PAI_TEMP={{ jobData.jobName }} && echo PAI_JOB_NAME=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ jobData.virtualCluster }} && echo PAI_JOB_VC_NAME=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ jobData.userName }} && echo PAI_USER_NAME=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ hdfsUri }} && echo PAI_DEFAULT_FS_URI=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskRolesNumber }} && echo PAI_TASK_ROLE_COUNT=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskRoleList }} && echo PAI_TASK_ROLE_LIST=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.taskNumber }} && echo PAI_TASK_ROLE_TASK_COUNT_{{ taskData.name }}=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP="{{ taskData.gpuNumber }},{{ taskData.cpuNumber }},{{ taskData.memoryMB }},{{ taskData.shmMB }}" \
+  && echo PAI_RESOURCE=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.minFailedTaskCount }} && echo PAI_MIN_FAILED_TASK_COUNT_{{ taskData.name }}=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.minSucceededTaskCount }} && echo PAI_MIN_SUCCEEDED_TASK_COUNT_{{ taskData.name }}=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.name }} && echo PAI_CURRENT_TASK_ROLE_NAME=$PAI_TEMP >> $ENV_LIST
+echo PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX=$TASK_INDEX >> $ENV_LIST
 
 port_list=(${CONTAINER_PORTS//;/ })
 for ports in "${port_list[@]}"; do
@@ -187,15 +189,27 @@ echo \# Backward compatibility >> $ENV_LIST
 echo PAI_CURRENT_CONTAINER_IP=$CONTAINER_IP >> $ENV_LIST
 echo PAI_TASK_ROLE_INDEX=$TASK_INDEX >> $ENV_LIST
 PAI_TEMP={{ jobData.userName }} && echo PAI_USERNAME=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ jobData.dataDir }} && echo PAI_DATA_DIR=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ jobData.outputDir }} && echo PAI_OUTPUT_DIR=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ jobData.codeDir }} && echo PAI_CODE_DIR=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskData.name }} && echo PAI_TASK_ROLE_NAME=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskData.taskNumber }} && echo PAI_TASK_ROLE_NUM=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.taskNumber }} && echo PAI_CURRENT_TASK_ROLE_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskData.cpuNumber }} && echo PAI_TASK_CPU_NUM=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.cpuNumber }} && echo PAI_CURRENT_TASK_ROLE_CPU_COUNT=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskData.memoryMB }} && echo PAI_TASK_MEM_MB=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.memoryMB }} && echo PAI_CURRENT_TASK_ROLE_MEM_MB=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskData.gpuNumber }} && echo PAI_TASK_GPU_NUM=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.gpuNumber }} && echo PAI_CURRENT_TASK_ROLE_GPU_COUNT=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.shmMB }} && echo PAI_CURRENT_TASK_ROLE_SHM_MB=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.minFailedTaskCount }} && echo PAI_CURRENT_TASK_ROLE_MIN_FAILED_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskData.minSucceededTaskCount }} && echo PAI_CURRENT_TASK_ROLE_MIN_SUCCEEDED_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ tasksNumber }} && echo PAI_TASKS_NUM=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ tasksNumber }} && echo PAI_JOB_TASK_COUNT=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskRolesNumber }} && echo PAI_TASK_ROLES_NUM=$PAI_TEMP >> $ENV_LIST
+PAI_TEMP={{ taskRolesNumber }} && echo PAI_JOB_TASK_ROLE_COUNT=$PAI_TEMP >> $ENV_LIST
 PAI_TEMP={{ taskRoleList }} && echo PAI_TASK_ROLE_LIST=$PAI_TEMP >> $ENV_LIST
-
+PAI_TEMP={{ taskRoleList }} && echo PAI_JOB_TASK_ROLE_LIST=$PAI_TEMP >> $ENV_LIST
 echo PAI_CURRENT_CONTAINER_PORT="$(cut -f 1 -d"," <<< $PAI_CONTAINER_HOST_http_PORT_LIST)" >> $ENV_LIST
 
 export $(grep -v '^#' $ENV_LIST | xargs)


### PR DESCRIPTION
Unify PAI runtime environment variable names in docs and envfile.
Here's the exposed environment variable list:
- PAI_JOB_NAME
- PAI_JOB_VC_NAME
- PAI_USER_NAME
- PAI_DEFAULT_FS_URI
- PAI_TASK_ROLE_COUNT
- PAI_TASK_ROLE_LIST
- PAI_TASK_ROLE_TASK_COUNT\_`$taskrole`
- PAI_HOST_IP\_`$taskRole`\_`$taskIndex`
- PAI_PORT_LIST\_`$taskRole`\_`$taskIndex`\_`$portType`
- PAI_RESOURCE\_`$taskRole` 
- PAI_MIN_FAILED_TASK_COUNT\_`$taskRole`
- PAI_MIN_SUCCEEDED_TASK_COUNT\_`$taskRole`
- PAI_CURRENT_TASK_ROLE_NAME
- PAI_CURRENT_TASK_ROLE_CURRENT_TASK_INDEX
