### PR TITLE
Support nvidia-container-runtime for gpu isolation

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -324,6 +324,7 @@ docker run --name $docker_name \
   --label PAI_JOB_VC_NAME={{ jobData.virtualCluster }} \
   --label PAI_USER_NAME={{ jobData.userName }} \
   --label PAI_CURRENT_TASK_ROLE_NAME={{ taskData.name }} \
+  --env NVIDIA_VISIBLE_DEVICES=$gpu_id \
   --env-file $ENV_LIST \
   --entrypoint="" \
    {{ jobData.image }} \


### PR DESCRIPTION
Support nvidia-container-runtime for gpu isolation.
Works for w/ and w/o `--runtime=nvidia`.

Fixes #1667, #2294.