### PR TITLE
export vc/node related metrics from yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
       before_install:
         - cd src/yarn-exporter/test
       install:
-        - pip install prometheus_client
+        - pip install prometheus_client twisted
       script:
         - python3 -m unittest discover .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,15 @@ matrix:
         - python3 -m unittest discover .
 
     - language: python
+      python: 3.6
+      before_install:
+        - cd src/yarn-exporter/test
+      install:
+        - pip install prometheus_client
+      script:
+        - python3 -m unittest discover .
+
+    - language: python
       python: 2.7
       install:
         - pip install markdown==2.6.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
       before_install:
         - cd src/yarn-exporter/test
       install:
-        - pip install prometheus_client twisted
+        - pip install prometheus_client twisted requests
       script:
         - python3 -m unittest discover .
 

--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -83,7 +83,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "100 * sum(yarn_gpus_used) / sum(yarn_total_gpu_num)",
+              "expr": "100 * (sum(yarn_node_gpu_total) - sum(yarn_node_gpu_available)) / sum(yarn_node_gpu_total)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -321,7 +321,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg(yarn_gpus_used)",
+              "expr": "sum(yarn_node_gpu_total) - sum(yarn_node_gpu_available)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -400,7 +400,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(yarn_total_gpu_num)-sum(yarn_gpus_used)",
+              "expr": "sum(yarn_node_gpu_available)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,

--- a/src/yarn-exporter/src/yarn_exporter.py
+++ b/src/yarn-exporter/src/yarn_exporter.py
@@ -220,7 +220,7 @@ class YarnCollector(object):
 
         for node in nodes:
             total_node += 1
-            if node["state"] != "RUNNING":
+            if node["state"] not in {"RUNNING", "DECOMMISSIONING"}:
                 continue
             active_node += 1
 

--- a/src/yarn-exporter/src/yarn_exporter.py
+++ b/src/yarn-exporter/src/yarn_exporter.py
@@ -34,20 +34,78 @@ from twisted.internet import reactor
 
 ##### yarn-exporter will generate following metrics
 
-cluster_metrics_histogram = Histogram("yarn_api_cluster_metrics_latency_seconds",
-        "Resource latency for requesting yarn api /ws/v1/cluster/metrics")
+cluster_scheduler_histogram = Histogram("yarn_api_cluster_scheduler_latency_seconds",
+        "Resource latency for requesting yarn api /ws/v1/cluster/scheduler")
 
-def gen_total_gpu_count():
-    return GaugeMetricFamily("yarn_total_gpu_num", "count of total gpu number")
-
-def gen_used_gpu_count():
-    return GaugeMetricFamily("yarn_gpus_used", "count of allocated gpu by yarn")
-
-def gen_total_node_count():
-    return GaugeMetricFamily("yarn_nodes_all", "total node count in yarn")
+cluster_nodes_histogram = Histogram("yarn_api_cluster_nodes_latency_seconds",
+        "Resource latency for requesting yarn api /ws/v1/cluster/nodes")
 
 def gen_active_node_count():
     return GaugeMetricFamily("yarn_nodes_active", "active node count in yarn")
