### PR TITLE
Add support for multiline user commands

### DIFF
--- a/src/rest-server/src/config/task.js
+++ b/src/rest-server/src/config/task.js
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const config = {
+    userCommandScriptName: 'user_command.sh', // on HDFS
+    userCommandScriptContainerPath: '/pai/command.sh', // inside a task container
+    dockerContainerScriptName: 'entry.sh', // on HDFS
+};
+
+module.exports = config;

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -143,7 +143,7 @@ function generate_ssh_connect_info()
   fi
 }
 
-# Check is SSH exists, if not - ignore ssh preparation and start part
+# Check if SSH exists, if not - ignore ssh preparation and start part
 # Start sshd in docker container
 if service --status-all 2>&1 | grep -q ssh; then
   prepare_ssh
@@ -180,40 +180,16 @@ azure_rdma_preparation
 {{/ azRDMA }}
 {{/ reqAzRDMA }}
 
-function write_user_command()
-{
-  local scriptPath="$1"
-
-  # Read an escaped string to an array and unescape
-  local lines=$'{{ taskData.command }}'
-  readarray -n 50 -t lines <<< "${lines}"
-  read -n 1000 -a lines <<< "${lines[@]}"
-
-  echo "#!/bin/bash" > "${scriptPath}"
-
-  # By default, exit on the first error
-  echo 'set -e' >> "${scriptPath}"
-  # Enable logging for the user command
-  echo 'set -x' >> "${scriptPath}"
-
-  printf '%s\n' "${lines[@]}" >> "${scriptPath}"
-
-  chmod a+x "${scriptPath}"
-}
-
 function run_user_command()
 {
-  local scriptPath="$1"
+  set -a
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
-  exec "${scriptPath}" || exit $?
+  $1 || exit $?
   printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END" # job_exporter relay on this exact output, if you are going to change this, remember to change job_exporter also
   exit 0
 }
 
-PAI_USER_COMMAND_PATH="/pai/command.sh"
-write_user_command "${PAI_USER_COMMAND_PATH}"
-
-run_user_command "${PAI_USER_COMMAND_PATH}" &
+run_user_command {{ userCommandScriptContainerPath }} &
 user_command_pid=$!
 
 while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 120 ] && \

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -47,13 +47,16 @@ touch "/alive/docker_$PAI_CONTAINER_ID"
 
 export PAI_WORK_DIR="$(pwd)"
 PAI_WEB_HDFS_PREFIX={{ webHdfsUri }}/webhdfs/v1/Container
-HDFS_LAUNCHER_PREFIX=$PAI_DEFAULT_FS_URI/Container
-export CLASSPATH="$(hadoop classpath --glob)"
+
 # Make all GPUs allocated to the container accessible
 export NVIDIA_VISIBLE_DEVICES=all
 
 task_role_no={{ idx }}
+
 printf "%s %s\n%s\n\n" "[INFO]" "ENV" "$(printenv | sort)"
