### PR TITLE
enable hadoop web cross-origin and log web service

### DIFF
--- a/src/hadoop-jobhistory/deploy/hadoop-jobhistory-configuration/yarn-site.xml.template
+++ b/src/hadoop-jobhistory/deploy/hadoop-jobhistory-configuration/yarn-site.xml.template
@@ -110,7 +110,7 @@
 
     <property>
       <name>yarn.log.server.web-service.url</name>
-      <value>http://{LOGSERVER_ADDRESS}:8188/ws/v1/applicationhistory/logs</value>
+      <value>http://{LOGSERVER_ADDRESS}:8188/ws/v1/applicationhistory</value>
     </property>
 
     <property>

--- a/src/hadoop-jobhistory/deploy/hadoop-jobhistory-configuration/yarn-site.xml.template
+++ b/src/hadoop-jobhistory/deploy/hadoop-jobhistory-configuration/yarn-site.xml.template
@@ -109,6 +109,11 @@
     </property>
 
     <property>
+      <name>yarn.log.server.web-service.url</name>
+      <value>http://{LOGSERVER_ADDRESS}:8188/ws/v1/applicationhistory/logs</value>
+    </property>
+
+    <property>
       <name>yarn.nodemanager.recovery.dir</name>
       <value>/var/lib/yarn/yarn-nm-recovery</value>
     </property>

--- a/src/hadoop-jobhistory/deploy/hadoop-jobhistory-configuration/yarn-site.xml.template
+++ b/src/hadoop-jobhistory/deploy/hadoop-jobhistory-configuration/yarn-site.xml.template
@@ -183,10 +183,19 @@
         <value>true</value>
    </property>
 
-    <property>
-        <name>yarn.timeline-service.http-cross-origin.enabled</name>
-        <value>true</value>
-    </property>
+  <property>
+    <name>yarn.timeline-service.http-cross-origin.enabled</name>
+    <value>true</value>
+  </property>
 
+  <property>
+    <name>yarn.resourcemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
 
 </configuration>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/core-site.xml
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/core-site.xml
@@ -36,6 +36,17 @@
 </property>
 
     <property>
+        <name>hadoop.http.cross-origin.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hadoop.http.filter.initializers</name>
+        <value>org.apache.hadoop.security.HttpCrossOriginFilterInitializer</value>
+    </property>
+
+
+    <property>
         <name>ipc.server.max.response.size</name>
         <value>5242880</value>
     </property>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -132,7 +132,7 @@
 
     <property>
       <name>yarn.log.server.web-service.url</name>
-      <value>http://{LOGSERVER_ADDRESS}:8188/ws/v1/applicationhistory/logs</value>
+      <value>http://{LOGSERVER_ADDRESS}:8188/ws/v1/applicationhistory</value>
     </property>
     
     <property>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -284,6 +284,21 @@
   </property>
 
   <property>
+    <name>yarn.timeline-service.http-cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <description>
     The duration (in ms) the YARN client waits for an expected state change
     to occur.  -1 means unlimited wait time.

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -129,6 +129,11 @@
       <name>yarn.log.server.url</name>
       <value>http://{LOGSERVER_ADDRESS}:8188/applicationhistory/logs</value>
     </property>
+
+    <property>
+      <name>yarn.log.server.web-service.url</name>
+      <value>http://{LOGSERVER_ADDRESS}:8188/ws/v1/applicationhistory/logs</value>
+    </property>
     
     <property>
       <name>yarn.nodemanager.recovery.enabled</name>
@@ -297,6 +302,8 @@
     <name>yarn.nodemanager.webapp.cross-origin.enabled</name>
     <value>true</value>
   </property>
+
+
 
   <property>
     <description>

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -303,8 +303,6 @@
     <value>true</value>
   </property>
 
-
-
   <property>
     <description>
     The duration (in ms) the YARN client waits for an expected state change

--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager-configuration/yarn-site.xml.template
@@ -248,6 +248,21 @@
   </property>
 
   <property>
+    <name>yarn.timeline-service.http-cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.resourcemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>yarn.nodemanager.webapp.cross-origin.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <description>
     The duration (in ms) the YARN client waits for an expected state change
     to occur.  -1 means unlimited wait time.


### PR DESCRIPTION
Before this PR, other service could only get a html page with embeded log.

With this PR, other service could get plain-text job log and customize their own UI.
log api at
```
[running job] http://{worker_ip}:8042/ws/v1/node/containers/{container_id}/logs/stdout

[completed job] http://{master_ip}:8188/ws/v1/applicationhistory/containers/{container_id}/logs/stdout?redirected_from_node=true