+
+def gen_queue_cpu_available():
+    return GaugeMetricFamily("yarn_queue_cpu_available", "available cpu in queue",
+            labels=["queue"])
+
+def gen_queue_cpu_cap():
+    return GaugeMetricFamily("yarn_queue_cpu_total", "total cpu in queue",
+            labels=["queue"])
+
+def gen_queue_mem_available():
+    return GaugeMetricFamily("yarn_queue_mem_available", "available mem in queue",
+            labels=["queue"])
+
+def gen_queue_mem_cap():
+    return GaugeMetricFamily("yarn_queue_mem_total", "total mem in queue",
+            labels=["queue"])
+
+def gen_queue_gpu_available():
+    return GaugeMetricFamily("yarn_queue_gpu_available", "available gpu in queue",
+            labels=["queue"])
+
+def gen_queue_gpu_cap():
+    return GaugeMetricFamily("yarn_queue_gpu_total", "total gpu in queue",
+            labels=["queue"])
+
+def gen_queue_running_jobs():
+    return GaugeMetricFamily("yarn_queue_running_job", "total running job count in queue",
+            labels=["queue"])
+
+def gen_queue_pending_jobs():
+    return GaugeMetricFamily("yarn_queue_pending_job", "total pending job count in queue",
+            labels=["queue"])
+
+def gen_queue_running_containers():
+    return GaugeMetricFamily("yarn_queue_running_container", "total running container count in queue",
+            labels=["queue"])
+
+def gen_queue_pending_containers():
+    return GaugeMetricFamily("yarn_queue_pending_container", "total pending container count in queue",
+            labels=["queue"])
+
+def gen_node_cpu_total():
+    return GaugeMetricFamily("yarn_node_cpu_total", "total cpu core in node",
+            labels=["node_ip"])
+
+def gen_node_cpu_available():
+    return GaugeMetricFamily("yarn_node_cpu_available", "available cpu core in node",
+            labels=["node_ip"])
+
+def gen_node_mem_total():
+    return GaugeMetricFamily("yarn_node_mem_total", "total mem in node",
+            labels=["node_ip"])
+
+def gen_node_mem_available():
+    return GaugeMetricFamily("yarn_node_mem_available", "available mem in node",
+            labels=["node_ip"])
+
+def gen_node_gpu_total():
+    return GaugeMetricFamily("yarn_node_gpu_total", "total gpu in node",
+            labels=["node_ip"])
+
+def gen_node_gpu_available():
+    return GaugeMetricFamily("yarn_node_gpu_available", "available gpu in node",
+            labels=["node_ip"])
 
 ##### yarn-exporter will generate above metrics
 
@@ -55,33 +113,140 @@ def request_with_histogram(url, histogram, *args, **kwargs):
     with histogram.time():
         return requests.get(url, *args, **kwargs)
 
+class ResourceItem(object):
+    def __init__(self, cpu=0, mem=0, gpu=0):
+        self.cpu = cpu
+        self.mem = mem
+        self.gpu = gpu
+
+
+class NodeCount(object):
+    def __init__(self, total=0, active=0):
+        self.total = total
+        self.active = active
+
 
 class YarnCollector(object):
     def __init__(self, yarn_url):
-        self.metric_url = urllib.parse.urljoin(yarn_url, "/ws/v1/cluster/metrics")
+        self.nodes_url = urllib.parse.urljoin(yarn_url, "/ws/v1/cluster/nodes")
+        self.scheduler_url = urllib.parse.urljoin(yarn_url, "/ws/v1/cluster/scheduler")
 
     def collect(self):
