### PR TITLE
[Rest Server] Support samba shares in container

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -294,6 +294,7 @@ docker run --name $docker_name \
   --privileged=false \
   --oom-score-adj=1000 \
   --cap-add=SYS_ADMIN \
+  --cap-add=DAC_READ_SEARCH \
   --network=host \
   --cpus={{ taskData.cpuNumber }} \
   --memory={{ taskData.memoryMB }}m \


### PR DESCRIPTION
Support samba shares in container, add `DAC_READ_SEARCH` cap in `docker run`.

Closes #2227.