### PR TITLE
prevent tasks scheduled by kube launcher be deemed as external user

### DIFF
--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -320,10 +320,17 @@ class GpuCollector(Collector):
 
         for line in content.split("\n"):
             line = line.strip()
-            if "pids" in line and "/docker/" in line:
-                parts = line.split("/docker/")
-                if len(parts) == 2 and re.match(u"[0-9a-f]+", parts[1]):
-                    return True, parts[1]
+            if "pids" in line:
+                if "/docker/" in line:
+                    parts = line.split("/docker/")
+                    if len(parts) == 2 and re.match(u"[0-9a-f]+", parts[1]):
+                        return True, parts[1]
+                elif "/kubepods/" in line:
+                    parts = line.split("/kubepods/")
+                    if len(parts) == 2 and re.match(u"pod[0-9a-f-]+", parts[1]):
+                        return True, parts[1]
+                else:
+                    logger.info("unknown format in pid cgroup %s", line)
 
         return False, ""
 


### PR DESCRIPTION
We have detection of external gpu users, previous this is implemented as check /proc/$pid/cgroup content, if it not starts with /docker/, it will be treat as external process.

But tasks started by kube launcher will have content started with `/kubepods/`.

This PR will treat these tasks also as normal users.