### PR TITLE
map gpu in kube tasks

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-jobview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-jobview-dashboard.json.template
@@ -91,7 +91,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME)(task_cpu_percent{container_label_PAI_JOB_NAME=~\"$job\"}) ",
+              "expr": "avg by (job_name)(task_cpu_percent{job_name=~\"$job\"}) ",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
@@ -190,7 +190,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (task_mem_usage_byte{ container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name) (task_mem_usage_byte{ job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -281,7 +281,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (task_net_in_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name) (task_net_in_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -292,7 +292,7 @@
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (task_net_out_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name) (task_net_out_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -388,7 +388,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (irate(task_block_in_byte{ container_label_PAI_JOB_NAME=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name) (irate(task_block_in_byte{ job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -399,7 +399,7 @@
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (irate(task_block_out_byte{ container_label_PAI_JOB_NAME=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name) (irate(task_block_out_byte{ job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Disk Write",
@@ -478,7 +478,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME)(task_gpu_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name)(task_gpu_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -560,7 +560,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME) (task_gpu_mem_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name) (task_gpu_mem_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
@@ -633,7 +633,7 @@
         "multiFormat": "regex values",
         "name": "job",
         "options": [],
-        "query": "label_values(task_cpu_percent, container_label_PAI_JOB_NAME)",
+        "query": "label_values(task_cpu_percent, job_name)",
         "refresh": 1,
         "regex": "^(?!\\s*$).+",
         "sort": 1,

--- a/src/grafana/deploy/grafana-configuration/pai-taskroleview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-taskroleview-dashboard.json.template
@@ -108,11 +108,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (task_cpu_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name) (task_cpu_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}",
               "refId": "A"
             }
           ],
@@ -208,13 +208,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (task_mem_usage_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name) (task_mem_usage_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -300,22 +300,22 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (task_net_in_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name) (task_net_in_byte{job_name=~\"$job\"})",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Net In {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "Net In {{'{{role_name}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (task_net_out_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name) (task_net_out_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Net Out {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "Net Out {{'{{role_name}}'}}",
               "refId": "B",
               "step": 600
             }
@@ -406,19 +406,19 @@
           "steppedLine": false,
           "targets": [
               {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (irate(task_block_in_byte{container_label_PAI_JOB_NAME=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name) (irate(task_block_in_byte{job_name=~\"$job\"}[{{interval}}s]))",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Read {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "Read {{'{{role_name}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (irate(task_block_out_byte{container_label_PAI_JOB_NAME=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name) (irate(task_block_out_byte{job_name=~\"$job\"}[{{interval}}s]))",
               "intervalFactor": 2,
-              "legendFormat": "Write {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "Write {{'{{role_name}}'}}",
               "refId": "B"
             }
           ],
@@ -494,11 +494,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME)(task_gpu_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name)(task_gpu_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -592,10 +592,10 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME) (task_gpu_mem_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name) (task_gpu_mem_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}",
               "refId": "B"
             }
           ],
@@ -665,7 +665,7 @@
         "multiFormat": "regex values",
         "name": "job",
         "options": [],
-        "query": "label_values(task_cpu_percent, container_label_PAI_JOB_NAME)",
+        "query": "label_values(task_cpu_percent, job_name)",
         "refresh": 1,
         "regex": "^(?!\\s*$).+",
         "sort": 1,

--- a/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
@@ -84,7 +84,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}}",
+              "legendFormat": "{{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "A"
             }
           ],
@@ -160,7 +160,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}}",
+              "legendFormat": "{{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "A"
             }
           ],
@@ -236,14 +236,14 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "Net In {{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}}",
+              "legendFormat": "Net In {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "A"
             },
             {
               "expr": "task_net_out_byte{instance=~\"$node(:[0-9]*)?$\"}",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Net Out {{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}}",
+              "legendFormat": "Net Out {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "B"
             }
           ],
@@ -319,14 +319,14 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "Read {{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}}",
+              "legendFormat": "Read {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "A"
             },
             {
               "expr": "irate(task_block_out_byte{instance=~\"$node(:[0-9]*)?$\"}[300s])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Write {{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}}",
+              "legendFormat": "Write {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "B"
             }
           ],
@@ -402,7 +402,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}} On GPU {{'{{'}}minor_number{{'}}'}}",
+              "legendFormat": "{{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}} On GPU {{'{{'}}minor_number{{'}}'}}",
               "refId": "A"
             }
           ],
@@ -478,7 +478,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{'{{'}}container_label_PAI_JOB_NAME{{'}}'}}-{{'{{'}}container_label_PAI_CURRENT_TASK_ROLE_NAME{{'}}'}}-{{'{{'}}container_env_PAI_TASK_INDEX{{'}}'}} On GPU {{'{{'}}minor_number{{'}}'}}",
+              "legendFormat": "{{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}} On GPU {{'{{'}}minor_number{{'}}'}}",
               "refId": "A"
             }
           ],
@@ -655,7 +655,7 @@
               "link": true,
               "linkTooltip": "Click to view each task's usage",
               "linkUrl": "{{url}}/dashboard/db/tasklevelmetrics?var-job=$__cell_4",
-              "pattern": "container_env_PAI_TASK_INDEX",
+              "pattern": "task_index",
               "thresholds": [],
               "type": "number",
               "unit": "short"
@@ -673,7 +673,7 @@
               "link": true,
               "linkTooltip": "Click to view each task role's usage",
               "linkUrl": "{{url}}/dashboard/db/taskrolelevelmetrics?var-job=$__cell_4",
-              "pattern": "container_label_PAI_CURRENT_TASK_ROLE_NAME",
+              "pattern": "role_name",
               "thresholds": [],
               "type": "number",
               "unit": "short"
@@ -691,7 +691,7 @@
               "link": true,
               "linkTooltip": "Click to view job's usage",
               "linkUrl": "{{url}}/dashboard/db/joblevelmetrics?var-job=$__cell_4",
-              "pattern": "container_label_PAI_JOB_NAME",
+              "pattern": "job_name",
               "thresholds": [],
               "type": "number",
               "unit": "short"
@@ -706,7 +706,7 @@
               ],
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "decimals": 2,
-              "pattern": "container_label_PAI_USER_NAME",
+              "pattern": "username",
               "thresholds": [],
               "type": "number",
               "unit": "short"

--- a/src/grafana/deploy/grafana-configuration/pai-taskview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-taskview-dashboard.json.template
@@ -96,11 +96,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME, container_env_PAI_TASK_INDEX) (task_cpu_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name, task_index) (task_cpu_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "instant": false,
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "refId": "A"
             }
           ],
