### PR TITLE
fix external process error

### DIFF
--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -348,6 +348,7 @@ class GpuCollector(Collector):
             if len(info.pids) > 0:
                 pids_use_gpu[minor]= info.pids
 
+        logger.debug("pids_use_gpu is %s, zombie_info is %s", pids_use_gpu, zombie_info)
         if len(pids_use_gpu) > 0:
             if zombie_info is None:
                 zombie_info = []
@@ -355,6 +356,7 @@ class GpuCollector(Collector):
             for minor, pids in pids_use_gpu.items():
                 for pid in pids:
                     found, z_id = pid_to_cid_fn(pid)
+                    logger.debug("pid %s has found %s, z_id %s", pid, found, z_id)
                     if found:
                         if z_id in zombie_info:
                             # found corresponding container

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -176,19 +176,24 @@ class ResourceGauges(object):
 
 class AtomicRef(object):
     """ a thread safe way to store and get object,
-    should not modify data get from this ref """
-    def __init__(self):
+    should not modify data get from this ref,
+    each get and set method should provide a time obj,
+    so this ref decide whether the data is out of date or not,
+    return None on expired """
+    def __init__(self, decay_time):
         self.data = None
+        self.date_in_produced = datetime.datetime.now()
+        self.decay_time = decay_time
         self.lock = threading.RLock()
 
-    def get_and_set(self, new_data):
-        data = None
+    def set(self, data, now):
         with self.lock:
-            data, self.data = self.data, new_data
-        return data
+            self.data, self.date_in_produced = data, now
 
-    def get(self):
+    def get(self, now):
         with self.lock:
+            if self.date_in_produced + self.decay_time < now:
+                return None
             return self.data
 
 
@@ -220,7 +225,7 @@ class Collector(object):
             with self.collector_histogram.time():
                 self.iteration_counter.labels(name=self.name).inc()
                 try:
-                    self.atomic_ref.get_and_set(self.collect_impl())
+                    self.atomic_ref.set(self.collect_impl(), datetime.datetime.now())
                 except Exception as e:
                     logger.exception("%s collector get an exception", self.name)
 
@@ -235,17 +240,17 @@ class Collector(object):
         pass
 
 
-def instantiate_collector(name, sleep_time, collector_class, *args):
+def instantiate_collector(name, sleep_time, decay_time, collector_class, *args):
     """ test cases helper fn to instantiate a collector """
-    atomic_ref = AtomicRef()
+    atomic_ref = AtomicRef(decay_time)
     return atomic_ref, collector_class(name, sleep_time, atomic_ref, iteration_counter, *args)
 
 
-def make_collector(name, sleep_time, collector_class, *args):
+def make_collector(name, sleep_time, decay_time, collector_class, *args):
     """ other module should use this fn to init a collector, this fn start a thread
     to run the collector and return an atomic_ref so outside world can get metrics
     collected by this collector """
-    atomic_ref, instance = instantiate_collector(name, sleep_time, collector_class, *args)
+    atomic_ref, instance = instantiate_collector(name, sleep_time, decay_time, collector_class, *args)
 
     t = threading.Thread(
             target=instance.collect,
@@ -374,14 +379,14 @@ class GpuCollector(Collector):
             external_process, zombie_container]
 
     def collect_impl(self):
-        zombie_info = self.zombie_info_ref.get_and_set(None)
-
         gpu_info = nvidia.nvidia_smi(GpuCollector.cmd_histogram,
                 GpuCollector.cmd_timeout)
 
         logger.debug("get gpu_info %s", gpu_info)
 
-        self.gpu_info_ref.get_and_set(gpu_info)
+        now = datetime.datetime.now()
+        self.gpu_info_ref.set(gpu_info, now)
+        zombie_info = self.zombie_info_ref.get(now)
 
         if gpu_info is not None:
             return GpuCollector.convert_to_metrics(gpu_info, zombie_info,
@@ -452,13 +457,12 @@ class ContainerCollector(Collector):
                 ContainerCollector.iftop_histogram,
                 ContainerCollector.iftop_timeout)
 
-        # set it to None so if nvidia-smi hangs till next time we get,
-        # we will get None
-        gpu_infos = self.gpu_info_ref.get_and_set(None)
-
         stats_obj = docker_stats.stats(ContainerCollector.stats_histogram,
                 ContainerCollector.stats_timeout)
-        self.stats_info_ref.get_and_set(stats_obj)
+
+        now = datetime.datetime.now()
+        gpu_infos = self.gpu_info_ref.get(now)
+        self.stats_info_ref.set(stats_obj, now)
 
         logger.debug("all_conns is %s", all_conns)
         logger.debug("gpu_info is %s", gpu_infos)
@@ -721,9 +725,9 @@ class ZombieCollector(Collector):
     def collect_impl(self):
         # set it to None so if docker-stats hangs till next time we get,
         # we will get None
-        stats_info = self.stats_info_ref.get_and_set(None)
+        stats_info = self.stats_info_ref.get(datetime.datetime.now())
         all_zombies = self.update_zombie_count(stats_info)
-        self.zombie_ids_ref.get_and_set(all_zombies)
+        self.zombie_ids_ref.set(all_zombies, datetime.datetime.now())
 
 
 class ProcessCollector(Collector):

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -348,13 +348,17 @@ class GpuCollector(Collector):
             if len(info.pids) > 0:
                 pids_use_gpu[minor]= info.pids
 
-        if zombie_info is not None and len(zombie_info) > 0 and len(pids_use_gpu) > 0:
+        if len(pids_use_gpu) > 0:
+            if zombie_info is None:
+                zombie_info = []
+
             for minor, pids in pids_use_gpu.items():
                 for pid in pids:
                     found, z_id = pid_to_cid_fn(pid)
-                    if found and z_id in zombie_info:
-                        # found corresponding container
-                        zombie_container.add_metric([minor, z_id], 1)
+                    if found:
+                        if z_id in zombie_info:
+                            # found corresponding container
+                            zombie_container.add_metric([minor, z_id], 1)
                     else:
                         external_process.add_metric([minor, pid], 1)
             logger.warning("found gpu used by external %s, zombie container %s",

--- a/src/job-exporter/src/docker_stats.py
+++ b/src/job-exporter/src/docker_stats.py
@@ -87,7 +87,7 @@ def stats(histogram, timeout):
     try:
         result = utils.exec_cmd([
             "docker", "stats", "--no-stream", "--format",
-            "table {{.Container}},{{.Name}},{{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.MemPerc}}"],
+            "table {{.ID}},{{.Name}},{{.CPUPerc}},{{.MemUsage}},{{.NetIO}},{{.BlockIO}},{{.MemPerc}}"],
             histogram=histogram,
             timeout=timeout)
         return parse_docker_stats(result)

--- a/src/job-exporter/src/main.py
+++ b/src/job-exporter/src/main.py
@@ -8,6 +8,7 @@ import threading
 import signal
 import faulthandler
 import gc
+import datetime
 
 import prometheus_client
 from prometheus_client import Gauge
@@ -34,10 +35,10 @@ class CustomCollector(object):
     def collect(self):
         data = []
 
+        now = datetime.datetime.now()
+
         for ref in self.atomic_refs:
-            # set None to achieve
-            # https://github.com/Microsoft/pai/issues/1764#issuecomment-442733098
-            d = ref.get_and_set(None)
+            d = ref.get(now)
             if d is not None:
                 data.extend(d)
 
@@ -129,14 +130,16 @@ def main(args):
 
     configured_gpu_counter.set(get_gpu_count("/gpu-config/gpu-configuration.json"))
 
+    decay_time = datetime.timedelta(seconds=args.interval * 2)
+
     # used to exchange gpu info between GpuCollector and ContainerCollector
-    gpu_info_ref = collector.AtomicRef()
+    gpu_info_ref = collector.AtomicRef(decay_time)
 
     # used to exchange docker stats info between ContainerCollector and ZombieCollector
-    stats_info_ref = collector.AtomicRef()
+    stats_info_ref = collector.AtomicRef(decay_time)
 
     # used to exchange zombie info between GpuCollector and ZombieCollector
-    zombie_info_ref = collector.AtomicRef()
+    zombie_info_ref = collector.AtomicRef(decay_time)
 
     interval = args.interval
     # Because all collector except container_collector will spent little time in calling
@@ -144,12 +147,12 @@ def main(args):
     # scrape interval. The 99th latency of container_collector loop is around 20s, so it
     # should only sleep 10s to adapt to scrape interval
     collector_args = [
-            ("docker_daemon_collector", interval, collector.DockerCollector),
-            ("gpu_collector", interval / 2, collector.GpuCollector, gpu_info_ref, zombie_info_ref, args.threshold),
-            ("container_collector", interval - 18, collector.ContainerCollector,
+            ("docker_daemon_collector", interval, decay_time, collector.DockerCollector),
+            ("gpu_collector", interval, decay_time, collector.GpuCollector, gpu_info_ref, zombie_info_ref, args.threshold),
+            ("container_collector", max(0, interval - 18), decay_time, collector.ContainerCollector,
                 gpu_info_ref, stats_info_ref, args.interface),
-            ("zombie_collector", interval, collector.ZombieCollector, stats_info_ref, zombie_info_ref),
-            ("process_collector", interval, collector.ProcessCollector),
+            ("zombie_collector", interval, decay_time, collector.ZombieCollector, stats_info_ref, zombie_info_ref),
+            ("process_collector", interval, decay_time, collector.ProcessCollector),
             ]
 
     refs = list(map(lambda x: collector.make_collector(*x), collector_args))
@@ -168,7 +171,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--log", "-l", help="log dir to store log", default="/datastorage/prometheus")
     parser.add_argument("--port", "-p", help="port to expose metrics", default="9102")
-    parser.add_argument("--interval", "-i", help="prometheus scrape interval", type=int, default=30)
+    parser.add_argument("--interval", "-i", help="prometheus scrape interval second", type=int, default=30)
     parser.add_argument("--interface", "-n", help="network interface for job-exporter to listen on", required=True)
     parser.add_argument("--threshold", "-t", help="memory threshold to consider gpu memory leak", type=int, default=20 * 1024 * 1024)
     args = parser.parse_args()

--- a/src/job-exporter/test/test_collector.py
+++ b/src/job-exporter/test/test_collector.py
@@ -76,6 +76,7 @@ class TestDockerCollector(base.TestBase):
         _, c = collector.instantiate_collector(
                 "test_docker_collector1",
                 0.5,
+                datetime.timedelta(seconds=1),
                 collector.DockerCollector)
 
         self.assert_metrics(c.collect_impl())
@@ -86,11 +87,12 @@ class TestDockerCollector(base.TestBase):
         ref = collector.make_collector(
                 "test_docker_collector2",
                 0.5,
+                datetime.timedelta(seconds=1),
                 collector.DockerCollector)
 
         metrics = None
         for i in range(10):
-            metrics = ref.get()
+            metrics = ref.get(datetime.datetime.now())
             if metrics is not None:
                 break
             time.sleep(0.1)
@@ -107,12 +109,14 @@ class TestZombieCollector(base.TestBase):
         # in from name, we need to differentiate name using time.
         t = str(time.time()).replace(".", "_")
 
+        decay_time = datetime.timedelta(seconds=1)
         _, self.collector = collector.instantiate_collector(
                 "test_zombie_collector" + t,
-                0.5,
+                decay_time,
+                datetime.timedelta,
                 collector.ZombieCollector,
-                collector.AtomicRef(),
-                collector.AtomicRef())
+                collector.AtomicRef(decay_time),
+                collector.AtomicRef(decay_time))
 
     def test_update_zombie_count_type1(self):
         start = datetime.datetime.now()


### PR DESCRIPTION
Fix external process error.

If pid using gpu can not found container id, we deem it as external process, if it has container id, it is not. If its container id in zombie list, it is zombie using gpu