### PR TITLE
increase threshold for CPU alert

### DIFF
--- a/src/prometheus/deploy/alerting/node.rules
+++ b/src/prometheus/deploy/alerting/node.rules
@@ -33,10 +33,10 @@ groups:
           summary: "Memory usage in {{$labels.instance}} is above 80% (current value is: {{ $value }})"
 
       - alert: NodeCPUUsage
-        expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 90
+        expr: (100 - (avg by (instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)) > 98
         for: 5m
         annotations:
-          summary: "CPU usage in {{$labels.instance}} is above 90% (current value is: {{ $value }})"
+          summary: "CPU usage in {{$labels.instance}} is above 98% (current value is: {{ $value }})"
 
       - alert: NodeDiskPressure
         expr: pai_node_count{disk_pressure="true"} > 1


### PR DESCRIPTION
increase threshold for CPU alert to 98%, as yarn currently do not reserve any CPU, so in heavy used cluster, yarn may allocate all CPU to tasks, and if tasks use CPU fully, it is easy for this alert to be triggered.

In a long term, we should reserve some CPU for system/service usage.