-        response = request_with_histogram(self.metric_url, cluster_metrics_histogram,
+        # nodes_url
+        response = request_with_histogram(self.nodes_url, cluster_nodes_histogram,
                 allow_redirects=True)
         response.raise_for_status()
-        metric = response.json()["clusterMetrics"]
 
-        total_gpu_num = gen_total_gpu_count()
-        total_gpu_num.add_metric([], metric["totalGPUs"])
-        yield total_gpu_num
+        total_resource = ResourceItem()
+        node_count = NodeCount()
 
-        gpus_used = gen_used_gpu_count()
-        gpus_used.add_metric([], metric["allocatedGPUs"])
-        yield gpus_used
-
-        nodes_all = gen_total_gpu_count()
-        nodes_all.add_metric([], metric["totalNodes"])
-        yield nodes_all
+        for metric in YarnCollector.gen_nodes_metrics(response.json(),
+                total_resource, node_count):
+            yield metric
 
         nodes_active = gen_active_node_count()
-        nodes_active.add_metric([], metric["activeNodes"])
+        nodes_active.add_metric([], node_count.active)
         yield nodes_active
 
+        # scheduler_url
+        response = request_with_histogram(self.scheduler_url, cluster_scheduler_histogram,
+                allow_redirects=True)
+        response.raise_for_status()
+        for metric in YarnCollector.gen_scheduler_metrics(response.json(), total_resource):
+            yield metric
+
+    @staticmethod
+    def gen_nodes_metrics(obj, total_resource, node_count):
+        nodes = obj["nodes"]["node"]
+
+        node_total_cpu = gen_node_cpu_total()
+        node_avail_cpu = gen_node_cpu_available()
+        node_total_mem = gen_node_mem_total()
+        node_avail_mem = gen_node_mem_available()
+        node_total_gpu = gen_node_gpu_total()
+        node_avail_gpu = gen_node_gpu_available()
+
+        total_cpu = total_mem = total_gpu = 0
+        avail_cpu = avail_mem = avail_gpu = 0
+        total_node = active_node = 0
+
+        for node in nodes:
+            total_node += 1
+            if node["state"] != "RUNNING":
+                continue
+            active_node += 1
+
+            total_cpu += node["usedVirtualCores"] + node["availableVirtualCores"]
+            avail_cpu += node["availableVirtualCores"]
+            total_mem += (node["usedMemoryMB"] + node["availMemoryMB"]) * 1024 * 1024
+            avail_mem += node["availMemoryMB"] * 1024 * 1024
+
+            ip = node["nodeHostName"]
+            node_total_cpu.add_metric([ip],
+                    node["usedVirtualCores"] + node["availableVirtualCores"])
+            node_avail_cpu.add_metric([ip], node["availableVirtualCores"])
+            node_total_mem.add_metric([ip],
+                    (node["availMemoryMB"] + node["usedMemoryMB"]) * 1024 * 1024)
+            node_avail_mem.add_metric([ip], node["availMemoryMB"] * 1024 * 1024)
+            if node.get("availableGPUs") is None and node.get("usedGPUs") is None:
+                continue
+
+            total_gpu += node["availableGPUs"] + node["usedGPUs"]
+            avail_gpu += node["availableGPUs"]
+
+            node_total_gpu.add_metric([ip], node["availableGPUs"] + node["usedGPUs"])
+            node_avail_gpu.add_metric([ip], node["availableGPUs"])
+
+        total_resource.cpu = total_cpu
+        total_resource.mem = total_mem
+        total_resource.gpu = total_gpu
+
+        node_count.total = total_node
+        node_count.active = active_node
+
+        return [node_total_cpu, node_avail_cpu,
+                node_total_mem, node_avail_mem,
+                node_total_gpu, node_avail_gpu]
+
+    @staticmethod
+    def gen_scheduler_metrics(obj, total_resource):
+        scheduler_info = obj["scheduler"]["schedulerInfo"]
+
+        cpu_cap = gen_queue_cpu_cap()
+        cpu_avail = gen_queue_cpu_available()
+        mem_cap = gen_queue_mem_cap()
+        mem_avail = gen_queue_mem_available()
+        gpu_cap = gen_queue_gpu_cap()
+        gpu_avail = gen_queue_gpu_available()
+
+        running_jobs = gen_queue_running_jobs()
+        pending_jobs = gen_queue_pending_jobs()
+        running_containers = gen_queue_running_containers()
+        pending_containers = gen_queue_pending_containers()
+
+        for queue in scheduler_info["queues"]["queue"]:
+            queue_name = queue["queueName"]
+            cap = queue["absoluteCapacity"] / 100.0
+            avail_cap = cap - queue["absoluteUsedCapacity"] / 100.0
+
+            cpu_cap.add_metric([queue_name], total_resource.cpu * cap)
+            mem_cap.add_metric([queue_name], total_resource.mem * cap)
+            gpu_cap.add_metric([queue_name], total_resource.gpu * cap)
+
+            cpu_avail.add_metric([queue_name], total_resource.cpu * cap - queue["resourcesUsed"]["vCores"])
+            mem_avail.add_metric([queue_name], total_resource.mem * cap - queue["resourcesUsed"]["memory"] * 1024 * 1024)
+            gpu_avail.add_metric([queue_name], total_resource.gpu * cap - queue["resourcesUsed"]["GPUs"])
+
+            running_jobs.add_metric([queue_name], queue["numActiveApplications"])
+            pending_jobs.add_metric([queue_name], queue["numPendingApplications"])
+            running_containers.add_metric([queue_name], queue["numContainers"])
+            pending_containers.add_metric([queue_name], queue["pendingContainers"])
+
+        return [cpu_cap, cpu_avail,
+                mem_cap, mem_avail,
+                gpu_cap, gpu_avail,
+                running_jobs, pending_jobs,
+                running_containers, pending_containers]
 
 class HealthResource(Resource):
     def render_GET(self, request):

--- a/src/yarn-exporter/test/base.py
+++ b/src/yarn-exporter/test/base.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import logging
+import unittest
+
+class TestBase(unittest.TestCase):
+    """
+    Test Base class for job-exporter
+    """
+    @classmethod
+    def setUpClass(cls):
+        logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",
+                level=logging.DEBUG)

--- a/src/yarn-exporter/test/data/empty_nodes
+++ b/src/yarn-exporter/test/data/empty_nodes
@@ -1,0 +1,1 @@
+{"nodes":null}

