### PR TITLE
Extend job expiry to reduce false timeout

### DIFF
--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -191,7 +191,7 @@ function run_user_command()
 run_user_command &
 user_command_pid=$!
 
-while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 60 ] && \
+while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 120 ] && \
         kill -0 $user_command_pid 2>/dev/null; do
   sleep 20
 done

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -191,14 +191,14 @@ function run_user_command()
 run_user_command &
 user_command_pid=$!
 
-while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 30 ] && \
+while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 60 ] && \
         kill -0 $user_command_pid 2>/dev/null; do
   sleep 20
 done
 
 if kill -0 $user_command_pid 2>/dev/null; then
   echo "job has been killed, docker container exiting"
-  exit 0
+  exit 1
 else
   wait $user_command_pid
   user_command_exitcode=$?


### PR DESCRIPTION
We found that some command might consume 10+ secs, then job will be considered timeout and killed
![image](https://user-images.githubusercontent.com/11887940/55374250-60158d00-553a-11e9-8e6c-45d2117aee57.png)


Still investigating.
