### PR TITLE
[HOT-FIX] Set the qucik-start template image tag to v0.10.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ ls $CONFIG_PATH/
 rm -rf $CONFIG_PATH/*.yaml
 ./paictl.py config generate -i ${QUICK_START_PATH}/quick-start.yaml -o $CONFIG_PATH
 # update image tag
-sed -i "s/tag: latest/tag: ${IMAGE_TAG}/" ${CONFIG_PATH}/services-configuration.yaml
+sed -i "/^    tag: /c\\    tag: ${IMAGE_TAG}" ${CONFIG_PATH}/services-configuration.yaml
 # setup registry
 $JENKINS_HOME/scripts/setup_azure_int_registry_new_com.sh $CONFIG_PATH
 # build images
@@ -146,7 +146,7 @@ cd /pai
 # Step 1. Generate config
 ./paictl.py config generate -i /quick-start/quick-start.yaml -o /cluster-configuration
 # update image tag
-sed -i "s/tag: latest/tag: ${IMAGE_TAG}/" /cluster-configuration/services-configuration.yaml
+sed -i "/^    tag: /c\\    tag: ${IMAGE_TAG}" /cluster-configuration/services-configuration.yaml
 # setup registry
 /jenkins/scripts/setup_azure_int_registry_new_com.sh /cluster-configuration
 
@@ -236,7 +236,7 @@ cd /pai
 # Step 1. Generate config
 ./paictl.py config generate -i /quick-start/quick-start.yaml -o /cluster-configuration
 # update image tag
-sed -i "s/tag: latest/tag: ${IMAGE_TAG}/" /cluster-configuration/services-configuration.yaml
+sed -i "/^    tag: /c\\    tag: ${IMAGE_TAG}" /cluster-configuration/services-configuration.yaml
 # setup registry
 /jenkins/scripts/setup_azure_int_registry_new_com.sh /cluster-configuration
 

--- a/deployment/quick-start/services-configuration.yaml.template
+++ b/deployment/quick-start/services-configuration.yaml.template
@@ -37,7 +37,7 @@ cluster:
     #username: <username>
     #password: <password>
 
-    tag: latest
+    tag: v0.10.1
 
     # The name of the secret in kubernetes will be created in your cluster
     # Must be lower case, e.g., regsecret.


### PR DESCRIPTION
Here's the case:

1. When user install, the `latest` was v0.9.
2. Somehow one service, for example rest-server, restart. Kubernetes would try to using the `latest` image, which is v0.10.

So we should fix the quick-start template tag to the currently release.
In this case, it should be v0.10.1.