### PR TITLE
Fix jq invocation errors with numeric task roles

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -164,8 +164,8 @@ function get_host_list()
           echo PAI_${taskrole}_${task_index}_${port_info[0]}_PORT=${port_info[1]} >> $1
         fi
       done
-    done < <(echo $taskrole_statuses | jq -r ".${taskrole}.taskStatuses.taskStatusArray[] | .containerIp, .containerPorts, .taskIndex")
-    echo PAI_TASK_ROLE_TASK_COUNT_${taskrole}=$(echo $taskrole_statuses | jq ".${taskrole}.taskStatuses.taskStatusArray | length") >> $1
+    done < <(echo $taskrole_statuses | jq -r ".\"${taskrole}\".taskStatuses.taskStatusArray[] | .containerIp, .containerPorts, .taskIndex")
+    echo PAI_TASK_ROLE_TASK_COUNT_${taskrole}=$(echo $taskrole_statuses | jq ".\"${taskrole}\".taskStatuses.taskStatusArray | length") >> $1
     # Backward compatibility
     host_list=$(echo $host_list | sed "s/,$//g")
     echo PAI_TASK_ROLE_${taskrole}_HOST_LIST=$host_list >> $1
@@ -264,7 +264,7 @@ if [[ -n $PAI_CODE_DIR ]]; then
       || { echo "Can not get code from HDFS. HDFS may be down."; exit 1; }
   elif [ $code_dir_size -eq 0]; then
     # pass when code_dir_size is 0
-    : 
+    :
   elif [ $code_dir_size -lt 0 ]; then
     echo "$PAI_CODE_DIR is less than 0MB, exit."
     exit 1


### PR DESCRIPTION
Fixes messages in task `stderr` log when using a numeric-only task role:

```
...
jq: error: Invalid numeric literal at EOF at line 1, column 6 (while parsing '.0009.') at <top-level>, line 1:
.0009.taskStatuses.taskStatusArray[] | .containerIp, .containerPorts, .taskIndex
jq: error: syntax error, unexpected IDENT, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
.0009.taskStatuses.taskStatusArray[] | .containerIp, .containerPorts, .taskIndex      
jq: 2 compile errors
...
```

- Added quotes for task role names in `jq` queries