### PR TITLE
monitor process memory consumption and alert for om[is]agent

### DIFF
--- a/src/job-exporter/src/ps.py
+++ b/src/job-exporter/src/ps.py
@@ -18,33 +18,38 @@
 
 import subprocess
 import logging
-import collections
 
 import utils
 
 logger = logging.getLogger(__name__)
 
+class ProcessInfo(object):
+    def __init__(self, pid, state, rss, cmd):
+        """ pid is string type, rss is a number in byte """
+        self.pid = pid
+        self.state = state
+        self.rss = rss
+        self.cmd = cmd
+
 def parse_result(ps):
-    result = collections.defaultdict(lambda : 0)
+    result = []
 
     for line in ps.split("\n"):
         line = line.strip()
         if len(line) == 0:
             continue
-        state = line[0]
-        cmd = line[2:]
-        if state == "D":
-            if "nvidia-smi" in cmd:
-                result["nvidia-smi"] += 1 # override command name to make alert rule easier
-            else:
-                cmd = cmd.split()[0] # remove args
-                result[cmd] += 1
+        parts = line.split()
+        state = parts[0]
+        rss = int(parts[1]) * 1024
+        pid = parts[2]
+        cmd = " ".join(parts[3:])
+        result.append(ProcessInfo(pid, state, rss, cmd))
 
     return result
 
-def get_zombie_process(histogram, timeout):
+def get_process_info(histogram, timeout):
     try:
-        ps_output = utils.exec_cmd(["ps", "ax", "--no-headers", "--format", "state,cmd"],
+        ps_output = utils.exec_cmd(["ps", "ax", "--no-headers", "--format", "state,rss,pid,cmd"],
                 histogram=histogram, timeout=timeout)
 
         return parse_result(ps_output)
@@ -52,7 +57,7 @@ def get_zombie_process(histogram, timeout):
         logger.exception("command '%s' return with error (code %d): %s",
                 e.cmd, e.returncode, e.output)
     except subprocess.TimeoutExpired:
-        logger.warning("ps aux timeout")
+        logger.warning("ps ax timeout")
     except Exception:
         logger.exception("exec ps aux error")
 

--- a/src/job-exporter/src/ps.py
+++ b/src/job-exporter/src/ps.py
@@ -59,6 +59,6 @@ def get_process_info(histogram, timeout):
     except subprocess.TimeoutExpired:
         logger.warning("ps ax timeout")
     except Exception:
-        logger.exception("exec ps aux error")
+        logger.exception("exec ps ax error")
 
     return None

--- a/src/job-exporter/src/ps.py
+++ b/src/job-exporter/src/ps.py
@@ -61,4 +61,4 @@ def get_process_info(histogram, timeout):
     except Exception:
         logger.exception("exec ps ax error")
 
-    return None
+    return []

--- a/src/job-exporter/test/data/ps_sample.txt
+++ b/src/job-exporter/test/data/ps_sample.txt
@@ -1,10 +1,4 @@
-D /var/drivers/nvidia/current/bin/nvidia-smi -q -x
-S /lib/systemd/systemd --system --deserialize 27
-S [kthreadd]
-I [kworker/0:0H]
-I [mm_percpu_wq]
-S [ksoftirqd/0]
-I [rcu_sched]
-I [rcu_bh]
-S [migration/0]
-S [watchdog/0]
+D 2 4 /var/drivers/nvidia/current/bin/nvidia-smi -q -x
+S 1 2 /lib/systemd/systemd --system --deserialize 27
+S 2 3 [kthreadd]
+I 4 5 [kworker/0:0H]

--- a/src/job-exporter/test/test_ps.py
+++ b/src/job-exporter/test/test_ps.py
@@ -34,8 +34,13 @@ class TestPS(base.TestBase):
         with open(sample_path, "r") as f:
             ps_result = f.read()
         parse_result = ps.parse_result(ps_result)
-        target_result = {"nvidia-smi": 1}
-        self.assertEqual(target_result, parse_result)
+
+        self.assertEqual(4, len(parse_result))
+        self.assertEqual("D", parse_result[0].state)
+        self.assertEqual("4", parse_result[0].pid)
+        self.assertEqual(2 * 1024, parse_result[0].rss)
+        self.assertEqual("/var/drivers/nvidia/current/bin/nvidia-smi -q -x",
+                parse_result[0].cmd)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/prometheus/deploy/alerting/node.rules
+++ b/src/prometheus/deploy/alerting/node.rules
@@ -55,3 +55,9 @@ groups:
         for: 5m
         annotations:
           summary: "{{$labels.instance}} is not ready"
+
+      - alert: AzureAgentConsumeTooMuchMem
+        expr: process_mem_usage_byte{cmd=~".*om[is]agent.*"} > 1073741824 # 1G
+        for: 5m
+        annotations:
+          summary: "{{$labels.cmd}} with pid {{$labels.pid}} in {{$labels.instance}} consume more than 1G of memory"


### PR DESCRIPTION
Get process memory consumption by ps rss, report those who use more than 500M to save space in prometheus. Also defined an alert rule for process `omiagent` and `omsagent`, these two processes are frequently causing OOM in azure VM, which DRI should take care of.