### PR TITLE
Split user log and runtime log into seperate files

### DIFF
--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -31,8 +31,8 @@ DISK_CLEANER_ERROR_FILE=/pai/log/diskCleaner.pai.error
 
 # create runtime docker log here. Since multi shell IO block will write to the files,
 # we just append lines to the log file to avoid flush exits contents.
-touch RUNTIME_DOCKER_ERR_LOG
-touch RUNTIME_DOCKER_LOG
+touch $RUNTIME_DOCKER_ERR_LOG
+touch $RUNTIME_DOCKER_LOG
 
 # This function is duplicate between dockerContainerScript and yarnContainerScript\
 # Need to remove one if we discard the shell scirpt
@@ -49,9 +49,9 @@ function log_runtime_error()
 
 function exit_handler()
 {
+  rc=$?
   printf "%s %s\n" \
     "[DEBUG]" "Docker container exit handler: EXIT signal received in docker container, exiting ..."
-  rc=$?
   if [[ $rc -eq 0 ]]; then
     exit 0
   fi

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -23,11 +23,21 @@
 exec 17>/pai/log/DockerContainerDebug.log
 BASH_XTRACEFD=17
 
+RUNTIME_DOCKER_LOG=/pai/log/runtime.docker.pai.log
+RUNTIME_DOCKER_ERR_LOG=/pai/log/runtime.docker.pai.error
+USER_LOG=/pai/log/user.pai.log
+USER_ERROR_LOG=/pai/log/user.pai.error
+
+# create runtime docker log here. Since multi shell IO block will write to the files,
+# we just append lines to the log file to avoid flush exits contents.
+touch RUNTIME_DOCKER_ERR_LOG
+touch RUNTIME_DOCKER_LOG
+
 function exit_handler()
 {
   printf "%s %s\n" \
     "[DEBUG]" "Docker container exit handler: EXIT signal received in docker container, exiting ..."
-}
+} 1>> $RUNTIME_DOCKER_LOG 2>> $RUNTIME_DOCKER_ERR_LOG
 
 # The cleaner will send SIGUSR1(10) to container to kill it. Trap the signal here and exit with code 1.
 function kill_handler()
@@ -35,7 +45,9 @@ function kill_handler()
   printf "%s %s\n" \
     "[INFO]" "Docker container killed by cleaner due to disk pressure."
   exit 1
-}
+} 1>> $RUNTIME_DOCKER_LOG 2>> $RUNTIME_DOCKER_ERR_LOG
+
+{
 
 set -x
 PS4="+[\t] "
@@ -180,6 +192,8 @@ azure_rdma_preparation
 # Write env to system-wide environment
 env | grep -E "^PAI|PATH|PREFIX|JAVA|HADOOP|NVIDIA|CUDA" > /etc/environment
 
+} 1>> $RUNTIME_DOCKER_LOG 2>> $RUNTIME_DOCKER_ERR_LOG
+
 function run_user_command()
 {
   printf "%s %s\n\n" "[INFO]" "USER COMMAND START"
@@ -188,7 +202,9 @@ function run_user_command()
   exit 0
 }
 
-run_user_command &
+run_user_command > >(tee $USER_LOG) 2> >(tee $USER_ERROR_LOG >&2) &
+
+{
 user_command_pid=$!
 
 while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 120 ] && \
@@ -223,4 +239,4 @@ else
 {{/ isDebug }}
   exit $user_command_exitcode
 fi
-
+} 1>> $RUNTIME_DOCKER_LOG 2>> $RUNTIME_DOCKER_ERR_LOG

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -27,32 +27,45 @@ RUNTIME_DOCKER_LOG=/pai/log/runtime.docker.pai.log
 RUNTIME_DOCKER_ERR_LOG=/pai/log/runtime.docker.pai.error
 USER_LOG=/pai/log/user.pai.log
 USER_ERROR_LOG=/pai/log/user.pai.error
+DISK_CLEANER_ERROR_FILE=/pai/log/diskCleaner.pai.error
 
 # create runtime docker log here. Since multi shell IO block will write to the files,
 # we just append lines to the log file to avoid flush exits contents.
 touch RUNTIME_DOCKER_ERR_LOG
 touch RUNTIME_DOCKER_LOG
 