@@ -196,13 +196,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME, container_env_PAI_TASK_INDEX) (task_mem_usage_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name, task_index) (task_mem_usage_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -288,23 +288,23 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME, container_env_PAI_TASK_INDEX) (task_net_in_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name, task_index) (task_net_in_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Net In {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "Net In {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME, container_env_PAI_TASK_INDEX) (task_net_out_byte{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name, task_index) (task_net_out_byte{job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Net Out {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "Net Out {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "refId": "B",
               "step": 600
             }
@@ -395,21 +395,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME,container_env_PAI_TASK_INDEX) (irate(task_block_in_byte{container_label_PAI_JOB_NAME=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name,task_index) (irate(task_block_in_byte{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "Read {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "Read {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
               "target": ""
             },
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME,container_env_PAI_TASK_INDEX) (irate(task_block_out_byte{container_label_PAI_JOB_NAME=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name,task_index) (irate(task_block_out_byte{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "Write {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "Write {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "refId": "B"
             }
           ],
@@ -485,11 +485,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME, container_env_PAI_TASK_INDEX)(task_gpu_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name, task_index)(task_gpu_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -568,11 +568,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME,container_env_PAI_TASK_INDEX) (task_gpu_mem_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name,task_index) (task_gpu_mem_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "{{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -673,13 +673,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME,container_env_PAI_TASK_INDEX, minor_number)(task_gpu_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name,task_index, minor_number)(task_gpu_percent{job_name=~\"$job\"})",
               "format": "time_series",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "GPU {{'{{minor_number}}'}} by {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "GPU {{'{{minor_number}}'}} by {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -771,12 +771,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (container_label_PAI_JOB_NAME, container_label_PAI_CURRENT_TASK_ROLE_NAME, container_env_PAI_TASK_INDEX, minor_number) (task_gpu_mem_percent{container_label_PAI_JOB_NAME=~\"$job\"})",
+              "expr": "avg by (job_name, role_name, task_index, minor_number) (task_gpu_mem_percent{job_name=~\"$job\"})",
               "hide": false,
               "instant": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "GPU {{'{{minor_number}}'}} by {{'{{container_label_PAI_CURRENT_TASK_ROLE_NAME}}'}}-{{'{{container_env_PAI_TASK_INDEX}}'}}",
+              "legendFormat": "GPU {{'{{minor_number}}'}} by {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "metric": "",
               "refId": "A",
               "step": 600,
@@ -850,7 +850,7 @@
         "multiFormat": "regex values",
         "name": "job",
         "options": [],
-        "query": "label_values(task_cpu_percent, container_label_PAI_JOB_NAME)",
+        "query": "label_values(task_cpu_percent, job_name)",
         "refresh": 1,
         "regex": "^(?!\\s*$).+",
         "sort": 1,

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -501,10 +501,10 @@ class ContainerCollector(Collector):
                         gpu_ids.append(gpu_infos[id].minor)
                     else:
                         logger.warning("gpu uuid %s can not be found in map %s",
-                                id, gpu_infos.keys())
+                                id, gpu_infos)
                 else:
                     logger.warning("unknown gpu id %s, gpu_infos is %s",
-                            id, gpu_infos.keys())
+                            id, gpu_infos)
 
         return gpu_ids, result_labels
 

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -88,10 +88,10 @@ def gen_gpu_used_by_zombie_container_counter():
 class ResourceGauges(object):
     def __init__(self):
         self.task_labels = [
-                "container_env_PAI_TASK_INDEX",
-                "container_label_PAI_CURRENT_TASK_ROLE_NAME",
-                "container_label_PAI_JOB_NAME",
-                "container_label_PAI_USER_NAME"
+                "username",
+                "job_name",
+                "role_name",
+                "task_index"
                 ]
         self.service_labels = ["name"]
 
@@ -341,6 +341,9 @@ class GpuCollector(Collector):
         pids_use_gpu = {} # key is gpu minor, value is an array of pid
 
         for minor, info in gpu_info.items():
+            if not minor.isdigit():
+                continue # ignore UUID
+
             core_utils.add_metric([minor], info.gpu_util)
             mem_utils.add_metric([minor], info.gpu_mem_util)
             ecc_errors.add_metric([minor, "single"], info.ecc_errors.single)
@@ -369,7 +372,7 @@ class GpuCollector(Collector):
                                 # found corresponding container
                                 zombie_container.add_metric([minor, zombie_id], 1)
                     else:
-                        external_process.add_metric([minor, pid], 1)
+                        external_process.add_metric([minor, str(pid)], 1)
             if len(zombie_container.samples) > 0 or len(external_process.samples) > 0:
                 logger.warning("found gpu used by external %s, zombie container %s",
                         external_process, zombie_container)
@@ -470,20 +473,27 @@ class ContainerCollector(Collector):
         return self.collect_container_metrics(stats_obj, gpu_infos, all_conns)
 
     @staticmethod
-    def parse_from_labels(labels):
+    def parse_from_labels(inspect_info, gpu_infos):
         gpu_ids = []
-        other_labels = {}
+        result_labels = {}
 
-        for key, val in labels.items():
-            if "container_label_GPU_ID" == key:
-                s2 = val.replace("\"", "").split(",")
-                for id in s2:
-                    if id:
-                        gpu_ids.append(id)
-            else:
-                other_labels[key] = val
+        result_labels["username"] = inspect_info.username or "unknown"
+        result_labels["job_name"] = inspect_info.job_name or "unknown"
+        result_labels["role_name"] = inspect_info.role_name or "unknown"
+        result_labels["task_index"] = inspect_info.task_index or "unknown"
 
-        return gpu_ids, other_labels
+        if inspect_info.gpu_ids:
+            ids = inspect_info.gpu_ids.replace("\"", "").split(",")
+            for id in ids:
+                if id.isdigit():
+                    gpu_ids.append(id)
+                elif id and gpu_infos is not None:
+                    # id is in form of UUID like
+                    # GPU-dc0671b0-61a4-443e-f456-f8fa6359b788
+                    if gpu_infos.get(id) is not None:
+                        gpu_ids.append(gpu_infos[id].minor)
+
+        return gpu_ids, result_labels
 
     @classmethod
     def infer_service_name(cls, container_name):
@@ -508,13 +518,13 @@ class ContainerCollector(Collector):
                 ContainerCollector.inspect_histogram,
                 ContainerCollector.inspect_timeout)
 
-        pid = utils.walk_json_field_safe(inspect_info, "pid")
-        inspect_labels = utils.walk_json_field_safe(inspect_info, "labels")
+        pid = inspect_info.pid
+        job_name = inspect_info.job_name
 
-        logger.debug("%s has pid %s, labels %s, service_name %s",
-                container_name, pid, inspect_labels, pai_service_name)
+        logger.debug("%s has inspect result %s, service_name %s",
+                container_name, inspect_info, pai_service_name)
 
-        if not inspect_labels and pai_service_name is None:
+        if job_name is None and pai_service_name is None:
             logger.debug("%s is ignored", container_name)
             return # other container, maybe kubelet or api-server
 
@@ -536,8 +546,7 @@ class ContainerCollector(Collector):
                     pid, debug_info.strip(), lsof_result, net_in, net_out)
 
         if pai_service_name is None:
-            gpu_ids, container_labels = ContainerCollector.parse_from_labels(inspect_info["labels"])
-            container_labels.update(inspect_info["env"])
+            gpu_ids, container_labels = ContainerCollector.parse_from_labels(inspect_info, gpu_infos)
 
             if gpu_infos:
                 for id in gpu_ids:

--- a/src/job-exporter/src/docker_inspect.py
+++ b/src/job-exporter/src/docker_inspect.py
@@ -25,39 +25,66 @@ import utils
 
 logger = logging.getLogger(__name__)
 
-target_label = {"PAI_JOB_NAME", "PAI_USER_NAME", "PAI_CURRENT_TASK_ROLE_NAME", "GPU_ID"}
-target_env = {"PAI_TASK_INDEX"}
+class InspectResult(object):
+    """ Represents a task meta data, parsed from docker inspect result """
+    def __init__(self, username, job_name, role_name, task_index, gpu_ids, pid):
+        self.username = username
+        self.job_name = job_name
+        self.role_name = role_name
+        self.task_index = task_index
+        self.gpu_ids = gpu_ids # comma seperated str, str may be minor_number or UUID
+        self.pid = pid
+
+    def __repr__(self):
+        return "username %s, job_name %s, role_name %s, task_index %s, gpu_ids %s, pid %s" % \
+                (self.username, self.job_name, self.role_name, self.task_index, self.gpu_ids, self.pid)
+
+    def __eq__(self, o):
+        return self.username == o.username and \
+                self.job_name == o.job_name and \
+                self.role_name == o.role_name and \
+                self.task_index == o.task_index and \
+                self.gpu_ids == o.gpu_ids and \
+                self.pid == o.pid
+
+
+keys = {"PAI_JOB_NAME", "PAI_USER_NAME", "PAI_CURRENT_TASK_ROLE_NAME", "GPU_ID",
+        "PAI_TASK_INDEX"}
 
 
 def parse_docker_inspect(inspect_output):
     obj = json.loads(inspect_output)
-    labels = {}
-    envs = {}
+
+    m = {}
 
     obj_labels = utils.walk_json_field_safe(obj, 0, "Config", "Labels")
     if obj_labels is not None:
-        for key in obj_labels:
-            if key in target_label:
-                label_key = "container_label_{0}".format(key)
-                label_val = obj_labels[key]
-                labels[label_key] = label_val
+        for k, v in obj_labels.items():
+            if k in keys:
+                m[k] = v
 
     obj_env = utils.walk_json_field_safe(obj, 0, "Config", "Env")
     if obj_env:
         for env in obj_env:
             k, v = env.split("=", 1)
-            if k in target_env:
-                key = "container_env_{0}".format(k)
-                envs[key] = v
+            if k in keys:
+                m[k] = v
 
             # for kube-launcher tasks
-            if k in target_label:
-                label_key = "container_label_{0}".format(k)
-                labels[label_key] = v
             if k == "FC_TASK_INDEX":
-                envs["container_env_PAI_TASK_INDEX"] = v
+                m["PAI_TASK_INDEX"] = v
+            elif k == "NVIDIA_VISIBLE_DEVICES" and v != "all":
+                m["GPU_ID"] = v
 
     pid = utils.walk_json_field_safe(obj, 0, "State", "Pid")
+
+    return InspectResult(
+            m.get("PAI_USER_NAME"),
+            m.get("PAI_JOB_NAME"),
+            m.get("PAI_CURRENT_TASK_ROLE_NAME"),
+            m.get("PAI_TASK_INDEX"),
+            m.get("GPU_ID"),
+            pid)
 
     return {"env": envs, "labels": labels, "pid": pid}
 

--- a/src/job-exporter/test/test_collector.py
+++ b/src/job-exporter/test/test_collector.py
@@ -17,7 +17,6 @@
 
 import os
 import sys
-import copy
 import unittest
 import datetime
 import time
@@ -29,6 +28,7 @@ sys.path.append(os.path.abspath("../src/"))
 
 import collector
 import nvidia
+import docker_inspect
 from collector import ContainerCollector
 from collector import GpuCollector
 
@@ -40,12 +40,24 @@ class TestContainerCollector(base.TestBase):
     """
 
     def test_parse_from_labels(self):
-        labels = {"container_label_PAI_USER_NAME": "openmindstudio", "container_label_GPU_ID": "0,1,", "container_label_PAI_JOB_NAME": "trialslot_nnimain_d65bc5ac", "container_label_PAI_CURRENT_TASK_ROLE_NAME": "tuner"}
-        gpuIds, otherLabels = ContainerCollector.parse_from_labels(labels)
-        self.assertEqual(["0", "1"], gpuIds,)
-        copied = copy.deepcopy(labels)
-        copied.pop("container_label_GPU_ID")
-        self.assertEqual(copied, otherLabels)
+        inspect_result = docker_inspect.InspectResult(
+                "openmindstudio",
+                "trialslot_nnimain_d65bc5ac",
+                "tuner",
+                "0",
+                "0,1,",
+                12345)
+
+        gpu_ids, labels = ContainerCollector.parse_from_labels(inspect_result, None)
+        self.assertEqual(["0", "1"], gpu_ids)
+
+        target_labels = {
+                "username": "openmindstudio",
+                "job_name": "trialslot_nnimain_d65bc5ac",
+                "role_name": "tuner",
+                "task_index": "0"}
+
+        self.assertEqual(target_labels, labels)
 
     def test_infer_service_name(self):
         self.assertIsNone(ContainerCollector.infer_service_name(
@@ -91,7 +103,7 @@ class TestDockerCollector(base.TestBase):
                 collector.DockerCollector)
 
         metrics = None
-        for i in range(10):
+        for i in range(20):
             metrics = ref.get(datetime.datetime.now())
             if metrics is not None:
                 break
@@ -197,8 +209,8 @@ class TestGpuCollector(base.TestBase):
 
     def test_convert_to_metrics(self):
         # sample may not ordered, and can not assertEqual directly, so tear them apart
-        gpu_info = {"0": nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44],
-            nvidia.EccError())}
+        gpu_info = nvidia.construct_gpu_info(
+                [nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44], nvidia.EccError(), "0", "GPU-uuid0")])
 
         zombie_info = {"abc", "def"}
 
@@ -226,7 +238,7 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(target_mem_leak, mem_leak)
 
         target_external_process = collector.gen_gpu_used_by_external_process_counter()
-        target_external_process.add_metric(["0", 44], 1)
+        target_external_process.add_metric(["0", "44"], 1)
         self.assertEqual(target_external_process, external_process)
 
         target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter()
@@ -234,8 +246,8 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(target_zombie_container, zombie_container)
 
         # test minor 1
-        gpu_info = {"1": nvidia.NvidiaGpuStatus(30, 31, [55, 123],
-            nvidia.EccError(single=2, double=3))}
+        gpu_info = nvidia.construct_gpu_info([
+            nvidia.NvidiaGpuStatus(30, 31, [55, 123], nvidia.EccError(single=2, double=3), "1", "GPU-uuid1")])
 
         metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
                 self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
@@ -259,16 +271,16 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(target_mem_leak, mem_leak)
 
         target_external_process = collector.gen_gpu_used_by_external_process_counter()
-        target_external_process.add_metric(["1", 55], 1)
-        target_external_process.add_metric(["1", 123], 1)
+        target_external_process.add_metric(["1", "55"], 1)
+        target_external_process.add_metric(["1", "123"], 1)
         self.assertEqual(target_external_process, external_process)
 
         target_zombie_container = collector.gen_gpu_used_by_zombie_container_counter()
         self.assertEqual(target_zombie_container, zombie_container)
 
         # test minor 2
-        gpu_info = {"2": nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024, [],
-            nvidia.EccError())}
+        gpu_info = nvidia.construct_gpu_info([
+            nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024, [], nvidia.EccError(), "2", "GPU-uuid2")])
 
         metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
                 self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024 * 1024)
@@ -298,8 +310,8 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(target_zombie_container, zombie_container)
 
         # test memory leak
-        gpu_info = {"3": nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024 + 1, [],
-            nvidia.EccError())}
+        gpu_info = nvidia.construct_gpu_info([
+            nvidia.NvidiaGpuStatus(40, 20 * 1024 * 1024 + 1, [], nvidia.EccError(), "3", "GPU-uuid3")])
 
         metrics = GpuCollector.convert_to_metrics(gpu_info, zombie_info,
                 self.make_pid_to_cid_fn(pid_to_cid_mapping), 20 * 1024)
@@ -311,8 +323,8 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(target_mem_leak, mem_leak)
 
     def test_convert_to_metrics_with_no_zombie_info_BUGFIX(self):
-        gpu_info = {"0": nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44],
-            nvidia.EccError())}
+        gpu_info = nvidia.construct_gpu_info([
+            nvidia.NvidiaGpuStatus(20, 21, [22, 33, 44], nvidia.EccError(), "0", "GPU-uuid0")])
 
         # zombie_info is empty should also have external process metric
         zombie_info = []
@@ -327,7 +339,7 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(0, len(zombie_container.samples))
         self.assertEqual(1, len(external_process.samples))
         self.assertEqual("0", external_process.samples[0].labels["minor_number"])
-        self.assertEqual(44, external_process.samples[0].labels["pid"])
+        self.assertEqual("44", external_process.samples[0].labels["pid"])
 
         # zombie_info is None should also have external process metric
         zombie_info = None
@@ -340,11 +352,11 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(0, len(zombie_container.samples))
         self.assertEqual(1, len(external_process.samples))
         self.assertEqual("0", external_process.samples[0].labels["minor_number"])
-        self.assertEqual(44, external_process.samples[0].labels["pid"])
+        self.assertEqual("44", external_process.samples[0].labels["pid"])
 
     def test_convert_to_metrics_with_real_id_BUGFIX(self):
-        gpu_info = {"0": nvidia.NvidiaGpuStatus(20, 21, [22],
-            nvidia.EccError())}
+        gpu_info = nvidia.construct_gpu_info([
+            nvidia.NvidiaGpuStatus(20, 21, [22], nvidia.EccError(), "0", "GPU-uuid0")])
 
         # zombie_info is empty should also have external process metric
         zombie_info = {"ce5de12d6275"}

--- a/src/job-exporter/test/test_docker_inspect.py
+++ b/src/job-exporter/test/test_docker_inspect.py
@@ -23,7 +23,7 @@ import base
 
 sys.path.append(os.path.abspath("../src/"))
 
-from docker_inspect import parse_docker_inspect
+from docker_inspect import parse_docker_inspect, InspectResult
 
 class TestDockerInspect(base.TestBase):
     """
@@ -34,16 +34,31 @@ class TestDockerInspect(base.TestBase):
         sample_path = "data/docker_inspect_sample.json"
         with open(sample_path, "r") as f:
             docker_inspect = f.read()
+
         inspect_info = parse_docker_inspect(docker_inspect)
-        target_inspect_info = {"labels": {"container_label_PAI_USER_NAME": "openmindstudio", "container_label_GPU_ID": "0,1,", "container_label_PAI_JOB_NAME": "trialslot_nnimain_d65bc5ac", "container_label_PAI_CURRENT_TASK_ROLE_NAME": "tuner"}, "env": {"container_env_PAI_TASK_INDEX": "0"}, "pid": 95539}
+        target_inspect_info = InspectResult(
+                "openmindstudio",
+                "trialslot_nnimain_d65bc5ac",
+                "tuner",
+                "0",
+                "0,1,",
+                95539)
+
         self.assertEqual(target_inspect_info, inspect_info)
 
     def test_parse_docker_inspect(self):
         sample_path = "data/docker_inspect_kube_launcher_task.json"
         with open(sample_path, "r") as f:
             docker_inspect = f.read()
+
         inspect_info = parse_docker_inspect(docker_inspect)
-        target_inspect_info = {"labels": {"container_label_PAI_USER_NAME": "core", "container_label_PAI_JOB_NAME": "core~tensorflowcifar10", "container_label_PAI_CURRENT_TASK_ROLE_NAME": "worker"}, "env": {"container_env_PAI_TASK_INDEX": "0"}, "pid": 23774}
+        target_inspect_info = InspectResult(
+                "core",
+                "core~tensorflowcifar10",
+                "worker",
+                "0",
+                "GPU-dc0671b0-61a4-443e-f456-f8fa6359b788",
+                23774)
         self.assertEqual(target_inspect_info, inspect_info)
 
 if __name__ == '__main__':

--- a/src/job-exporter/test/test_nvidia.py
+++ b/src/job-exporter/test/test_nvidia.py
@@ -34,8 +34,14 @@ class TestNvidia(base.TestBase):
         with open(sample_path, "r") as f:
             nvidia_smi_result = f.read()
         nvidia_smi_parse_result = nvidia.parse_smi_xml_result(nvidia_smi_result)
-        target_smi_info = {"1": nvidia.NvidiaGpuStatus(98, 50, [3093], nvidia.EccError()),
-                "0": nvidia.NvidiaGpuStatus(100, 25, [1357, 2384, 3093], nvidia.EccError())}
+
+        zero = nvidia.NvidiaGpuStatus(100, 25, [1357, 2384, 3093], nvidia.EccError(),
+                "0", "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b")
+        one = nvidia.NvidiaGpuStatus(98, 50, [3093], nvidia.EccError(),
+                "1", "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6")
+
+        target_smi_info = {"1": one, "0": zero, "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b": zero, "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6": one}
+
         self.assertEqual(target_smi_info, nvidia_smi_parse_result)
 
     def test_exporter_will_not_report_unsupported_gpu(self):
@@ -43,6 +49,7 @@ class TestNvidia(base.TestBase):
         with open(sample_path, "r") as f:
             nvidia_smi_result = f.read()
         nvidia_smi_parse_result = nvidia.parse_smi_xml_result(nvidia_smi_result)
+
         self.assertEqual({}, nvidia_smi_parse_result)
 
 


### PR DESCRIPTION
Tasks run by nvidia-container-runtime will have ENV of `NVIDIA_VISIBLE_DEVICES` and value is GPU uuids, these uuid can mapped into minor number by info get from nvidia-smi.

This PR will make job-exporter able to get resource usage of tasks run by either yarn-launcher and kube-launcher, including GPU usage.