### PR TITLE
User pretending for a task

### DIFF
--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -47,13 +47,16 @@ touch "/alive/docker_$PAI_CONTAINER_ID"
 
 export PAI_WORK_DIR="$(pwd)"
 PAI_WEB_HDFS_PREFIX={{ webHdfsUri }}/webhdfs/v1/Container
-HDFS_LAUNCHER_PREFIX=$PAI_DEFAULT_FS_URI/Container
-export CLASSPATH="$(hadoop classpath --glob)"
+
 # Make all GPUs allocated to the container accessible
 export NVIDIA_VISIBLE_DEVICES=all
 
 task_role_no={{ idx }}
+
 printf "%s %s\n%s\n\n" "[INFO]" "ENV" "$(printenv | sort)"
+
+# Write env to system-wide environment
+env | grep -E "^PAI|PATH|PREFIX|JAVA|HADOOP|NVIDIA|CUDA|(.*_PROXY)" > /etc/environment
 
 cp -r /pai/code/* ./
 
@@ -109,6 +112,7 @@ function get_ssh_key_files()
   info_source="webhdfs"
   localKeyPath=/root/.ssh/{{ jobData.jobName }}.pub
   localPrivateKeyPath=/root/.ssh/{{ jobData.jobName }}
+
   if [[ -f $localKeyPath ]]; then
     rm -f $localKeyPath
   fi
@@ -139,7 +143,7 @@ function generate_ssh_connect_info()
   fi
 }
 
-# Check whether hdfs bianry and ssh exists, if not ignore ssh preparation and start part
+# Check is SSH exists, if not - ignore ssh preparation and start part
 # Start sshd in docker container
 if service --status-all 2>&1 | grep -q ssh; then
   prepare_ssh
@@ -149,10 +153,8 @@ if service --status-all 2>&1 | grep -q ssh; then
   destFilePath=${sshConnectInfoFolder}/$PAI_CONTAINER_ID-$PAI_CONTAINER_HOST_IP-$PAI_CONTAINER_SSH_PORT
   generate_ssh_connect_info ${destFilePath}
 
-  # Enable SSH connect inside
-  # Move ssh config file to /root/.ssh/
-  mv /pai/ssh_config/config /root/.ssh/
-  # Start ssh service
+  # Enable SSH connect
+  cp /pai/ssh_config/config /root/.ssh/
   start_ssh_service
 else
   printf "%s %s\n %s %s \n" \
@@ -162,7 +164,7 @@ fi
 
 {{# reqAzRDMA }}
 {{# azRDMA }}
-function  azure_rdma_preparation()
+function azure_rdma_preparation()
 {
     # https://unix.stackexchange.com/questions/404189/find-and-sed-string-in-docker-got-error-device-or-resource-busy
     cp /etc/hosts /hosts.tmp
@@ -177,17 +179,39 @@ function  azure_rdma_preparation()
 azure_rdma_preparation
 {{/ azRDMA }}
 {{/ reqAzRDMA }}
-# Write env to system-wide environment
-env | grep -E "^PAI|PATH|PREFIX|JAVA|HADOOP|NVIDIA|CUDA" > /etc/environment
+
+function write_user_command()
+{
+  PAI_USER_COMMAND_DIR="/pai/taskData"
+  PAI_USER_COMMAND_PATH="${PAI_USER_COMMAND_DIR}/command.sh"
+  mkdir -p "${PAI_USER_COMMAND_DIR}"
+
+  # Read an escaped string to an array and unescape
+  local lines=$'{{ taskData.command }}'
+  readarray -n 50 -t lines <<< "${lines}"
+  read -n 1000 -a lines <<< "${lines[@]}"
+
+  echo "#!/bin/bash" > "${PAI_USER_COMMAND_PATH}"
+
+  # By default, exit on the first error
+  echo 'set -e' >> "${PAI_USER_COMMAND_PATH}"
+  # Enable logging for the user command
+  echo 'set -x' >> "${PAI_USER_COMMAND_PATH}"
+
+  printf '%s\n' "${lines[@]}" >> "${PAI_USER_COMMAND_PATH}"
+
+  chmod a+x "${PAI_USER_COMMAND_PATH}"
+}
 
 function run_user_command()
 {
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
-  eval {{ taskData.command }} || exit $?
+  exec "${PAI_USER_COMMAND_PATH}" || exit $?
   printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END" # job_exporter relay on this exact output, if you are going to change this, remember to change job_exporter also
   exit 0
 }
 
+write_user_command
 run_user_command &
 user_command_pid=$!
 
@@ -197,12 +221,12 @@ while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 30 
 done
 
 if kill -0 $user_command_pid 2>/dev/null; then
-  echo "job has been killed, docker container exiting"
+  echo "[INFO] The job has been killed, Docker container exiting"
   exit 0
 else
   wait $user_command_pid
   user_command_exitcode=$?
-  echo "job has finished with exit code $user_command_exitcode"
+
 {{# isDebug }}
   if [[ $user_command_exitcode -ne 0 ]]; then
     echo "============================================================================="
@@ -221,6 +245,8 @@ else
 
   fi
 {{/ isDebug }}
+
+  echo "[INFO] The job has finished with exit code $user_command_exitcode"
   exit $user_command_exitcode
 fi
 

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -243,11 +243,6 @@ function write_user_command()
   PAI_USER_COMMAND_PATH="${PAI_USER_COMMAND_DIR}/command.sh"
   mkdir -p "${PAI_USER_COMMAND_DIR}"
 
-  # Read an escaped string to an array and unescape
-  local lines=$'{{ taskData.command }}'
-  readarray -n 50 -t lines <<< "${lines}"
-  read -n 1000 -a lines <<< "${lines[@]}"
-
   echo "#!/bin/bash" > "${PAI_USER_COMMAND_PATH}"
 
   # By default, exit on the first error
@@ -255,7 +250,9 @@ function write_user_command()
   # Enable logging for the user command
   echo 'set -x' >> "${PAI_USER_COMMAND_PATH}"
 
-  printf '%s\n' "${lines[@]}" >> "${PAI_USER_COMMAND_PATH}"
+  cat <<EOF >> "${PAI_USER_COMMAND_PATH}"
+{{{ taskData.command }}}
+EOF
 
   chmod a+x "${PAI_USER_COMMAND_PATH}"
 }

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -180,6 +180,63 @@ azure_rdma_preparation
 {{/ azRDMA }}
 {{/ reqAzRDMA }}
 
+function set_up_user()
+{
+  PAI_CONTAINER_USER_NAME="${PAI_CONTAINER_USER_NAME:-$PAI_USER_NAME}"
+  PAI_CONTAINER_USER_NAME="${PAI_CONTAINER_USER_NAME:-root}" # fallback
+  PAI_CONTAINER_USER_UID="${PAI_CONTAINER_USER_UID:-$PAI_USER_UID}"
+  PAI_CONTAINER_USER_GID="${PAI_CONTAINER_USER_GID:-$PAI_USER_GID}"
+  PAI_CONTAINER_USER_GROUPS="${PAI_CONTAINER_USER_GROUPS:-$PAI_USER_GROUPS}"
+
+  if [[ "${PAI_CONTAINER_USER_NAME}" = "root" ]]; then
+    printf "%s %s\n" \
+      "[INFO]" "Running as user '${PAI_CONTAINER_USER_NAME}'"
+    return
+  fi
+
+  if [[ -n "${PAI_CONTAINER_USER_NAME}" ]]; then
+    for gid in ${PAI_CONTAINER_USER_GID} ${PAI_CONTAINER_USER_GROUPS}; do
+      groupadd -g "${gid}" "${gid}"
+    done
+
+    if [[ -n "${PAI_CONTAINER_USER_UID}" ]]; then
+      local userid="-u ${PAI_CONTAINER_USER_UID}"
+    fi
+    if [[ -n "${PAI_CONTAINER_USER_GID}" ]]; then
+      local usergid="-g ${PAI_CONTAINER_USER_GID}"
+    fi
+    if [[ -n "${PAI_CONTAINER_USER_GROUPS}" ]]; then
+      local usergroups="-G $(echo "${PAI_CONTAINER_USER_GROUPS}" | sed "s@ @,@g" -)"
+    fi
+
+    # avoid Docker sparse files problem: https://github.com/moby/moby/issues/5419
+    useradd $userid $usergid $usergroups \
+      --create-home --home-dir "/home/${PAI_CONTAINER_USER_NAME}" \
+      --no-log-init \
+      --shell /bin/bash --password "" \
+      "${PAI_CONTAINER_USER_NAME}"
+    if [[ "$?" -ne "0" ]]; then
+      printf "%s %s\n" \
+        "[ERROR]" "Failed to create the requested user"
+      return
+    fi
+
+    # Enable passwordless login via SSH
+    cp -r /root/.ssh /home/${PAI_CONTAINER_USER_NAME}/
+
+    # Enable sudo invocation if possible
+    if sudo -V >/dev/null 2>&1; then
+      echo "${PAI_CONTAINER_USER_NAME} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+    else
+      printf "%s %s\n" \
+        "[WARNING]" "Failed to find sudo, root access will be unavailable"
+    fi
+  fi
+}
+
+set_up_user
+
+
 function write_user_command()
 {
   PAI_USER_COMMAND_DIR="/pai/taskData"
@@ -206,7 +263,7 @@ function write_user_command()
 function run_user_command()
 {
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
-  exec "${PAI_USER_COMMAND_PATH}" || exit $?
+  su "${PAI_CONTAINER_USER_NAME}" "${PAI_USER_COMMAND_PATH}" || exit $?
   printf "\n%s %s\n\n" "[INFO]" "USER COMMAND END" # job_exporter relay on this exact output, if you are going to change this, remember to change job_exporter also
   exit 0
 }

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -344,5 +344,6 @@ docker run --name $docker_name \
   --env NVIDIA_VISIBLE_DEVICES=void \
   --env-file $ENV_LIST \
   --entrypoint="" \
+  --user "root" \
    {{ jobData.image }} \
   /bin/bash '/pai/bootstrap/docker_bootstrap.sh'


### PR DESCRIPTION
- Enabled user changing in a container
    - Now, it's possible to change user parameters of the user in a task container. This is similar to using `docker run --user <user/uid>:<gid> --groups-add <gid> ...` parameters. The main reason for this is LDAP auth support and access to protected file shares (NFS, Hadoop, etc.) inside the container.
    - Currently, user can specify the user parameters if it is needed, or decide not to leave from `root` (questionable option)
    - `sudo` rights are added to the selected container user if `sudo` is available in a container. This is useful for interactive work to experiment with container setup (enables `apt` calls etc.) and if something like `mount` command is required.
- Task command is extracted to a separate file
- No new requirements for a task container

Depends on #2406 