### PR TITLE
Restrict vcname character in VC related API

### DIFF
--- a/src/rest-server/src/controllers/vc.js
+++ b/src/rest-server/src/controllers/vc.js
@@ -25,8 +25,7 @@ const createError = require('../util/error');
 const validate = (req, res, next, vcName) => {
   if (! /^[A-Za-z0-9_,]+$/.test(vcName)) {
     return next(createError('Bad Request', 'InvalidParametersError', 'VC name should only contain alpha-numeric and underscore characters'));
-  }
-  if (vcName === 'default' && req.method !== 'GET') {
+  } else if (vcName === 'default' && req.method !== 'GET') {
     return next(createError('Forbidden', 'ForbiddenUserError', `Update operation to default vc isn't allowed`));
   } else {
     return next();

--- a/src/rest-server/src/controllers/vc.js
+++ b/src/rest-server/src/controllers/vc.js
@@ -23,8 +23,8 @@ const createError = require('../util/error');
  * Validation, not allow operation to "default" vc.
  */
 const validate = (req, res, next, vcName) => {
-  if (! /^[A-Za-z0-9._~]+$/.test(vcName)) {
-    return next(createError('Bad Request', 'InvalidParametersError', 'VC name should only container letters, numbers and ._~'));
+  if (! /^[A-Za-z0-9_,]+$/.test(vcName)) {
+    return next(createError('Bad Request', 'InvalidParametersError', 'VC name should only contain alpha-numeric and underscore characters'));
   }
   if (vcName === 'default' && req.method !== 'GET') {
     return next(createError('Forbidden', 'ForbiddenUserError', `Update operation to default vc isn't allowed`));

--- a/src/rest-server/src/controllers/vc.js
+++ b/src/rest-server/src/controllers/vc.js
@@ -23,7 +23,7 @@ const createError = require('../util/error');
  * Validation, not allow operation to "default" vc.
  */
 const validate = (req, res, next, vcName) => {
-  if (! /^[A-Za-z0-9_,]+$/.test(vcName)) {
+  if (! /^[A-Za-z0-9_]+$/.test(vcName)) {
     return next(createError('Bad Request', 'InvalidParametersError', 'VC name should only contain alpha-numeric and underscore characters'));
   } else if (vcName === 'default' && req.method !== 'GET') {
     return next(createError('Forbidden', 'ForbiddenUserError', `Update operation to default vc isn't allowed`));

--- a/src/rest-server/src/controllers/vc.js
+++ b/src/rest-server/src/controllers/vc.js
@@ -23,6 +23,9 @@ const createError = require('../util/error');
  * Validation, not allow operation to "default" vc.
  */
 const validate = (req, res, next, vcName) => {
+  if (! /^[A-Za-z0-9._~]+$/.test(vcName)) {
+    return next(createError('Bad Request', 'InvalidParametersError', 'VC name should only container letters, numbers and ._~'));
+  }
   if (vcName === 'default' && req.method !== 'GET') {
     return next(createError('Forbidden', 'ForbiddenUserError', `Update operation to default vc isn't allowed`));
   } else {

--- a/src/rest-server/test/vc.js
+++ b/src/rest-server/test/vc.js
@@ -851,6 +851,25 @@ describe('VC API PUT /api/v1/virtual-clusters', () => {
       });
   });
 
+  it('[Negative] should not update vc if  vcname contains illegal character', (done) => {
+    nock.cleanAll();
+    nock(yarnUri)
+      .get('/ws/v1/cluster/scheduler')
+      .reply(200, yarnErrorResponse);
+
+    chai.request(server)
+      .put('/api/v1/virtual-clusters/aaa%20bbb')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        'vcCapacity': 80
+      })
+      .end((err, res) => {
+        expect(res, 'status code').to.have.status(400);
+        expect(res.body).to.have.property('code', 'InvalidParametersError');
+        done();
+      });
+  });
+
   it('[Negative] should not update vc if upstream error', (done) => {
     nock(yarnUri)
       .put('/ws/v1/cluster/scheduler-conf')


### PR DESCRIPTION
#2169 
YARN actually supports more kinds of characters such as space, but PAI doesn't.
This pr is to keep consistent with other PAI API.