+# This function is duplicate between dockerContainerScript and yarnContainerScript\
+# Need to remove one if we discard the shell scirpt
+function log_runtime_error()
+{
+  local level=$1
+  local message_type=$2
+  local error_message=$3
+  local timestamp=$(date +%s)
+
+  printf "%s\n" "$timestamp $level $message_type $error_message" >> $RUNTIME_DOCKER_ERR_LOG
+}
+
+
 function exit_handler()
 {
   printf "%s %s\n" \
     "[DEBUG]" "Docker container exit handler: EXIT signal received in docker container, exiting ..."
+  rc=$?
+  if [[ $rc -eq 0 ]]; then
+    exit 0
+  fi
+
+  log_runtime_error "ERROR" "REASON" "\"Exiting because of user error, exit code: $rc\""
+  exit $rc
 } 1>> $RUNTIME_DOCKER_LOG 2>> $RUNTIME_DOCKER_ERR_LOG
 
-# The cleaner will send SIGUSR1(10) to container to kill it. Trap the signal here and exit with code 1.
-function kill_handler()
-{
-  printf "%s %s\n" \
-    "[INFO]" "Docker container killed by cleaner due to disk pressure."
-  exit 1
-} 1>> $RUNTIME_DOCKER_LOG 2>> $RUNTIME_DOCKER_ERR_LOG
 
 {
 
 set -x
 PS4="+[\t] "
 trap exit_handler EXIT
-trap kill_handler 10
 
 touch "/alive/docker_$PAI_CONTAINER_ID"
 
@@ -207,8 +220,34 @@ run_user_command > >(tee $USER_LOG) 2> >(tee $USER_ERROR_LOG >&2) &
 {
 user_command_pid=$!
 
+function grep_kill_command_from_file()
+{
+  local file_name=$1
+  local rc=0
+
+  if [[ -f $file_name ]]; then
+    grep "ACTION \"KILL\"" $file_name 2>&1 > /dev/null
+    rc=$?
+  fi
+  return $rc
+}
+
+function handle_exit_command()
+{
+  if [[ -f $DISK_CLEANER_ERROR_FILE ]]; then
+    grep_kill_command_from_file $DISK_CLEANER_ERROR_FILE
+    if [[ $? -eq 0 ]]; then
+      printf "[INFO] Docker container killed by cleaner due to disk pressure.\n"
+      log_runtime_error "ERROR" "REASON" "\"docker container killed by disk cleaner\""
+      exit 1
+    fi
+  fi
+}
+
+
 while [ $(( $(date +%s) - $(stat -c %Y /alive/yarn_$PAI_CONTAINER_ID) )) -lt 120 ] && \
         kill -0 $user_command_pid 2>/dev/null; do
+  handle_exit_command
   sleep 20
 done
 
@@ -219,6 +258,7 @@ else
   wait $user_command_pid
   user_command_exitcode=$?
   echo "job has finished with exit code $user_command_exitcode"
+
 {{# isDebug }}
   if [[ $user_command_exitcode -ne 0 ]]; then
     echo "============================================================================="

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -26,14 +26,19 @@ export PAI_DEFAULT_FS_URI={{ hdfsUri }}
 exec 13>$LAUNCHER_LOG_DIR/YarnContainerDebug.log
 BASH_XTRACEFD=13
 
+RUNTIME_YARN_ERR_LOG=$LAUNCHER_LOG_DIR/runtime.yarn.pai.error
+RUNTIME_YARN_LOG=$LAUNCHER_LOG_DIR/runtime.yarn.pai.log
+
+touch RUNTIME_YARN_ERR_LOG
+touch RUNTIME_YARN_LOG
+
 # YARN kill container will send SIGTERM(15) and SIGKILL(9)
 function sigterm_handler()
 {
   printf "[DEBUG] SIGTERM received, job may be killed by YARN\n"
   killed_by_yarn=true
   exit 143
-}
-
+} 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
 
 function exit_handler()
 {
@@ -62,8 +67,9 @@ function exit_handler()
   fi
 
   exit $rc
-}
+} 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
 
+{
 set -x
 PS4="+[\t] "
 trap sigterm_handler SIGTERM
@@ -278,6 +284,11 @@ fi
 log_dir="tmp/pai-root/log"
 mkdir -p $log_dir
 ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/DockerContainerDebug.log $LAUNCHER_LOG_DIR/DockerContainerDebug.log
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/runtime.user.pai.error $LAUNCHER_LOG_DIR/runtime.user.pai.error
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/runtime.user.pai.log $LAUNCHER_LOG_DIR/runtime.user.pai.log
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/user.pai.error $LAUNCHER_LOG_DIR/user.pai.error
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/user.pai.log $LAUNCHER_LOG_DIR/user.pai.log
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/diskCleaner.pai.error $LAUNCHER_LOG_DIR/diskCleaner.pai.error
 
 # copy the hadoop configuration file
 hadoop_config_dir="hadoop_config"
@@ -295,6 +306,7 @@ container_local_dir=$mounted_path/nm-local-dir/usercache/{{ jobData.userName }}/
 docker pull {{ jobData.image }} \
   || { echo "Can not pull Docker image"; exit 1; }
 
+} 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
 ## ATTENTION: do not specify `--pid=host` when run job, otherwise job-exporter can not get right
 ## network consumption
 docker run --name $docker_name \

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -178,10 +178,11 @@ function generate_agg_err()
   # Here we persume the kill event trigger seq is diskCleaner, runtime and user error
   printf "[DEBUG] Generate aggregate dynamic error info\n"
 
+  printf "[PAI_RUNTIME_ERROR_START]\n" >> $RUNTIME_AGG_ERROR_FILE
   generate_error_summary
 
   echo "errorLogs:" >> $RUNTIME_AGG_ERROR_FILE
-  echo "- user: |" >> $RUNTIME_AGG_ERROR_FILE
+  echo "  user: |" >> $RUNTIME_AGG_ERROR_FILE
   if [[ -f $USER_ERROR_FILE ]]; then
     printf "%s\n" "$(printf_file_tail_with_shift $USER_ERROR_FILE "    " 20)" >> $RUNTIME_AGG_ERROR_FILE
   fi
@@ -199,6 +200,7 @@ function generate_agg_err()
   if [[ -f $DISK_CLEANER_ERROR_FILE ]]; then
     printf "%s\n" "$(printf_file_tail_with_shift $DISK_CLEANER_ERROR_FILE "    " 5)" >> $RUNTIME_AGG_ERROR_FILE
   fi
+  printf "[PAI_RUNTIME_ERROR_END]\n" >> $RUNTIME_AGG_ERROR_FILE
 }
 
 

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -64,7 +64,7 @@ function sigterm_handler()
   log_runtime_error "ERROR" "REASON" "\"YARN Container receive signal SIGTERM\""
   log_runtime_error "ERROR" "RECEIVE_SIGNAL" "\"SIGTERM\""
   exit $CONTAINER_SIGTERM_ERROR
-} 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
+} 1>> $RUNTIME_YARN_LOG 2>> $RUNTIME_YARN_ERR_LOG
 
 
 function write_error_summary()