--- a/src/yarn-exporter/test/data/nodes
+++ b/src/yarn-exporter/test/data/nodes
@@ -1,0 +1,36 @@
+{
+  "nodes": {
+    "node": [
+      {
+        "rack": "/default-rack",
+        "state": "RUNNING",
+        "id": "10.151.40.4:8041",
+        "nodeHostName": "10.151.40.4",
+        "nodeHTTPAddress": "10.151.40.4:8042",
+        "lastHealthUpdate": 1551851216991,
+        "version": "2.9.0",
+        "healthReport": "",
+        "numContainers": 2,
+        "usedMemoryMB": 33792,
+        "availMemoryMB": 150528,
+        "usedVirtualCores": 9,
+        "availableVirtualCores": 15,
+        "numRunningOpportContainers": 0,
+        "usedMemoryOpportGB": 0,
+        "usedVirtualCoresOpport": 0,
+        "numQueuedContainers": 0,
+        "usedGPUs": 1,
+        "availableGPUs": 3,
+        "availableGPUAttribute": 14,
+        "resourceUtilization": {
+          "nodePhysicalMemoryMB": 45468,
+          "nodeVirtualMemoryMB": 45468,
+          "nodeCPUUsage": 2.6057980060577393,
+          "aggregatedContainersPhysicalMemoryMB": 437,
+          "aggregatedContainersVirtualMemoryMB": 2938,
+          "containersCPUUsage": 0.003000000026077032
+        }
+      }
+    ]
+  }
+}

