### PR TITLE
Web portal submit job: support init json from sessionStorage.

### DIFF
--- a/src/webportal/src/app/job/job-submit/job-submit.component.js
+++ b/src/webportal/src/app/job/job-submit/job-submit.component.js
@@ -160,31 +160,41 @@ $(document).ready(() => {
       resize();
     };
     const query = url.parse(window.location.href, true).query;
+    const op = query.op;
     const type = query.type;
     const username = query.user;
     const jobname = query.jobname;
-    if (type != null && username != null && jobname != null) {
-      const url = username==''
-        ? `${webportalConfig.restServerUri}/api/v1/jobs/${jobname}/config`
-        : `${webportalConfig.restServerUri}/api/v1/user/${username}/jobs/${jobname}/config`;
-      $.ajax({
-        url: url,
-        type: 'GET',
-        success: (data) => {
-          let jobConfigObj = JSON.parse(data);
-          let timestamp = Date.now();
-          jobConfigObj.jobName += `_${timestamp}`;
-          editor.setValue(Object.assign({}, jobDefaultConfig, jobConfigObj));
-        },
-        error: (xhr, textStatus, error) => {
-          const res = JSON.parse(xhr.responseText);
-          if (res.message === 'ConfigFileNotFound') {
-            alert('This job\'s config file has not been stored.');
-          } else {
-            alert('Error: ' + res.message);
-          }
-        },
-      });
+    if (op === 'resubmit') {
+      if (type != null && username != null && jobname != null) {
+        const url = username==''
+          ? `${webportalConfig.restServerUri}/api/v1/jobs/${jobname}/config`
+          : `${webportalConfig.restServerUri}/api/v1/user/${username}/jobs/${jobname}/config`;
+        $.ajax({
+          url: url,
+          type: 'GET',
+          success: (data) => {
+            let jobConfigObj = JSON.parse(data);
+            let timestamp = Date.now();
+            jobConfigObj.jobName += `_${timestamp}`;
+            editor.setValue(Object.assign({}, jobDefaultConfig, jobConfigObj));
+          },
+          error: (xhr, textStatus, error) => {
+            const res = JSON.parse(xhr.responseText);
+            if (res.message === 'ConfigFileNotFound') {
+              alert('This job\'s config file has not been stored.');
+            } else {
+              alert('Error: ' + res.message);
+            }
+          },
+        });
+      }
+    } else if (op === 'init') {
+      try {
+        const jobConfigObj = JSON.parse(window.sessionStorage.getItem('init-job'));
+        editor.setValue(Object.assign({}, jobDefaultConfig, jobConfigObj));
+      } finally {
+        window.sessionStorage.removeItem('init-job');
+      }
     }
   });
 });


### PR DESCRIPTION
Dependency of #2238

Since the maximum length in address bar of browser will be (usually) 2000 chars, transfer the job JSON through url might be risky, so we choose sessionStorage

## Usage

1. Save the initial job JSON string by `window.sessionStorage.setItem('job-init', job)`
2. Navigate to `/submit.html?op=init`
3. The saved job JSON string will be automatically loaded from sessionStorage, than cleared.