@@ -118,6 +118,7 @@ function printf_file_tail_with_shift()
   local file_content=$(tail -n "$tail_num" "$file_name")
   while IFS= read -r line
   do
+    line=$(echo $line | sed -e 's/^[[:blank:]]*//' | tr -d '\n\r')
     echo "$shift_space$line"
   done < <(printf '%s\n' "$file_content")
 }
@@ -246,7 +247,7 @@ function exit_handler()
   echo $rc > "/var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
 
   exit $rc
-} 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
+} 1>> $RUNTIME_YARN_LOG 2>> $RUNTIME_YARN_ERR_LOG
 
 {
 set -x
@@ -463,8 +464,8 @@ fi
 log_dir="tmp/pai-root/log"
 mkdir -p $log_dir
 ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/DockerContainerDebug.log $LAUNCHER_LOG_DIR/DockerContainerDebug.log
-ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/runtime.user.pai.error $LAUNCHER_LOG_DIR/runtime.user.pai.error
-ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/runtime.user.pai.log $LAUNCHER_LOG_DIR/runtime.user.pai.log
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/runtime.docker.pai.error $LAUNCHER_LOG_DIR/runtime.docker.pai.error
+ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/runtime.docker.pai.log $LAUNCHER_LOG_DIR/runtime.docker.pai.log
 ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/user.pai.error $LAUNCHER_LOG_DIR/user.pai.error
 ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/user.pai.log $LAUNCHER_LOG_DIR/user.pai.log
 ln -s /$LOCAL_DIRS/$CONTAINER_ID/$log_dir/diskCleaner.pai.error $LAUNCHER_LOG_DIR/diskCleaner.pai.error
@@ -485,7 +486,7 @@ container_local_dir=$mounted_path/nm-local-dir/usercache/{{ jobData.userName }}/
 docker pull {{ jobData.image }} \
   || { echo "Can not pull Docker image"; exit 1; }
 
-} 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
+} 1>> $RUNTIME_YARN_LOG 2>> $RUNTIME_YARN_ERR_LOG
 ## ATTENTION: do not specify `--pid=host` when run job, otherwise job-exporter can not get right
 ## network consumption
 docker run --name $docker_name \

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -28,43 +28,220 @@ BASH_XTRACEFD=13
 
 RUNTIME_YARN_ERR_LOG=$LAUNCHER_LOG_DIR/runtime.yarn.pai.error
 RUNTIME_YARN_LOG=$LAUNCHER_LOG_DIR/runtime.yarn.pai.log
