### PR TITLE
Fix hadoop-ai ecc eccor detection

### DIFF
--- a/src/hadoop-ai/build/build-pre.sh
+++ b/src/hadoop-ai/build/build-pre.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0") > /dev/null
 hadoopBinaryDir="/hadoop-binary"
 
 # When Changing the patch id, please update it.
-patchId="12940533-12933562-docker_executor"
+patchId="12940533-12933562-docker_executor-fix1"
 
 hadoopBinaryPath="${hadoopBinaryDir}/hadoop-2.9.0.tar.gz"
 cacheVersion="${hadoopBinaryDir}/${patchId}-done"

--- a/src/hadoop-ai/build/build.sh
+++ b/src/hadoop-ai/build/build.sh
@@ -29,13 +29,10 @@ cd hadoop
 
 git checkout branch-2.9.0
 
-cp /hadoop-2.9.0.gpu-port.patch /hadoop
-cp /HDFS-13773.patch /hadoop
-cp /docker-executor.patch /hadoop
-
-git apply hadoop-2.9.0.gpu-port.patch
-git apply HDFS-13773.patch
-git apply docker-executor.patch
+git apply /hadoop-2.9.0.gpu-port.patch
+git apply /HDFS-13773.patch
+git apply /docker-executor.patch
+git apply /hadoop-ai-fix.patch
 
 mvn package -Pdist,native -DskipTests -Dmaven.javadoc.skip=true -Dtar
 

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -75,6 +75,8 @@ RUN wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.
 
 COPY docker-executor.patch /
 
+COPY hadoop-ai-fix.patch /
+
 COPY build.sh /
 
 RUN chmod u+x build.sh

--- a/src/hadoop-ai/build/hadoop-ai-fix.patch
+++ b/src/hadoop-ai/build/hadoop-ai-fix.patch
@@ -1,0 +1,62 @@
+diff --git a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
+index 8801b4a940f..2d3138164f0 100644
+--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
++++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
+@@ -138,7 +138,7 @@
+    |   1  Tesla K80           Off  | 000083D4:00:00.0 Off |                    1 |
+    | N/A   32C    P8    28W / 149W |     11MiB / 11439MiB |      0%      Default |
+    +-------------------------------+----------------------+----------------------+
+-   |   2  Tesla K80           Off  | 00009D9C:00:00.0 Off |                    0 |
++   |   2  Tesla K80           Off  | 00009D9C:00:00.0 Off |                    2 |
+    | N/A   29C    P8    25W / 149W |     12MiB / 11439MiB |      0%      Default |
+    +-------------------------------+----------------------+----------------------+
+    |   3  Tesla K80           Off  | 0000B6D4:00:00.0 Off |                  N/A |
+@@ -169,7 +169,7 @@
+    +-----------------------------------------------------------------------------+
+    */
+   Pattern GPU_INFO_FORMAT =
+-      Pattern.compile("\\s+([0-9]{1,2})\\s+[\\s\\S]*\\s+(0|1|N/A|Off)\\s+");
++      Pattern.compile("\\s+([0-9]{1,2})\\s+[\\s\\S]*\\s+(\\d+|N/A|Off)\\s+");
+   Pattern GPU_MEM_FORMAT =
+       Pattern.compile("([0-9]+)MiB\\s*/\\s*([0-9]+)MiB");
+ 
+@@ -820,8 +820,13 @@ private void refreshGpuIfNeeded(boolean excludeOwnerlessUsingGpus, int gpuNotRea
+               long index = Long.parseLong(mat.group(1));
+               currentIndex = index;
+ 
+-              String errCode = mat.group(2);
+-              if (!errCode.equals("1")) {
++              int errCode;
++              try {
++                errCode = Integer.parseInt(mat.group(2));
++              } catch (NumberFormatException e) {
++                errCode = 0;
++              }
++              if (errCode == 0) {
+                 gpuAttributeCapacity |= (1L << index);
+               } else {
+                 LOG.error("ignored error: gpu " + index + " ECC code is 1, will make this gpu unavailable");
+diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java
+index 52cc3f8f160..71f9c95cdbc 100644
+--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java
++++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java
+@@ -269,7 +269,7 @@ int readDiskBlockInformation(String diskName, int defSector) {
+           "|   1  Tesla K80           Off  | 000083D4:00:00.0 Off |                    1 |\n" +
+           "| N/A   32C    P8    28W / 149W |     11MiB / 11439MiB |      0%      Default |\n" +
+           "+-------------------------------+----------------------+----------------------+\n" +
+-          "|   2  Tesla K80           Off  | 00009D9C:00:00.0 Off |                    0 |\n" +
++          "|   2  Tesla K80           Off  | 00009D9C:00:00.0 Off |                    2 |\n" +
+           "| N/A   29C    P8    25W / 149W |     12MiB / 11439MiB |      0%      Default |\n" +
+           "+-------------------------------+----------------------+----------------------+\n" +
+           "|   3  Tesla K80           Off  | 0000B6D4:00:00.0 Off |                  N/A |\n" +
+@@ -605,8 +605,8 @@ private void InitialGPUTestFile()  throws IOException {
+   public void parsingGPUFile() throws Exception {
+ 
+     InitialGPUTestFile();
+-    assertEquals(7, plugin.getNumGPUs(false, 0));
+-    assertEquals(253, plugin.getGpuAttributeCapacity(false, 0));
++    assertEquals(6, plugin.getNumGPUs(false, 0));
++    assertEquals(249, plugin.getGpuAttributeCapacity(false, 0));
+   }
+ 
+ 

--- a/src/hadoop-ai/build/hadoop-ai-fix.patch
+++ b/src/hadoop-ai/build/hadoop-ai-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
-index 8801b4a940f..2d3138164f0 100644
+index 8801b4a940f..30d33086516 100644
 --- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
 +++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/SysInfoLinux.java
 @@ -138,7 +138,7 @@
@@ -20,7 +20,7 @@ index 8801b4a940f..2d3138164f0 100644
    Pattern GPU_MEM_FORMAT =
        Pattern.compile("([0-9]+)MiB\\s*/\\s*([0-9]+)MiB");
  
-@@ -820,8 +820,13 @@ private void refreshGpuIfNeeded(boolean excludeOwnerlessUsingGpus, int gpuNotRea
+@@ -820,11 +820,16 @@ private void refreshGpuIfNeeded(boolean excludeOwnerlessUsingGpus, int gpuNotRea
                long index = Long.parseLong(mat.group(1));
                currentIndex = index;
  
@@ -35,7 +35,11 @@ index 8801b4a940f..2d3138164f0 100644
 +              if (errCode == 0) {
                  gpuAttributeCapacity |= (1L << index);
                } else {
-                 LOG.error("ignored error: gpu " + index + " ECC code is 1, will make this gpu unavailable");
+-                LOG.error("ignored error: gpu " + index + " ECC code is 1, will make this gpu unavailable");
++                LOG.error("ignored error: gpu " + index + " ECC code is " + mat.group(2) + ", will make this gpu unavailable");
+               }
+             }
+           }
 diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java
 index 52cc3f8f160..71f9c95cdbc 100644
 --- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestSysInfoLinux.java


### PR DESCRIPTION
Origin code only consider ecc code 0/1, but it's actually an int.

Readable patch is here:
https://github.com/mzmssg/hadoop/pull/3