### PR TITLE
yarn container script exit handler fix and refactor

### DIFF
--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -309,6 +309,12 @@
   </property>
 
   <property>
+    <name>yarn.nodemanager.sleep-delay-before-sigkill.ms</name>
+    <value>10000</value>
+  </property>
+
+
+  <property>
     <description>
     The duration (in ms) the YARN client waits for an expected state change
     to occur.  -1 means unlimited wait time.

--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/yarn-site.xml.template
@@ -309,12 +309,6 @@
   </property>
 
   <property>
-    <name>yarn.nodemanager.sleep-delay-before-sigkill.ms</name>
-    <value>10000</value>
-  </property>
-
-
-  <property>
     <description>
     The duration (in ms) the YARN client waits for an expected state change
     to occur.  -1 means unlimited wait time.

--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -426,7 +426,6 @@ class Job {
           'taskData': data.taskRoles[idx],
           'jobData': data,
           'inspectPidFormat': '{{.State.Pid}}',
-          'inspectOOMKilledFormat': '{{.State.OOMKilled}}',
           'jobEnvs': jobEnvs,
           'azRDMA': azureEnv.azRDMA === 'false' ? false : true,
           'isDebug': data.jobEnvs && data.jobEnvs.isDebug === true ? true : false,

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -44,7 +44,7 @@ function exit_handler()
 {
   rc=$?
   printf "[DEBUG] EXIT signal received in yarn container, performing clean up action...\n"
-  if [ $rc -eq 125]; then
+  if [ $rc -eq 125 ]; then
     printf "[DEBUG] Exit code 125, it may be docker daemon error, convert it to a transient error\n"
     rc=205
   fi

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -26,44 +26,49 @@ export PAI_DEFAULT_FS_URI={{ hdfsUri }}
 exec 13>$LAUNCHER_LOG_DIR/YarnContainerDebug.log
 BASH_XTRACEFD=13
 
+function sigterm_handler()
+{
+  printf "[DEBUG] SIGTERM received, job may be killed by YARN\n"
+
+  pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
+  if [ $pid -gt 0 ]; then
+    kill -15 $pid &&\
+      printf "[DEBUG] Docker container $docker_name killed successfully." ||\
+      printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."
+  fi
+  exit 143
+}
+
 
 function exit_handler()
 {
   rc=$?
-  echo "Exited with $rc"
-  local handler="Yarn container exit handler"
-  debug_log "$handler"  "EXIT signal received in yarn container, performing clean up action..."
+  printf "[DEBUG] EXIT signal received in yarn container, performing clean up action...\n"
+  if [ $rc -eq 125]; then
+    printf "[DEBUG] Exit code 125, it may be docker daemon error, convert it to a transient error\n"
+    rc=205
+  fi
 
-  debug_log "$handler" "trying to kill docker container $docker_name"
-  docker logs $docker_name
-  docker inspect $docker_name
   pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
-  if [ $pid -gt 0 ]; then
-    kill -9 $pid &&\
-      debug_log "$handler" "docker caontainer $docker_name killed successfully." ||\
-      debug_log "$handler" "tries to kill the container $docker_name but failed. Maybe it has already exited."
-  else
-    debug_log "$handler" "docker container $docker_name has already exited"
+  if [ $pid -eq 0 ]; then
+    printf "[DEBUG] Docker container $docker_name has already exited"
     is_oom=$(docker inspect --format={{{ inspectOOMKilledFormat }}} $docker_name 2>/dev/null)
-    debug_log "$handler" "docker container $docker_name is exited by OOM? $is_oom"
     if [ "$is_oom" = "true" ]; then
+      printf "[DEBUG] docker container $docker_name is exited by OOM."
       rc=55
     fi
   fi
 
-  docker container rm $docker_name
-  pkill --parent $$
-
-  debug_log "$handler" "write exit code to file"
-  debug_log "$handler" "yarn container exit code: $rc"
-  debug_log "$handler" "exit code file path: /var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
+  printf "[DEBUG] Write exit code $rc to file /var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode.\n"
   echo $rc > "/var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
 
+  docker container rm $docker_name
   exit $rc
 }
 
 set -x
 PS4="+[\t] "
+trap sigterm_handler SIGTERM
 trap exit_handler EXIT
 
 

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -30,7 +30,7 @@ BASH_XTRACEFD=13
 function sigterm_handler()
 {
   printf "[DEBUG] SIGTERM received, job may be killed by YARN\n"
-
+  killed_by_yarn=true
   exit 143
 }
 
@@ -45,7 +45,7 @@ function exit_handler()
     rc=205
   fi
 
-  if [[ $rc -eq 137 || $rc -eq 143 ]]; then
+  if [[ $rc -eq 137 || $rc -eq 143 && ${killed_by_yarn} != true ]]; then
     printf "[DEBUG] Exit code $rc, it may be critical system errors or OOM\n"
     rc=55
   fi

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -26,12 +26,14 @@ export PAI_DEFAULT_FS_URI={{ hdfsUri }}
 exec 13>$LAUNCHER_LOG_DIR/YarnContainerDebug.log
 BASH_XTRACEFD=13
 
+# YARN kill container will send SIGTERM(15) and SIGKILL(9)
 function sigterm_handler()
 {
   printf "[DEBUG] SIGTERM received, job may be killed by YARN\n"
 
   pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
   if [ $pid -gt 0 ]; then
+    # This is a best effort kill, so we only use SIGTERM(15)
     kill -15 $pid &&\
       printf "[DEBUG] Docker container $docker_name killed successfully." ||\
       printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."
@@ -45,7 +47,8 @@ function exit_handler()
   rc=$?
   printf "[DEBUG] EXIT signal received in yarn container, performing clean up action...\n"
   if [ $rc -eq 125 ]; then
-    printf "[DEBUG] Exit code 125, it may be docker daemon error, convert it to a transient error\n"
+    # We assume 125 is a docker error, and retry it without burning user's retry count
+    printf "[DEBUG] Exit code 125, it may be docker error, convert it to a transient error\n"
     rc=205
   fi
 
@@ -62,6 +65,7 @@ function exit_handler()
   printf "[DEBUG] Write exit code $rc to file /var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode.\n"
   echo $rc > "/var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
 
+  # Any time-consuming operations please put here, otherwise NM couldn't get exitcode as restart
   docker container rm $docker_name
   exit $rc
 }

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -45,7 +45,7 @@ function exit_handler()
     rc=205
   fi
 
-  if [[ ${killed_by_yarn} != true && $rc -eq 137 || $rc -eq 143 ]]; then
+  if [[ ${killed_by_yarn} != true && $rc -eq 143 || $rc -eq 137 ]]; then
     printf "[DEBUG] Exit code $rc, it may be critical system errors or OOM\n"
     rc=55
   fi

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -45,7 +45,7 @@ function exit_handler()
     rc=205
   fi
 
-  if [[ $rc -eq 137 || $rc -eq 143 && ${killed_by_yarn} != true ]]; then
+  if [[ ${killed_by_yarn} != true && $rc -eq 137 || $rc -eq 143 ]]; then
     printf "[DEBUG] Exit code $rc, it may be critical system errors or OOM\n"
     rc=55
   fi

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -31,13 +31,6 @@ function sigterm_handler()
 {
   printf "[DEBUG] SIGTERM received, job may be killed by YARN\n"
 
-  pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
-  if [ $pid -gt 0 ]; then
-    # This is a best effort kill, so we only use SIGTERM(15)
-    kill -15 $pid &&\
-      printf "[DEBUG] Docker container $docker_name killed successfully." ||\
-      printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."
-  fi
   exit 143
 }
 
@@ -45,28 +38,29 @@ function sigterm_handler()
 function exit_handler()
 {
   rc=$?
-  printf "[DEBUG] EXIT signal received in yarn container, performing clean up action...\n"
-  if [ $rc -eq 125 ]; then
+  printf "[DEBUG] Performing clean up action...\n"
+  if [[ $rc -eq 125 ]]; then
     # We assume 125 is a docker error, and retry it without burning user's retry count
     printf "[DEBUG] Exit code 125, it may be docker error, convert it to a transient error\n"
     rc=205
   fi
 
-  pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
-  if [ $pid -eq 0 ]; then
-    printf "[DEBUG] Docker container $docker_name has already exited"
-    is_oom=$(docker inspect --format={{{ inspectOOMKilledFormat }}} $docker_name 2>/dev/null)
-    if [ "$is_oom" = "true" ]; then
-      printf "[DEBUG] docker container $docker_name is exited by OOM."
-      rc=55
-    fi
+  if [[ $rc -eq 137 || $rc -eq 143 ]]; then
+    printf "[DEBUG] Exit code $rc, it may be critical system errors or OOM\n"
+    rc=55
   fi
 
   printf "[DEBUG] Write exit code $rc to file /var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode.\n"
   echo $rc > "/var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
 
-  # Any time-consuming operations please put here, otherwise NM couldn't get exitcode as restart
-  docker container rm $docker_name
+  # After all necessary steps, do a best effort kill here
+  pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
+  if [ $pid -gt 0 ]; then
+    kill -15 $pid &&\
+      printf "[DEBUG] Docker container $docker_name killed successfully." ||\
+      printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."
+  fi
+
   exit $rc
 }
 
@@ -300,6 +294,7 @@ docker pull {{ jobData.image }} \
 docker run --name $docker_name \
   --init \
   --tty \
+  --rm \
   --privileged=false \
   --oom-score-adj=1000 \
   --cap-add=SYS_ADMIN \

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -46,7 +46,7 @@ function exit_handler()
   fi
 
   if [[ ${killed_by_yarn} != true && $rc -eq 143 || $rc -eq 137 ]]; then
-    printf "[DEBUG] Exit code $rc, it may be critical system errors or OOM\n"
+    printf "[DEBUG] Exit code $rc, it may be due to out of memory (OOM) or other critical errors.\n"
     rc=55
   fi
 


### PR DESCRIPTION
This PR includes:
1. Revert #1108, remove unnecessary logs.
2. Improve log readability. Killed job and finished job will have different logs. 
Killed job:
![image](https://user-images.githubusercontent.com/11887940/54591283-e4f5a680-4a64-11e9-9244-22db003b7aa2.png)
Finished job:
![image](https://user-images.githubusercontent.com/11887940/54591378-11112780-4a65-11e9-99c1-d0cb1dff66fb.png)
3. #2336 
We assume only docker errors raise 125 errorcode. This pr covert it to 205, which is launcher USER_APP_TRANSIENT_ERROR. Then launcher will retry it without burning retry count.