### PR TITLE
Fix hadoop-run build error

### DIFF
--- a/docs/pai-management/doc/how-to-setup-dev-box.md
+++ b/docs/pai-management/doc/how-to-setup-dev-box.md
@@ -55,6 +55,7 @@ sudo docker run -itd \
         -e COLUMNS=$COLUMNS -e LINES=$LINES -e TERM=$TERM \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /pathConfiguration:/cluster-configuration  \
+        -v /hadoop-binary:/hadoop-binary  \
         --pid=host \
         --privileged=true \
         --net=host \
@@ -99,6 +100,7 @@ sudo docker run -itd \
         -e COLUMNS=$COLUMNS -e LINES=$LINES -e TERM=$TERM \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /pathConfiguration:/cluster-configuration  \
+        -v /hadoop-binary:/hadoop-binary  \
         --pid=host \
         --privileged=true \
         --net=host \

--- a/src/dev-box/dev-box-k8s-deploy.yaml
+++ b/src/dev-box/dev-box-k8s-deploy.yaml
@@ -15,6 +15,8 @@ spec:
     volumeMounts:
     - mountPath: /var/run/docker.sock
       name: docker-socket
+    - mountPath: /hadoop-binary
+      name: hadoop-binary-path
     name: dev-box
     command: [ "/bin/bash", "-c", "--" ]
     args: [ "while true; do sleep 3000; done;" ]
@@ -22,6 +24,9 @@ spec:
     - name: docker-socket
       hostPath:
         path: /var/run/docker.sock
+    - name: hadoop-binary-path
+      hostPath:
+        path: /hadoop-binary
   hostNetwork: true
   restartPolicy: Always
 


### PR DESCRIPTION
Related issue: #2021 #2293 

docker daemon volume is a host path. We should map it to devbox, then our code could retrive it.