### PR TITLE
Submit simple job plugin: add basic master-workers support.

### DIFF
--- a/contrib/submit-simple-job/package.json
+++ b/contrib/submit-simple-job/package.json
@@ -1,6 +1,6 @@
 {
   "name": "submit-simple-job",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PAI web portal plugin for submit simple job",
   "main": "index.tsx",
   "scripts": {


### PR DESCRIPTION
## Background ##

Per customer's requirement, Submit simple job web portal plugin should support MPI job, which basically includes two task roles: master & worker, which master task run the customized command as well as worker task just sleep infinitely.

## Design ##

Add a new job type "master-workers" job, when selected, a number input box for *workers count* is appeared. When a master-workers job is submitted, there will be 2 task roles generated:

- `master` task role: 1 task, assign 0 GPU, run the command provided by user.
- `worker` task role: *workers count* tasks, assign user filled GPU count, run `sleep inifinty` as command.

Besides, all other command pre-process are as previous, such as install dependencies, mount NFS, set environment variables.

This job type is:
- Conflict with HyperParameter training.
- Not conflict with enabling tensorboard.