### PR TITLE
Query unhealthy GPU from prometheus

### DIFF
--- a/docs/tools/node_maintain.md
+++ b/docs/tools/node_maintain.md
@@ -4,7 +4,8 @@
 
 This [tool](../../src/tools/node_maintain.py) help you to gracefully decommission unhealthy nodes in OpenPAI. 
 
-**NOTES: This tool should be invoked in the dev-box, under `{PAI_ROOT_DIR}/src/tools`. For now, it only supports decommissioning YARN nodes.**
+**NOTES: This tool should be invoked in the dev-box, under `{PAI_ROOT_DIR}/src/tools`. For now, it only supports decommissioning YARN nodes.
+HDFS decommissioning might be added in the future.**
 
 ## Commands
 
@@ -15,6 +16,8 @@ python node_maintain.py {object} {action} {arguments}
 ```
 
 ### Get current unhealthy GPU nodes
+
+PAI monitors gpu healthiness and aggregate them in prometheus. You could query the bad GPUs from it in some ways:
 
 ###### 1. Query prometheus by this tool
 ```bash

--- a/docs/tools/node_maintain.md
+++ b/docs/tools/node_maintain.md
@@ -4,7 +4,7 @@
 
 This [tool](../../src/tools/node_maintain.py) help you to gracefully decommission unhealthy nodes in OpenPAI. 
 
