### PR TITLE
fix alert label error

### DIFF
--- a/src/prometheus/deploy/alerting/node.rules
+++ b/src/prometheus/deploy/alerting/node.rules
@@ -42,19 +42,19 @@ groups:
         expr: pai_node_count{disk_pressure="true"} > 0
         for: 5m
         annotations:
-          summary: "{{$labels.instance}} is under disk pressure"
+          summary: "{{$labels.name}} is under disk pressure"
 
       - alert: NodeOutOfDisk
         expr: pai_node_count{out_of_disk="true"} > 0
         for: 5m
         annotations:
-          summary: "{{$labels.instance}} is out of disk"
+          summary: "{{$labels.name}} is out of disk"
 
       - alert: NodeNotReady
         expr: pai_node_count{ready!="true"} > 0
         for: 5m
         annotations:
-          summary: "{{$labels.instance}} is not ready"
+          summary: "{{$labels.name}} is not ready"
 
       - alert: AzureAgentConsumeTooMuchMem
         expr: process_mem_usage_byte{cmd=~".*om[is]agent.*"} > 1073741824 # 1G


### PR DESCRIPTION
fix alert label error in pai_node_count alert.

This metric is scrapped by watchdog, so the instance label will be where watchdog was deployed. We can not use this label, there are `name` label in watchdog to represent the node's IP, so we should use `name` here instead of `instance`.