### PR TITLE
Fix yarn container failed when docker container exited quickly.

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -290,7 +290,6 @@ docker pull {{ jobData.image }} \
 ## network consumption
 docker run --name $docker_name \
   --init \
-  --detach \
   --tty \
   --privileged=false \
   --oom-score-adj=1000 \
@@ -329,9 +328,3 @@ docker run --name $docker_name \
   --entrypoint="" \
    {{ jobData.image }} \
   /bin/bash '/pai/bootstrap/docker_bootstrap.sh'
-
-docker_pid=$(docker inspect --format "{{{ inspectPidFormat }}}" $docker_name)
-
-echo "Docker container pid is $docker_pid"
-
-docker attach --no-stdin $docker_name


### PR DESCRIPTION
Fixes Jenkins CI failed.

`docker_pid` was used for detect cgroup failed, which has been removed to make all OOM as user failed, 55.

Since Jenkins CI just runs `bash --version` as command, which usually be finished quickly, there is a bad case that the container exited before `docker attach` and will cause yarn failed.

This PR reverts this part.