+
+# Write env to system-wide environment
+env | grep -E "^PAI|PATH|PREFIX|JAVA|HADOOP|NVIDIA|CUDA|(.*_PROXY)" > /etc/environment
 
 cp -r /pai/code/* ./
 
@@ -109,6 +112,7 @@ function get_ssh_key_files()
   info_source="webhdfs"
   localKeyPath=/root/.ssh/{{ jobData.jobName }}.pub
   localPrivateKeyPath=/root/.ssh/{{ jobData.jobName }}
+
   if [[ -f $localKeyPath ]]; then
     rm -f $localKeyPath
   fi
@@ -139,7 +143,7 @@ function generate_ssh_connect_info()
   fi
 }
 
-# Check whether hdfs bianry and ssh exists, if not ignore ssh preparation and start part
+# Check is SSH exists, if not - ignore ssh preparation and start part
 # Start sshd in docker container
 if service --status-all 2>&1 | grep -q ssh; then
   prepare_ssh
@@ -149,10 +153,8 @@ if service --status-all 2>&1 | grep -q ssh; then
   destFilePath=${sshConnectInfoFolder}/$PAI_CONTAINER_ID-$PAI_CONTAINER_HOST_IP-$PAI_CONTAINER_SSH_PORT
   generate_ssh_connect_info ${destFilePath}
 
-  # Enable SSH connect inside
-  # Move ssh config file to /root/.ssh/
-  mv /pai/ssh_config/config /root/.ssh/
-  # Start ssh service
+  # Enable SSH connect
+  cp /pai/ssh_config/config /root/.ssh/
   start_ssh_service
 else
   printf "%s %s\n %s %s \n" \
@@ -162,7 +164,7 @@ fi
 
 {{# reqAzRDMA }}
 {{# azRDMA }}
-function  azure_rdma_preparation()
+function azure_rdma_preparation()
 {
     # https://unix.stackexchange.com/questions/404189/find-and-sed-string-in-docker-got-error-device-or-resource-busy
     cp /etc/hosts /hosts.tmp
@@ -177,17 +179,39 @@ function  azure_rdma_preparation()
 azure_rdma_preparation
 {{/ azRDMA }}
 {{/ reqAzRDMA }}
-# Write env to system-wide environment
-env | grep -E "^PAI|PATH|PREFIX|JAVA|HADOOP|NVIDIA|CUDA" > /etc/environment
+
+function write_user_command()
+{
+  PAI_USER_COMMAND_DIR="/pai/taskData"
+  PAI_USER_COMMAND_PATH="${PAI_USER_COMMAND_DIR}/command.sh"
+  mkdir -p "${PAI_USER_COMMAND_DIR}"
+
+  # Read an escaped string to an array and unescape
+  local lines=$'{{ taskData.command }}'
+  readarray -n 50 -t lines <<< "${lines}"
+  read -n 1000 -a lines <<< "${lines[@]}"
+
+  echo "#!/bin/bash" > "${PAI_USER_COMMAND_PATH}"
+
+  # By default, exit on the first error
+  echo 'set -e' >> "${PAI_USER_COMMAND_PATH}"
+  # Enable logging for the user command
+  echo 'set -x' >> "${PAI_USER_COMMAND_PATH}"
+
+  printf '%s\n' "${lines[@]}" >> "${PAI_USER_COMMAND_PATH}"
+
+  chmod a+x "${PAI_USER_COMMAND_PATH}"
+}
 
 function run_user_command()
 {
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
-  eval {{ taskData.command }} || exit $?
+  exec "${PAI_USER_COMMAND_PATH}" || exit $?
   printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END" # job_exporter relay on this exact output, if you are going to change this, remember to change job_exporter also
   exit 0
 }
 
+write_user_command
 run_user_command &
 user_command_pid=$!
 
@@ -197,12 +221,12 @@ while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 120
 done
 
 if kill -0 $user_command_pid 2>/dev/null; then
-  echo "job has been killed, docker container exiting"
+  echo "[INFO] The job has been killed, Docker container exiting"
   exit 1
 else
   wait $user_command_pid
   user_command_exitcode=$?
-  echo "job has finished with exit code $user_command_exitcode"
+
 {{# isDebug }}
   if [[ $user_command_exitcode -ne 0 ]]; then
     echo "============================================================================="
@@ -221,6 +245,8 @@ else
 
   fi
 {{/ isDebug }}
+
+  echo "[INFO] The job has finished with exit code $user_command_exitcode"
   exit $user_command_exitcode
 fi
 

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -182,37 +182,38 @@ azure_rdma_preparation
 
 function write_user_command()
 {
-  PAI_USER_COMMAND_DIR="/pai/taskData"
-  PAI_USER_COMMAND_PATH="${PAI_USER_COMMAND_DIR}/command.sh"
-  mkdir -p "${PAI_USER_COMMAND_DIR}"
+  local scriptPath="$1"
 
   # Read an escaped string to an array and unescape
   local lines=$'{{ taskData.command }}'
   readarray -n 50 -t lines <<< "${lines}"
   read -n 1000 -a lines <<< "${lines[@]}"
 
-  echo "#!/bin/bash" > "${PAI_USER_COMMAND_PATH}"
+  echo "#!/bin/bash" > "${scriptPath}"
 
   # By default, exit on the first error
-  echo 'set -e' >> "${PAI_USER_COMMAND_PATH}"
+  echo 'set -e' >> "${scriptPath}"
   # Enable logging for the user command
-  echo 'set -x' >> "${PAI_USER_COMMAND_PATH}"
+  echo 'set -x' >> "${scriptPath}"
 
-  printf '%s\n' "${lines[@]}" >> "${PAI_USER_COMMAND_PATH}"
+  printf '%s\n' "${lines[@]}" >> "${scriptPath}"
 
-  chmod a+x "${PAI_USER_COMMAND_PATH}"
+  chmod a+x "${scriptPath}"
 }
 
 function run_user_command()
 {
+  local scriptPath="$1"
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
-  exec "${PAI_USER_COMMAND_PATH}" || exit $?
+  exec "${scriptPath}" || exit $?
   printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END" # job_exporter relay on this exact output, if you are going to change this, remember to change job_exporter also
   exit 0
 }
 
-write_user_command
-run_user_command &
+PAI_USER_COMMAND_PATH="/pai/command.sh"
+write_user_command "${PAI_USER_COMMAND_PATH}"
+
+run_user_command "${PAI_USER_COMMAND_PATH}" &
 user_command_pid=$!
 
 while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 120 ] && \

--- a/src/rest-server/src/templates/userCommandScript.mustache
+++ b/src/rest-server/src/templates/userCommandScript.mustache
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# By default, exit on the first error
+set -e
+
+# Sending a signal to Bash makes it exit *immediately*
+# if the signal has the default handler (set like "trap - SIG"),
+# as opposed to non-default handlers, waiting for the current
+# command to finish,
+# so the signal should be catched in the user command script.
+#
+# By default, the user command script does nothing on the signals PAI sends.
+#
+# We could leave the handlers empty ("") or set the default (- or nothing)
+# handlers, however, doing this incurs an issue in a subprocess
+# (e.g. if user command runs a script) -
+# it can not change the default handler to anything else (reference below).
+# Thus, we have to set any non-empty (not "") handler. This way it works.
+#
+# References:
+# > POSIX 2 / https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html:
+# > Signals ignored upon entry to the shell cannot be trapped or reset.
+# > Trapped signals that are not being ignored are reset to their original
+# >   values in a subshell or subshell environment when one is created.
+#
+trap ' ' "${PAI_GRACEFUL_EXIT_SIGNAL}"
+trap ' ' "${PAI_OOM_KILLED_SIGNAL}"
+
+# Enable logging for the user command
+set -x
+
+{{{ taskData.command }}}

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -247,7 +247,7 @@ PAI_TEMP={{ key }}={{ value }} && echo $PAI_TEMP >> $ENV_LIST
 # Prepare docker bootstrap script
 bootstrap_dir="tmp/pai-root/bootstrap"
 mkdir -p $bootstrap_dir
-hdfs dfs -get {{ hdfsUri }}/Container/$HADOOP_USER_NAME/$FRAMEWORK_NAME/DockerContainerScripts/{{ idx }}.sh $bootstrap_dir/docker_bootstrap.sh \
+hdfs dfs -get {{ hdfsUri }}/Container/$HADOOP_USER_NAME/$FRAMEWORK_NAME/DockerContainerScripts/{{ idx }}/{{ entryScriptName }} $bootstrap_dir/docker_bootstrap.sh \
   || { echo "Can not get script from HDFS."; exit 1; }
 
 # Prepare user code
@@ -291,6 +291,12 @@ mounted_path=$(docker inspect $container_id |\
   jq -r --arg hadoop_tmp_dir "$hadoop_tmp_dir" '.[] | .Mounts | .[] | select(.Destination==$hadoop_tmp_dir) | .Source')
 container_local_dir=$mounted_path/nm-local-dir/usercache/{{ jobData.userName }}/appcache/$APP_ID/$CONTAINER_ID
 
+# Prepare the user command script
+user_command_script="user_command.sh"
+hdfs dfs -get {{ hdfsUri }}/Container/$HADOOP_USER_NAME/$FRAMEWORK_NAME/DockerContainerScripts/{{ idx }}/{{ userCommandScriptName }} $user_command_script \
+  || { echo "Can not get script from HDFS."; exit 1; }
+chmod a+x $user_command_script
+
 # Pull docker image and run
 docker pull {{ jobData.image }} \
   || { echo "Can not pull Docker image"; exit 1; }
@@ -332,6 +338,7 @@ docker run --name $docker_name \
   --volume $container_local_dir/$log_dir:/pai/log \
   --volume $container_local_dir/$bootstrap_dir:/pai/bootstrap:ro \
   --volume $container_local_dir/$code_dir:/pai/code:ro \
+  --volume $container_local_dir/$user_command_dir/$user_command_script:{{ userCommandScriptContainerPath }}:ro \
   --volume /var/drivers/nvidia/current:/usr/local/nvidia:ro \
   --volume $container_local_dir/$hadoop_config_dir:/etc/hadoop \
   --volume $container_local_dir/$ssh_config_file:/pai/ssh_config/:ro \


### PR DESCRIPTION
- Added support for multiline user commands
    - User commands gets written to a separate script file. By default, the script fails on the first error and prints executed commands
    - Command has some reasonable restrictions on line count and line length
- Proxy environment variables forwarded to `/etc/environment` (can be improved by using more portable  `/etc/profile`, forwarding all the environment, and exposing proxy settings somewhere)
- Removed unused code from Docker entry point
- Slightly improved log messages
- Fixed `mv` file access issue for `/pai/ssh_config` read-only mount