### PR TITLE
[Rest API] Add task state; Add job's retry details; Refine job config

### DIFF
--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -440,10 +440,16 @@ Status: 200
     createdTime: "createdTimestamp",
     completedTime: "completedTimestamp",
     executionType: "executionType",
-    // Sum of succeededRetriedCount, transientNormalRetriedCount,
-    // transientConflictRetriedCount, nonTransientRetriedCount,
-    // and unKnownRetriedCount
-    retries: retriedCount,
+    // sum of retries
+    retries: retries,
+    retryDetails: {
+      // Failed caused by user's code
+      user: userRetries,
+      // System failed, and it can ensure that it will success within a finite retry times
+      system: systemRetries,
+      // System cannot get required resource to run.
+      resource: resourceRetries,
+    },
     appId: "applicationId",
     appProgress: "applicationProgress",
     appTrackingUrl: "applicationTrackingUrl",
@@ -461,6 +467,7 @@ Status: 200
       },
       taskStatuses: {
         taskIndex: taskIndex,
+        taskState: taskState,
         containerId: "containerId",
         containerIp: "containerIp",
         containerPorts: {

--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -445,8 +445,8 @@ Status: 200
     retryDetails: {
       // Job failed due to user or unknown error
       user: userRetries,
-      // Job failed due to system/plaform error
-      system: systemRetries,
+      // Job failed due to platform error
+      platform: platformRetries,
       // Job cannot get required resource to run within timeout
       resource: resourceRetries,
     },

--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -443,11 +443,11 @@ Status: 200
     // sum of retries
     retries: retries,
     retryDetails: {
-      // Failed caused by user's code
+      // Job cannot get required resource to run within timeout
       user: userRetries,
-      // System failed, and it can ensure that it will success within a finite retry times
+      // Job failed due to system/plaform error
       system: systemRetries,
-      // System cannot get required resource to run.
+      // Job failed due to user or unknown error
       resource: resourceRetries,
     },
     appId: "applicationId",

--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -443,11 +443,11 @@ Status: 200
     // sum of retries
     retries: retries,
     retryDetails: {
-      // Job cannot get required resource to run within timeout
+      // Job failed due to user or unknown error
       user: userRetries,
       // Job failed due to system/plaform error
       system: systemRetries,
-      // Job failed due to user or unknown error
+      // Job cannot get required resource to run within timeout
       resource: resourceRetries,
     },
     appId: "applicationId",

--- a/src/rest-server/src/controllers/job.js
+++ b/src/rest-server/src/controllers/job.js
@@ -16,6 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // module dependencies
+const yaml = require('js-yaml');
 const Job = require('../models/job');
 const createError = require('../util/error');
 const logger = require('../config/logger');
@@ -149,8 +150,10 @@ const getConfig = (req, res, next) => {
     req.job.name,
     (error, result) => {
       if (!error) {
-        // result maybe json or yaml, depends on the job type user submitted.
-        return typeof(result) == 'string' ? res.status(200).json(result) : res.status(200).send(result).type('yaml');
+        const data = yaml.safeLoad(result);
+        const type = req.accepts(['json', 'yaml']) || 'json';
+        const body = type === 'json' ? JSON.stringify(data) : yaml.safeDump(data);
+        return res.status(200).send(body).type(type);
       } else if (error.message.startsWith('[WebHDFS] 404')) {
         return next(createError('Not Found', 'NoJobConfigError', `Config of job ${req.job.name} is not found.`));
       } else {

--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -119,7 +119,7 @@ class Job {
             //    and cannot get required resource to run.
             // 3. unKnownRetriedCount
             //    Usually caused by user's code.
-            const systemRetries = frameworkInfo.frameworkRetryPolicyState.transientNormalRetriedCount;
+            const platformRetries = frameworkInfo.frameworkRetryPolicyState.transientNormalRetriedCount;
             const resourceRetries = frameworkInfo.frameworkRetryPolicyState.transientConflictRetriedCount;
             const userRetries = frameworkInfo.frameworkRetryPolicyState.unKnownRetriedCount;
             const job = {
@@ -128,10 +128,10 @@ class Job {
               state: this.convertJobState(frameworkInfo.frameworkState, frameworkInfo.applicationExitCode),
               subState: frameworkInfo.frameworkState,
               executionType: frameworkInfo.executionType,
-              retries: systemRetries + resourceRetries + userRetries,
+              retries: platformRetries + resourceRetries + userRetries,
               retryDetails: {
                 user: userRetries,
-                system: systemRetries,
+                platform: platformRetries,
                 resource: resourceRetries,
               },
               createdTime: frameworkInfo.firstRequestTimestamp || new Date(2018, 1, 1).getTime(),
@@ -368,7 +368,7 @@ class Job {
         frameworkStatus.applicationExitCode,
       );
 
-      const systemRetries = frameworkStatus.frameworkRetryPolicyState.transientNormalRetriedCount;
+      const platformRetries = frameworkStatus.frameworkRetryPolicyState.transientNormalRetriedCount;
       const resourceRetries = frameworkStatus.frameworkRetryPolicyState.transientConflictRetriedCount;
       const userRetries = frameworkStatus.frameworkRetryPolicyState.unKnownRetriedCount;
       jobDetail.jobStatus = {
@@ -377,10 +377,10 @@ class Job {
         state: jobState,
         subState: frameworkStatus.frameworkState,
         executionType: framework.summarizedFrameworkInfo.executionType,
-        retries: systemRetries + resourceRetries + userRetries,
+        retries: platformRetries + resourceRetries + userRetries,
         retryDetails: {
           user: userRetries,
-          system: systemRetries,
+          platform: platformRetries,
           resource: resourceRetries,
         },
         createdTime: frameworkStatus.frameworkCreatedTimestamp,

--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -59,9 +59,9 @@ class Job {
         jobState = 'RUNNING';
         break;
       case 'FRAMEWORK_COMPLETED':
-        if (typeof exitCode !== 'undefined' && parseInt(exitCode) === 0) {
+        if (exitCode === 0) {
           jobState = 'SUCCEEDED';
-        } else if (typeof exitCode !== 'undefined' && parseInt(exitCode) == 214) {
+        } else if (exitCode === 214) {
           jobState = 'STOPPED';
         } else {
           jobState = 'FAILED';
@@ -83,7 +83,7 @@ class Job {
       case 'CONTAINER_RUNNING':
         return 'RUNNING';
       case 'TASK_COMPLETED':
-        if (typeof exitCode !== 'undefined' && parseInt(exitCode) === 0) {
+        if (exitCode === 0) {
           return 'SUCCEEDED';
         } else {
           return 'FAILED';


### PR DESCRIPTION
- add task state field
- add job's retry details field
- refine job config api
    - use request's Accept header to determine whether json or yaml will be sent.
    - BREAK CHANGE: fix the bug that old job config api may return an escaped json string instead of a json object