### PR TITLE
Fix script entrypoint to correctly redirect stdout/stderr

### DIFF
--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -535,7 +535,7 @@ class Job {
         'taskNumber': data.taskRoles[i].taskNumber,
         'taskService': {
           'version': 0,
-          'entryPoint': `source YarnContainerScripts/${i}.sh`,
+          'entryPoint': `bash YarnContainerScripts/${i}.sh`,
           'sourceLocations': [`/Container/${data.userName}/${data.jobName}/YarnContainerScripts`],
           'resource': {
             'cpuNumber': data.taskRoles[i].cpuNumber,


### PR DESCRIPTION
This is full yarn entrypoint: 
`exec /bin/bash -c "source YarnContainerScripts/2.sh 1>$LAUNCHER_LOG_DIR/stdout 2>$LAUNCHER_LOG_DIR/stderr"`
`source` will extract the exit_handler to parent process  and bypass the redirect.

There are 2 fix options:
1. replace `source` with `bash`
2. move redirect out of quotation

Source:
![image](https://user-images.githubusercontent.com/11887940/55788529-12c18e80-5aeb-11e9-91e3-46cd916c0f58.png)

Bash:
![image](https://user-images.githubusercontent.com/11887940/55788601-2ec53000-5aeb-11e9-887a-5f1057e6a60a.png)
