### PR TITLE
[Job Debugging] If user command's exitcode is none zero, container will be reserved.

### DIFF
--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -444,6 +444,7 @@ class Job {
           'azRDMA': azureEnv.azRDMA === 'false' ? false : true,
           'paiMachineList': paiConfig.machineList,
           'reqAzRDMA': data.jobEnvs && data.jobEnvs.paiAzRDMA === true ? true : false,
+          'isDebug': data.jobEnvs && data.jobEnvs.isDebug === true ? true : false,
         });
     return dockerContainerScript;
   }

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -203,7 +203,7 @@ else
   user_command_exitcode=$?
   echo "job has finished with exit code $user_command_exitcode"
 {{# isDebug }}
-  if [[ $user_command_exitcode -ne 0 ]; then
+  if [[ $user_command_exitcode -ne 0 ]]; then
     echo "============================================================================="
     echo "======   The job container failed, so it will be reserved for 1 week   ======"
     echo "======          After debugging, please stop the job manually.         ======"

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -202,6 +202,11 @@ else
   wait $user_command_pid
   user_command_exitcode=$?
   echo "job has finished with exit code $user_command_exitcode"
+  if [[ $user_command_exitcode -ne 0 ]; then
+    echo "The job container failed, so it will be reserved for 1 week"
+    echo "After debugging, please stop the job manually."
+    sleep 604800
+  fi
   exit $user_command_exitcode
 fi
 

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -203,8 +203,10 @@ else
   user_command_exitcode=$?
   echo "job has finished with exit code $user_command_exitcode"
   if [[ $user_command_exitcode -ne 0 ]; then
-    echo "The job container failed, so it will be reserved for 1 week"
-    echo "After debugging, please stop the job manually."
+    echo "============================================================================="
+    echo "======   The job container failed, so it will be reserved for 1 week   ======"
+    echo "======          After debugging, please stop the job manually.         ======"
+    echo "============================================================================="
     sleep 604800
   fi
   exit $user_command_exitcode

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -202,6 +202,7 @@ else
   wait $user_command_pid
   user_command_exitcode=$?
   echo "job has finished with exit code $user_command_exitcode"
+{{# isDebug }}
   if [[ $user_command_exitcode -ne 0 ]; then
     echo "============================================================================="
     echo "======   The job container failed, so it will be reserved for 1 week   ======"
@@ -209,6 +210,7 @@ else
     echo "============================================================================="
     sleep 604800
   fi
+{{/ isDebug }}
   exit $user_command_exitcode
 fi
 


### PR DESCRIPTION
## Related Issue
#2213 
#2214 

## Design

When user submit the job, set the following property in the  jobEnv of jobConfig. If the job's user command fails, the container will be kept for 1 weeks. And user could debug the container after ssh to it. After debugging, user should manually stop it to recycle the system resources.

#### When submitting job from webportal:
![image](https://user-images.githubusercontent.com/8675883/53543182-be76d680-3b5c-11e9-873a-e99dc8c59801.png)

#### when submitting job from json file:
```
  "jobEnvs": {
    "isDebug": true
  }
```

#### When you job failed, click into the ```Go to Tracking Page``` and looking into the ```stdout```. You could find following log.
```
[INFO] USER COMMAND START

job has finished with exit code 2
=============================================================================
======   The job container failed, so it will be reserved for 1 week   ======
======          After debugging, please stop the job manually.         ======
=============================================================================
```