+RUNTIME_DOCKER_ERR_LOG=$LAUNCHER_LOG_DIR/runtime.docker.pai.error
+RUNTIME_DOCKER_LOG=$LAUNCHER_LOG_DIR/runtime.docker.pai.log
+USER_ERROR_FILE=$LAUNCHER_LOG_DIR/user.pai.error
+DISK_CLEANER_ERROR_FILE=$LAUNCHER_LOG_DIR/diskCleaner.pai.error
+RUNTIME_AGG_ERROR_FILE=$LAUNCHER_LOG_DIR/runtime.pai.agg.error
 
 touch RUNTIME_YARN_ERR_LOG
 touch RUNTIME_YARN_LOG
+
+EXIT_SUCCEED=0
+CONTAINER_SIGTERM_ERROR=143
+DOCKER_DEAMON_ERROR=193
+CONTAINER_OOM_ERROR=196
+CONTAINER_OOD_ERROR=198
+RUNTIME_UNRECOGNIZED_ERROR=255
+
+
+function log_runtime_error()
+{
+  local level=$1
+  local message_type=$2
+  local error_message=$3
+  local timestamp=$(date +%s)
+
+  printf "%s\n" "$timestamp $level $message_type $error_message" >> $RUNTIME_YARN_ERR_LOG
+}
+
 
 # YARN kill container will send SIGTERM(15) and SIGKILL(9)
 function sigterm_handler()
 {
   printf "[DEBUG] SIGTERM received, job may be killed by YARN\n"
   killed_by_yarn=true
-  exit 143
+  log_runtime_error "ERROR" "REASON" "\"YARN Container receive signal SIGTERM\""
+  log_runtime_error "ERROR" "RECEIVE_SIGNAL" "\"SIGTERM\""
+  exit $CONTAINER_SIGTERM_ERROR
 } 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG
