### PR TITLE
[Drivers] Add an optional configuration to skip ib drivers installation.

### DIFF
--- a/src/drivers/build/install-all-drivers
+++ b/src/drivers/build/install-all-drivers
@@ -43,13 +43,17 @@ else
     echo NVIDIA gpu not detected, skipping driver installation
 fi
 
-if lspci | grep -qE '(Network|Infiniband) controller.*Mellanox.*ConnectX'; then
-    echo Infiniband hardware detected
-    # Installing InfiniBand drivers and GPU direct RDMA drivers
-    ./install-ib-drivers || exit $?
-    echo Infiniband drivers is installed successfully.
+if [ -n ${SKIP_IB} ]; then
+    if lspci | grep -qE '(Network|Infiniband) controller.*Mellanox.*ConnectX'; then
+        echo Infiniband hardware detected
+        # Installing InfiniBand drivers and GPU direct RDMA drivers
+        ./install-ib-drivers || exit $?
+        echo Infiniband drivers is installed successfully.
+    else
+        echo Infiniband hardware is not detected, skipping driver installation
+    fi
 else
-    echo Infiniband hardware is not detected, skipping driver installation
+    echo "Depending on configuration, the variable SKIP_IB is set. So the ib installation will be skipped!"
 fi
 
 

--- a/src/drivers/build/install-all-drivers
+++ b/src/drivers/build/install-all-drivers
@@ -43,7 +43,7 @@ else
     echo NVIDIA gpu not detected, skipping driver installation
 fi
 
-if [ -n ${SKIP_IB} ]; then
+if [ -z ${SKIP_IB} ]; then
     if lspci | grep -qE '(Network|Infiniband) controller.*Mellanox.*ConnectX'; then
         echo Infiniband hardware detected
         # Installing InfiniBand drivers and GPU direct RDMA drivers

--- a/src/drivers/config/drivers.py
+++ b/src/drivers/config/drivers.py
@@ -49,6 +49,8 @@ class Drivers:
             return False, "set-nvidia-runtime is miss in service-configuration -> drivers."
         if self.service_configuration["set-nvidia-runtime"] not in [False, True]:
             return False, "Value of set-nvidia-runtme should be false or true."
+        if self.service_configuration["skip-ib-installation"] not in [False, True]:
+            return False, "Value of skip-ib-installation should be false or true."
         if "version" not in self.service_configuration:
             return False, "version is miss in service-configuration -> drivers."
         if self.service_configuration["version"] not in ["384.111", "390.25", "410.73"]:

--- a/src/drivers/config/drivers.yaml
+++ b/src/drivers/config/drivers.yaml
@@ -26,3 +26,6 @@ set-nvidia-runtime: false
 version: "384.111"
 
 pre-installed-nvidia-path: /usr/local/nvidia
+
+
+skip-ib-installation: false

--- a/src/drivers/deploy/drivers.yaml.template
+++ b/src/drivers/deploy/drivers.yaml.template
@@ -57,6 +57,10 @@ spec:
         - mountPath: {{ cluster_cfg["drivers"]["pre-installed-nvidia-path"] }}
           name: pre-install-nv-driver-path
         env:
+        {% if cluster_cfg['drivers']['skip-ib-installation'] %}
+        - name: SKIP_IB
+          value: "true"
+        {%- endif %}
         - name: DRIVER_PATH
           value: /var/drivers/nvidia
         - name: PRE_INSTALLED_NV_DRIVER_PATH


### PR DESCRIPTION
Approach to skip InfiniBand installation, after the PR.

1): Configuration
Please set the following configuration into your service configuration.
```
drivers:
    skip-ib-installation: true
```
