### PR TITLE
Deploy: add explicit config field in webportal  plugin

### DIFF
--- a/docs/webportal/PLUGINS.md
+++ b/docs/webportal/PLUGINS.md
@@ -17,10 +17,13 @@ webportal:
   plugins:
   - title: Marketplace
     uri: /scripts/plugins/marketplace.bundle.js
+    config:
+      repo: Microsoft/pai
 ```
 
 - The `title` field is the title of the web portal plugin listed in the menu, it could be customized by administrators for the same plugin with different configurations.
 - The `uri` field is the entry file of the web portal plugin, usually previded by the plugin developer. It may be an absolute URL or a root-relative URL, as the different deploy type of the web portal plugin.
+- The `config` field is a key-value dictionary to configure the web portal plugin, available configs are listed in web portal plugin's specific document.
 
 In addition, you can also lock the plugin version if the uri refers the Internet, follow the [Publish](#publish) section to move the online web portal plugin to offline.
 
@@ -50,7 +53,7 @@ If any other PAI configuration is needed, please open an issue, PAI developers w
 
 ### Provide Plugin Configurations
 
-Ask system administration to set the query string of the entry file, like `http://example.com/github-plugin.js?repo=Microsoft%2Fpai`, `document.currentScript.src` would help you get the full uri of the script, including the query string.
+The config of the plugin will be set as the query string of the entry file, like `http://example.com/github-plugin.js?repo=Microsoft%2Fpai`, `document.currentScript.src` would help you get the full uri of the script, including the query string.
 
 ### Migrate Current AI Web Tools to PAI Web Portal Plugin
 

--- a/src/webportal/config/webportal.md
+++ b/src/webportal/config/webportal.md
@@ -20,6 +20,8 @@ webportal:
     server-port: new-value
 ```
 
+About config the web portal plugin, see [PLUGINS.md](../../../docs/webportal/PLUGINS.md)
+
 ## Generated Configuration <a name="G_Config"></a>
 
 After parsing, object model looks like:

--- a/src/webportal/config/webportal.py
+++ b/src/webportal/config/webportal.py
@@ -58,6 +58,7 @@ class Webportal:
         server_port = self.service_configuration['server-port']
         uri = 'http://{0}:{1}'.format(master_ip, server_port)
         plugins = self.service_configuration['plugins']
+        print plugins
         return {
             'server-port': server_port,
             'uri': uri,

--- a/src/webportal/config/webportal.py
+++ b/src/webportal/config/webportal.py
@@ -61,7 +61,7 @@ class Webportal:
         return {
             'server-port': server_port,
             'uri': uri,
-            'plugins': json.dumps(apply_config(plugin) for plugin in plugins),
+            'plugins': json.dumps([apply_config(plugin) for plugin in plugins]),
         }
 
     #### All service and main module (kubrenetes, machine) is generated. And in this check steps, you could refer to the service object model which you will used in your own service, and check its existence and correctness.

--- a/src/webportal/config/webportal.py
+++ b/src/webportal/config/webportal.py
@@ -16,6 +16,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import json
+import urllib
+import urlparse
 
 
 class Webportal:
@@ -40,6 +42,17 @@ class Webportal:
     def run(self):
         # parse your service object model here, and return a generated dictionary
 
+        def apply_config(plugin):
+            uri = plugin['uri']
+            if 'config' in plugin:
+                # Python 2 only uses urlquote_plus in urlencode
+                config_query = urllib.urlencode(plugin['config'], True).replace('+', '%20')
+                uri = urlparse.urljoin(uri, '?' + config_query)
+            return {
+                title: plugin['title'],
+                uri: uri,
+            }
+
         machine_list = self.cluster_configuration['machine-list']
         master_ip = [host['hostip'] for host in machine_list if host.get('pai-master') == 'true'][0]
         server_port = self.service_configuration['server-port']
@@ -48,7 +61,7 @@ class Webportal:
         return {
             'server-port': server_port,
             'uri': uri,
-            'plugins': json.dumps(plugins),
+            'plugins': json.dumps(apply_config(plugin) for plugin in plugins),
         }
 
     #### All service and main module (kubrenetes, machine) is generated. And in this check steps, you could refer to the service object model which you will used in your own service, and check its existence and correctness.

--- a/src/webportal/config/webportal.py
+++ b/src/webportal/config/webportal.py
@@ -49,8 +49,8 @@ class Webportal:
                 config_query = urllib.urlencode(plugin['config'], True).replace('+', '%20')
                 uri = urlparse.urljoin(uri, '?' + config_query)
             return {
-                title: plugin['title'],
-                uri: uri,
+                'title': plugin['title'],
+                'uri': uri,
             }
 
         machine_list = self.cluster_configuration['machine-list']
@@ -58,7 +58,6 @@ class Webportal:
         server_port = self.service_configuration['server-port']
         uri = 'http://{0}:{1}'.format(master_ip, server_port)
         plugins = self.service_configuration['plugins']
-        print plugins
         return {
             'server-port': server_port,
             'uri': uri,


### PR DESCRIPTION
Dependency of #2238

In `service-configuration.yaml`

Before:

```yaml
webportal:
  plugins:
  - title: Plugin Title
    uri: //example.com/plugin.js?foo=bar
```

After:

```yaml
webportal:
  plugins:
  - title: Plugin Title
    uri: //example.com/plugin.js
    config:
      foo: bar
```