+
+
+function write_error_summary()
+{
+  local exit_code=$1
+  local trigger=$2
+  local parse_file=$3
+  local docker_status=$4
+  local caught_signal=$5
+
+  local user_exit_code=$(grep -o "INFO USER_EXIT_CODE.*" $RUNTIME_YARN_ERR_LOG | tail -n 1 | grep -o "[0-9]*")
+  if [[ $exit_code == "" ]]; then
+    if [[ $user_exit_code != "" && $user_exit_code -gt 0 ]]; then
+      exit_code=$RUNTIME_UNRECOGNIZED_ERROR
+    else
+      exit_code=$EXIT_SUCCEED
+    fi
+  fi
+
+  echo "exitcode: ${exit_code}" >> $RUNTIME_AGG_ERROR_FILE
+  echo "trigger: $trigger" >> $RUNTIME_AGG_ERROR_FILE
+
+  if [[ $parse_file != "" ]]; then
+    local reason=$(grep "ERROR REASON" $parse_file |  tail -n 1 | grep -o '".*"' | sed 's/"//g')
+    local solution=$(grep "ERROR SOLUTION" $parse_file |  tail -n 1 | grep -o '".*"' | sed 's/"//g')
+  fi
+  
+  echo "reason: $reason" >> $RUNTIME_AGG_ERROR_FILE
+  echo "solution: $solution" >> $RUNTIME_AGG_ERROR_FILE
+  echo "originalUserExitCode: $user_exit_code" >> $RUNTIME_AGG_ERROR_FILE
+
+  echo "dockerStatus: $docker_status" >> $RUNTIME_AGG_ERROR_FILE
+  echo "caughtSignal: $caught_signal" >> $RUNTIME_AGG_ERROR_FILE
+
+  # Not supported yet
+  echo "caughtException:" >> $RUNTIME_AGG_ERROR_FILE
+  echo "matchedUserLogString:" >> $RUNTIME_AGG_ERROR_FILE
+}
+
+
+function printf_file_tail_with_shift()
+{
+  local file_name=$1
+  local shift_space=$2
+  local tail_num=$3
+
+  if [[ $tail_num == "" ]]; then
+    tail_num=10
+  fi
+
+  local file_content=$(tail -n "$tail_num" "$file_name")
+  while IFS= read -r line
+  do
+    echo "$shift_space$line"
+  done < <(printf '%s\n' "$file_content")
+}
+
+
+function generate_error_summary()
+{
+  if [[ -f $DISK_CLEANER_ERROR_FILE ]]; then
+    grep "ACTION \"KILL\"" $DISK_CLEANER_ERROR_FILE 2>&1 > /dev/null
+    if [[ $? -eq 0 ]]; then
+      write_error_summary $CONTAINER_OOD_ERROR "diskCleanerErrorLog" $DISK_CLEANER_ERROR_FILE
+      return
+    fi
+  fi
+
+  if [[ -f $RUNTIME_DOCKER_ERR_LOG ]]; then
+    grep "ERROR REASON" $RUNTIME_DOCKER_ERR_LOG | grep "Exiting because of user error" 2>&1 > /dev/null
+    if [[ $? -eq 0 ]]; then
+      write_error_summary $RUNTIME_UNRECOGNIZED_ERROR "originalUserExitCode" $RUNTIME_DOCKER_ERR_LOG
+      return
+    fi
+  fi
+
+  if [[ -f $RUNTIME_YARN_ERR_LOG ]]; then
+    grep "ERROR REASON" $RUNTIME_YARN_ERR_LOG | grep "docker deamon error" 2>&1 > /dev/null
+    if [[ $? -eq 0 ]]; then
+      write_error_summary $DOCKER_DEAMON_ERROR "dockerStatus" $RUNTIME_YARN_ERR_LOG "DeamonError"
+      return
+    fi
+
+    grep "ERROR REASON" $RUNTIME_YARN_ERR_LOG | grep "out of memory (OOM)" 2>&1 > /dev/null
+    if [[ $? -eq 0 ]]; then
+      local signal=$(grep -o "RECEIVE_SIGNAL.*" $RUNTIME_YARN_ERR_LOG | grep -o '".*"' | sed 's/"//g')
+      if [[ $signal == "" ]]; then
+        signal="unknownSignal"
+      fi
+      write_error_summary $CONTAINER_OOM_ERROR "caughtSignal" $RUNTIME_YARN_ERR_LOG "" $signal
+      return
+    fi
+
+    grep "ERROR REASON" $RUNTIME_YARN_ERR_LOG | grep "YARN Container receive signal SIGTERM" 2>&1 > /dev/null
+    if [[ $? -eq 0 ]]; then
+      local signal=$(grep -o "RECEIVE_SIGNAL.*" $RUNTIME_YARN_ERR_LOG | grep -o '".*"' | sed 's/"//g')
+      if [[ $signal == "" ]]; then
+        signal="unknownSignal"
+      fi
+      write_error_summary $CONTAINER_SIGTERM_ERROR "caughtSignal" $RUNTIME_YARN_ERR_LOG "" $signal
+    fi
+  fi
+
+  # write empty error summary for successful exit
+  write_error_summary
+}
+
+
+function generate_agg_err()
+{
+  # Here we persume the kill event trigger seq is diskCleaner, runtime and user error
+  printf "[DEBUG] Generate aggregate dynamic error info\n"
+
+  generate_error_summary
+
+  echo "errorLogs:" >> $RUNTIME_AGG_ERROR_FILE
+  echo "- user: |" >> $RUNTIME_AGG_ERROR_FILE
+  if [[ -f $USER_ERROR_FILE ]]; then
+    printf "%s\n" "$(printf_file_tail_with_shift $USER_ERROR_FILE "    " 20)" >> $RUNTIME_AGG_ERROR_FILE
+  fi
+
+  echo "  runtime: |" >> $RUNTIME_AGG_ERROR_FILE
+  if [[ -f $RUNTIME_DOCKER_ERR_LOG ]]; then
+    printf "%s\n" "$(printf_file_tail_with_shift $RUNTIME_DOCKER_ERR_LOG "    " 5)" >> $RUNTIME_AGG_ERROR_FILE
+  fi
+
+  if [[ -f $RUNTIME_YARN_ERR_LOG ]]; then
+    printf "%s\n" "$(printf_file_tail_with_shift $RUNTIME_YARN_ERR_LOG "    " 5)" >> $RUNTIME_AGG_ERROR_FILE
+  fi
+
+  echo "  disk: |" >> $RUNTIME_AGG_ERROR_FILE
+  if [[ -f $DISK_CLEANER_ERROR_FILE ]]; then
+    printf "%s\n" "$(printf_file_tail_with_shift $DISK_CLEANER_ERROR_FILE "    " 5)" >> $RUNTIME_AGG_ERROR_FILE
+  fi
+}
+
 
 function exit_handler()
 {
   rc=$?
-  printf "[DEBUG] Performing clean up action...\n"
+
+  log_runtime_error "INFO" "USER_EXIT_CODE" "$rc"
+
   if [[ $rc -eq 125 ]]; then
     # We assume 125 is a docker error, and retry it without burning user's retry count
     printf "[DEBUG] Exit code 125, it may be docker error, convert it to a transient error\n"
-    rc=205
+    log_runtime_error "ERROR" "REASON" "\"Current container is killed, may be due to the docker deamon error\""
   fi
 
   if [[ ${killed_by_yarn} != true && $rc -eq 143 || $rc -eq 137 ]]; then
     printf "[DEBUG] Exit code $rc, it may be due to out of memory (OOM) or other critical errors.\n"
-    rc=55
-  fi
+    log_runtime_error "ERROR" "REASON" "\"Current container is killed, may be due to out of memory (OOM) or other critical errors.\""
+    if [[ $rc -eq 143 ]]; then
+      log_runtime_error "ERROR" "RECEIVE_SIGNAL" "\"SIGTERM\""
+    fi
 
-  printf "[DEBUG] Write exit code $rc to file /var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode.\n"
-  echo $rc > "/var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
+    if [[ $rc -eq 137 ]]; then
+      log_runtime_error "ERROR" "RECEIVE_SIGNAL" "\"SIGKILL\""
+    fi
+  fi
 
   # After all necessary steps, do a best effort kill here
   pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
-  if [ $pid -gt 0 ]; then
+  if [[ $pid != "" && $pid -gt 0 ]]; then
     kill -15 $pid &&\
       printf "[DEBUG] Docker container $docker_name killed successfully." ||\
       printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."
   fi
+  generate_agg_err
+
+  rc=$(grep "exitcode:" $RUNTIME_AGG_ERROR_FILE | head -n 1 | grep -o '[0-9]*')
+  if [[ $rc -eq "" ]]; then
+    rc=0
+  fi
+
+  printf "[DEBUG] Write exit code $rc to file /var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode.\n"
+  echo $rc > "/var/lib/hadoopdata/nm-local-dir/nmPrivate/$APP_ID/$CONTAINER_ID/$CONTAINER_ID.pid.exitcode"
 
   exit $rc
 } 1 >> $RUNTIME_YARN_LOG 2 >> $RUNTIME_YARN_ERR_LOG


### PR DESCRIPTION
This change contains following chanages:
1. Collect DockerCotainerLog to runtime.docker.pai.error
2. Collect YarnContainerLog to runtime.yarn.pai.error
3. Collect user log to user.pai.error

Testing Done:
Just test the basic function for redirection command