--- a/src/yarn-exporter/test/data/scheduler
+++ b/src/yarn-exporter/test/data/scheduler
@@ -1,0 +1,223 @@
+{
+  "scheduler": {
+    "schedulerInfo": {
+      "type": "capacityScheduler",
+      "capacity": 100,
+      "usedCapacity": 37.5,
+      "maxCapacity": 100,
+      "queueName": "root",
+      "queues": {
+        "queue": [
+          {
+            "type": "capacitySchedulerLeafQueueInfo",
+            "capacity": 100,
+            "usedCapacity": 37.5,
+            "maxCapacity": 100,
+            "absoluteCapacity": 100,
+            "absoluteMaxCapacity": 100,
+            "absoluteUsedCapacity": 37.5,
+            "numApplications": 1,
+            "queueName": "default",
+            "state": "RUNNING",
+            "resourcesUsed": {
+              "memory": 33792,
+              "vCores": 9,
+              "GPUs": 1
+            },
+            "hideReservationQueues": false,
+            "nodeLabels": [
+              "*"
+            ],
+            "allocatedContainers": 2,
+            "reservedContainers": 0,
+            "pendingContainers": 0,
+            "capacities": {
+              "queueCapacitiesByPartition": [
+                {
+                  "partitionName": "",
+                  "capacity": 100,
+                  "usedCapacity": 37.5,
+                  "maxCapacity": 100,
+                  "absoluteCapacity": 100,
+                  "absoluteUsedCapacity": 37.5,
+                  "absoluteMaxCapacity": 100,
+                  "maxAMLimitPercentage": 100
+                }
+              ]
+            },
+            "resources": {
+              "resourceUsagesByPartition": [
+                {
+                  "partitionName": "",
+                  "used": {
+                    "memory": 33792,
+                    "vCores": 9,
+                    "GPUs": 1
+                  },
+                  "reserved": {
+                    "memory": 0,
+                    "vCores": 0,
+                    "GPUs": 0
+                  },
+                  "pending": {
+                    "memory": 0,
+                    "vCores": 0,
+                    "GPUs": 0
+                  },
+                  "amUsed": {
+                    "memory": 1024,
+                    "vCores": 1,
+                    "GPUs": 0
+                  },
+                  "amLimit": {
+                    "memory": 184320,
+                    "vCores": 24,
+                    "GPUs": 4
+                  }
+                }
+              ]
+            },
+            "numActiveApplications": 1,
+            "numPendingApplications": 0,
+            "numContainers": 2,
+            "maxApplications": 10000,
+            "maxApplicationsPerUser": 10000,
+            "userLimit": 100,
+            "users": {
+              "user": [
+                {
+                  "username": "admin",
+                  "resourcesUsed": {
+                    "memory": 33792,
+                    "vCores": 9,
+                    "GPUs": 1
+                  },
+                  "numPendingApplications": 0,
+                  "numActiveApplications": 1,
+                  "AMResourceUsed": {
+                    "memory": 1024,
+                    "vCores": 1,
+                    "GPUs": 0
+                  },
+                  "userResourceLimit": {
+                    "memory": 184320,
+                    "vCores": 24,
+                    "GPUs": 4
+                  },
+                  "resources": {
+                    "resourceUsagesByPartition": [
+                      {
+                        "partitionName": "",
+                        "used": {
+                          "memory": 33792,
+                          "vCores": 9,
+                          "GPUs": 1
+                        },
+                        "reserved": {
+                          "memory": 0,
+                          "vCores": 0,
+                          "GPUs": 0
+                        },
+                        "pending": {
+                          "memory": 0,
+                          "vCores": 0,
+                          "GPUs": 0
+                        },
+                        "amUsed": {
+                          "memory": 1024,
+                          "vCores": 1,
+                          "GPUs": 0
+                        },
+                        "amLimit": {
+                          "memory": 184320,
+                          "vCores": 24,
+                          "GPUs": 4
+                        }
+                      }
+                    ]
+                  },
+                  "userWeight": 1,
+                  "isActive": false
+                }
+              ]
+            },
+            "userLimitFactor": 100,
+            "AMResourceLimit": {
+              "memory": 184320,
+              "vCores": 24,
+              "GPUs": 4
+            },
+            "usedAMResource": {
+              "memory": 1024,
+              "vCores": 1,
+              "GPUs": 0
+            },
+            "userAMResourceLimit": {
+              "memory": 184320,
+              "vCores": 24,
+              "GPUs": 4
+            },
+            "preemptionDisabled": false,
+            "defaultPriority": 0
+          }
+        ]
+      },
+      "capacities": {
+        "queueCapacitiesByPartition": [
+          {
+            "partitionName": "",
+            "capacity": 100,
+            "usedCapacity": 37.5,
+            "maxCapacity": 100,
+            "absoluteCapacity": 100,
+            "absoluteUsedCapacity": 37.5,
+            "absoluteMaxCapacity": 100,
+            "maxAMLimitPercentage": 0
+          }
+        ]
+      },
+      "health": {
+        "lastrun": 1551851174745,
+        "operationsInfo": {
+          "entry": {
+            "key": "last-release",
+            "value": {
+              "nodeId": "10.151.40.4:8041",
+              "containerId": "container_e22_1551430067422_0465_01_000001",
+              "queue": "root.default"
+            }
+          }
+        },
+        "lastRunDetails": [
+          {
+            "operation": "releases",
+            "count": 0,
+            "resources": {
+              "memory": 0,
+              "vCores": 0,
+              "GPUs": 0
+            }
+          },
+          {
+            "operation": "allocations",
+            "count": 0,
+            "resources": {
+              "memory": 0,
+              "vCores": 0,
+              "GPUs": 0
+            }
+          },
+          {
+            "operation": "reservations",
+            "count": 0,
+            "resources": {
+              "memory": 0,
+              "vCores": 0,
+              "GPUs": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/yarn-exporter/test/test_collector.py
+++ b/src/yarn-exporter/test/test_collector.py
@@ -132,5 +132,13 @@ class TestYarnCollector(base.TestBase):
         self.assertEqual(1, len(metrics[9].samples))
         self.assertEqual(0, metrics[9].samples[0].value)
 
+    def test_gen_nodes_metrics_using_empty_nodes(self):
+        with open("data/empty_nodes") as f:
+            obj = json.loads(f.read())
+
+        total_resource = yarn_exporter.ResourceItem()
+        node_count = yarn_exporter.NodeCount()
+        metrics = YarnCollector.gen_nodes_metrics(obj, total_resource, node_count)
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/yarn-exporter/test/test_collector.py
+++ b/src/yarn-exporter/test/test_collector.py
@@ -1,0 +1,136 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import sys
+import unittest
+import logging
+import json
+
+import base
+
+sys.path.append(os.path.abspath("../src/"))
+
+import yarn_exporter
+from yarn_exporter import YarnCollector
+
+logger = logging.getLogger(__name__)
+
+class TestYarnCollector(base.TestBase):
+    """
+    Test YarnCollector in yarn_exporter.py
+    """
+
+    def test_gen_nodes_metrics(self):
+        with open("data/nodes") as f:
+            obj = json.loads(f.read())
+
+        total_resource = yarn_exporter.ResourceItem()
+        node_count = yarn_exporter.NodeCount()
+        metrics = YarnCollector.gen_nodes_metrics(obj, total_resource, node_count)
+
+        self.assertEqual(1, node_count.total)
+        self.assertEqual(1, node_count.active)
+
+        self.assertEqual(24, total_resource.cpu)
+        self.assertEqual(184320 * 1024 * 1024, total_resource.mem)
+        self.assertEqual(4, total_resource.gpu)
+
+        self.assertEqual(6, len(metrics))
+        # total cpu
+        self.assertEqual(1, len(metrics[0].samples))
+        self.assertEqual(24, metrics[0].samples[0].value)
+
+        # available cpu
+        self.assertEqual(1, len(metrics[1].samples))
+        self.assertEqual(15, metrics[1].samples[0].value)
+
+        # total mem
+        self.assertEqual(1, len(metrics[2].samples))
+        self.assertEqual(184320 * 1024 * 1024, metrics[2].samples[0].value)
+
+        # available mem
+        self.assertEqual(1, len(metrics[3].samples))
+        self.assertEqual(150528 * 1024 * 1024, metrics[3].samples[0].value)
+
+        # total gpu
+        self.assertEqual(1, len(metrics[4].samples))
+        self.assertEqual(4, metrics[4].samples[0].value)
+
+        # available gpu
+        self.assertEqual(1, len(metrics[5].samples))
+        self.assertEqual(3, metrics[5].samples[0].value)
+
+    def test_gen_scheduler_metrics(self):
+        with open("data/nodes") as f:
+            obj = json.loads(f.read())
+
+        total_resource = yarn_exporter.ResourceItem()
+        node_count = yarn_exporter.NodeCount()
+        YarnCollector.gen_nodes_metrics(obj, total_resource, node_count)
+
+        with open("data/scheduler") as f:
+            obj = json.loads(f.read())
+
+        metrics = YarnCollector.gen_scheduler_metrics(obj, total_resource)
+
+        self.assertEqual(10, len(metrics))
+
+        self.assertEqual(1, len(metrics[0].samples))
+
+        # queue cpu cap
+        self.assertEqual(1, len(metrics[0].samples))
+        self.assertEqual(24, metrics[0].samples[0].value)
+
+        # queue cpu available
+        self.assertEqual(1, len(metrics[1].samples))
+        self.assertEqual(15, metrics[1].samples[0].value)
+
+        # queue mem cap
+        self.assertEqual(1, len(metrics[2].samples))
+        self.assertEqual(184320 * 1024 * 1024, metrics[2].samples[0].value)
+
+        # queue mem available
+        self.assertEqual(1, len(metrics[3].samples))
+        self.assertEqual(150528 * 1024 * 1024, metrics[3].samples[0].value)
+
+        # queue gpu cap
+        self.assertEqual(1, len(metrics[4].samples))
+        self.assertEqual(4, metrics[4].samples[0].value)
+
+        # queue gpu available
+        self.assertEqual(1, len(metrics[5].samples))
+        self.assertEqual(3, metrics[5].samples[0].value)
+
+        # running jobs
+        self.assertEqual(1, len(metrics[6].samples))
+        self.assertEqual(1, metrics[6].samples[0].value)
+
+        # pending jobs
+        self.assertEqual(1, len(metrics[7].samples))
+        self.assertEqual(0, metrics[7].samples[0].value)
+
+        # running containers
+        self.assertEqual(1, len(metrics[8].samples))
+        self.assertEqual(2, metrics[8].samples[0].value)
+
+        # pending containers
+        self.assertEqual(1, len(metrics[9].samples))
+        self.assertEqual(0, metrics[9].samples[0].value)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
export following metrics:

* yarn_queue_cpu_available
* yarn_queue_cpu_total
* yarn_queue_mem_available
* yarn_queue_mem_total
* yarn_queue_gpu_available
* yarn_queue_gpu_total
* yarn_queue_running_job
* yarn_queue_pending_job
* yarn_queue_running_container
* yarn_queue_pending_container
* yarn_node_cpu_total
* yarn_node_cpu_available
* yarn_node_mem_total
* yarn_node_mem_available
* yarn_node_gpu_total
* yarn_node_gpu_available