### PR TITLE
[Web Portal] chore: keep using port 9286 in dev server; fix favicon.ico display

### DIFF
--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -190,6 +190,7 @@ const config = (env, argv) => ({
     }),
     new CopyWebpackPlugin([
       {from: 'src/assets', to: 'assets'},
+      {from: 'src/assets/img/favicon.ico', to: 'favicon.ico'},
     ]),
     new MiniCssExtractPlugin({
       filename: 'styles/[name].bundle.css',
@@ -286,6 +287,7 @@ const config = (env, argv) => ({
   ],
   devServer: {
     contentBase: path.resolve(__dirname, '..', 'dist'),
+    port: 9286,
   },
   optimization: {
     minimizer: [

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -32,18 +32,19 @@ const logger = require('./logger');
 const app = express();
 
 app.use(compress());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 app.use(cookieParser());
 
+// setup favicon
+app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
+
 // setup the logger for requests
-app.use(morgan('dev', { 'stream': logger.stream }));
+app.use(morgan('dev', {'stream': logger.stream}));
 
 // setup the root path
 app.use(express.static(path.join(appRoot.path, 'dist')));
 
-// setup favicon
-app.use(favicon(path.join(appRoot.path, 'dist', 'assets', 'img', 'favicon.ico')));
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {
@@ -57,7 +58,7 @@ app.use((err, req, res, next) => {
   logger.warn('%s', err.stack);
   res.status(err.status || 500).json({
     message: err.message,
-    error: config.env === 'development' ? err.stack : {}
+    error: config.env === 'development' ? err.stack : {},
   });
 });
 

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -36,11 +36,11 @@ app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 app.use(cookieParser());
 
-// setup favicon
-app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
-
 // setup the logger for requests
 app.use(morgan('dev', {'stream': logger.stream}));
+
+// setup favicon
+app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
 
 // setup the root path
 app.use(express.static(path.join(appRoot.path, 'dist')));


### PR DESCRIPTION
- webpack
  - change dev server's port
  - copy favicon to output directory root
- server
  - fix some lint errors in express.js