-**NOTES: This tool should be involved in the dev-box, under `{PAI_ROOT_DIR}/src/tools`. For now, it only supports decommissioning YARN nodes.**
+**NOTES: This tool should be invoked in the dev-box, under `{PAI_ROOT_DIR}/src/tools`. For now, it only supports decommissioning YARN nodes.**
 
 ## Commands
 

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -243,7 +243,7 @@ def setup_parser():
     # a parent parser to avoid repeatedly add arguments for all subcommands
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument("-m", "--master", dest="master_ip",
-                               help="master node ip, by default it's 127.0.0.1", required=True)
+                               help="master node ip", required=True)
     parent_parser.add_argument("--resource-manager-ip",
                                help="specify yarn resource manager ip separately, by default it's master node ip")
     parent_parser.add_argument("--api-server-ip",
@@ -260,7 +260,7 @@ def setup_parser():
     parser_get = prometheus_subparsers.add_parser("get", parents=[parent_parser], help="print current gpu alerts")
     parser_get.set_defaults(func=get_gpu_alert)
 
-    # node list parser
+    # blacklist parser
     blacklist_parser = sub_parser.add_parser("blacklist", help="blacklist operation")
     blacklist_subparsers = blacklist_parser.add_subparsers(dest="action")
 
@@ -298,3 +298,4 @@ def main():
 if __name__ == "__main__":
     logger = setup_logger()
     main()
+    

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -103,7 +103,7 @@ class YarnOperator(object):
 
 
 class AlertOperator(object):
-    GPU_alert_name = ["NvidiaSmiLatencyTooLarge", "NvidiaMemoryLeak", "NvidiaZombieProcess", "GpuUsedByExternalProcess"]
+    GPU_alert_name = ["NvidiaSmiLatencyTooLarge", "NvidiaSmiEccError", "NvidiaMemoryLeak", "NvidiaZombieProcess", "GpuUsedByExternalProcess", "GpuUsedByZombieContainer"]
 
     def __init__(self, prometheus_ip, prometheus_port=9091):
         self.master_ip = prometheus_ip

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -144,7 +144,7 @@ def get_unready_nodes(decommissioned_nodes, current_status):
         if state not in {"DECOMMISSIONED"} and node in decommissioned_nodes:
             unready_nodes[node] = state
         # should recommission but not
-        if state in {"DECOMMISSIONED"} and node not in decommissioned_nodes:
+        if state in {"DECOMMISSIONED", "DECOMMISSIONING"} and node not in decommissioned_nodes:
             unready_nodes[node] = state
     return unready_nodes
 

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -162,13 +162,13 @@ def get_unready_nodes(decommissioned_nodes, current_status):
 def get_gpu_alert(args):
     alert_operator = AlertOperator(args.prometheus_ip, args.prometheus_port)
     alerting_nodes = alert_operator.get_gpu_alert_nodes()
-    logger.info("Current gpu alerting nodes: {}".format(alerting_nodes))
+    logger.info("Current gpu alerts: {}".format(alerting_nodes))
 
 
 def get_decommission_nodes(args):
     k8s_operator = KubernetesOperator(args.api_server_ip)
     existing_nodes = k8s_operator.get_nodes()
-    logger.info("Current unhealthy node list: {}".format(','.join(existing_nodes)))
+    logger.info("Current configmap node list: {}".format(','.join(existing_nodes)))
     return existing_nodes
 
 
@@ -180,7 +180,7 @@ def add_decommission_nodes(args):
         nodes = set(nodes.split(','))
     full_list = existing_nodes | nodes
     k8s_operator.set_nodes(full_list)
-    logger.info("Add node: {}".format(args.nodes))
+    logger.info("Add node: {} to configmap".format(args.nodes))
     return full_list
 
 
@@ -192,7 +192,7 @@ def remove_decommission_nodes(args):
         nodes = set(nodes.split(','))
     full_list = existing_nodes - nodes
     k8s_operator.set_nodes(full_list)
-    logger.info("Remove node: {}".format(args.nodes))
+    logger.info("Remove node: {} from configmap".format(args.nodes))
     return full_list
 
 
@@ -202,7 +202,7 @@ def update_decommission_nodes(args):
     if isinstance(nodes, str):
         nodes = set(nodes.split(','))
     k8s_operator.set_nodes(nodes)
-    logger.info("Update node list: {}".format(args.nodes))
+    logger.info("Update configmap node list: {}".format(args.nodes))
     return nodes
 
 
@@ -216,7 +216,7 @@ def refresh_yarn_nodes(args):
         unready_nodes = get_unready_nodes(decommissioned_nodes, current_status)
         if len(unready_nodes) == 0:
             break
-        logger.info("Unready nodes: {}. waiting...".format(unready_nodes))
+        logger.info("Unready nodes: {}. Waiting...".format(unready_nodes))
         time.sleep(30)
     logger.info("Successfully refresh nodes.")
 

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -55,7 +55,7 @@ class KubernetesOperator(object):
         data_dict = {self.configmap_data_key: nodes_str}
         update_configmap(self.kube_config_path, self.configmap_name, data_dict)
 
-class TestKubernetesOperator(unittest.Testcase):
+class TestKubernetesOperator(unittest.TestCase):
     def test_get_multiple_nodes(self):
         pass
 

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -298,4 +298,3 @@ def main():
 if __name__ == "__main__":
     logger = setup_logger()
     main()
-    

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -102,6 +102,34 @@ class YarnOperator(object):
             logger.error(e.output)
 
 
+class AlertOperator(object):
+
+    def __init__(self, alert_manager_ip, alert_manager_port=9093):
+        self.master_ip = alert_manager_ip
+        self.master_port = alert_manager_port
+        self.alert_manager_url = "http://{}:{}/alert-manager/api/v1/alerts".format(alert_manager_ip, alert_manager_port)
+
+    def get_alert_nodes(self):
+        try:
+            response = requests.get(self.alert_manager_url)
+        except Exception as e:
+            logger.exception(e)
+            sys.exit(1)
+
+        if response.status_code != requests.codes.ok or response.json()["status"] != "success":
+            logger.error("Response error: {}".format(response.text))
+            sys.exit(1)
+        nodes_info = response.json()["data"]
+        current_nodes = {}
+        pass
+
+    def decommission_nodes(self):
+        try:
+            subprocess.check_output(self.update_command, stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError as e:
+            logger.error(e.output)
+
+
 def get_unready_nodes(decommissioned_nodes, current_status):
     unready_nodes = {}
     for node, state in current_status.iteritems():

--- a/src/tools/node_maintain.py
+++ b/src/tools/node_maintain.py
@@ -5,6 +5,7 @@ import sys
 import argparse
 import time
 import subprocess
+import unittest
 
 sys.path.append("../..")
 from deployment.paiLibrary.common.kubernetes_handler import get_configmap, update_configmap
@@ -53,6 +54,18 @@ class KubernetesOperator(object):
         nodes_str = '\n'.join(nodes)
         data_dict = {self.configmap_data_key: nodes_str}
         update_configmap(self.kube_config_path, self.configmap_name, data_dict)
+
+class TestKubernetesOperator(unittest.Testcase):
+    def test_get_multiple_nodes(self):
+        pass
+
+    def test_get_single_node(self):
+        pass
+
+    def test_get_empty_node(self):
+        pass
+
+
 
 
 class YarnOperator(object):


### PR DESCRIPTION
A part of #2192

After #2209, unhealthy gpu info will be collected by prometheus. This PR provides following operation guide after alerting.

In our design, admin need to do:
1. Query prometheus, collect unhealthy nodes.
2. Add unhealthy nodes to blacklist.
3. Enforce service to reload the blacklist.

More details in https://github.com/Microsoft/pai/blob/8b186958f9ed55c4c0fac157977f58f9b56adc8c/docs/tools/node_maintain.md