### PR TITLE
[hadoop] remove duplicate diagnostics

### DIFF
--- a/src/hadoop-ai/build/build-pre.sh
+++ b/src/hadoop-ai/build/build-pre.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0") > /dev/null
 hadoopBinaryDir="/hadoop-binary"
 
 # When changing the patch id, please update it.
-patchId="12940533-12933562-docker_executor-12944563-fix1"
+patchId="12940533-12933562-docker_executor-12944563-fix1-20190410"
 
 hadoopBinaryPath="${hadoopBinaryDir}/hadoop-2.9.0.tar.gz"
 cacheVersion="${hadoopBinaryDir}/${patchId}-done"

--- a/src/hadoop-ai/build/build.sh
+++ b/src/hadoop-ai/build/build.sh
@@ -35,6 +35,7 @@ git apply /docker-executor.patch
 # to avoid potential endless loop, refer to https://issues.apache.org/jira/browse/YARN-8513?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel
 git apply /YARN-8896-2.9.0.patch
 git apply /hadoop-ai-fix.patch
+git apply /hadoop-2.9.0-fix.patch
 
 mvn package -Pdist,native -DskipTests -Dmaven.javadoc.skip=true -Dtar
 

--- a/src/hadoop-ai/build/hadoop-2.9.0-fix.patch
+++ b/src/hadoop-ai/build/hadoop-2.9.0-fix.patch
@@ -1,0 +1,38 @@
+diff --git a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java
+index 0cf6b55..164fcf6 100644
+--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java
++++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/container/ContainerImpl.java
+@@ -1525,9 +1525,15 @@ public void transition(ContainerImpl container, ContainerEvent event) {
+   static class ExitedWithFailureTransition extends ContainerTransition {
+ 
+     boolean clCleanupRequired;
++    boolean diagnosticsRequired;
+ 
+     public ExitedWithFailureTransition(boolean clCleanupRequired) {
++      this(clCleanupRequired, true);
++    }
++
++    public ExitedWithFailureTransition(boolean clCleanupRequired, boolean diagnosticsRequired) {
+       this.clCleanupRequired = clCleanupRequired;
++      this.diagnosticsRequired = diagnosticsRequired;
+     }
+ 
+     @Override
+@@ -1535,7 +1541,7 @@ public void transition(ContainerImpl container, ContainerEvent event) {
+       container.setIsReInitializing(false);
+       ContainerExitEvent exitEvent = (ContainerExitEvent) event;
+       container.exitCode = exitEvent.getExitCode();
+-      if (exitEvent.getDiagnosticInfo() != null) {
++      if (diagnosticsRequired && exitEvent.getDiagnosticInfo() != null) {
+         container.addDiagnostics(exitEvent.getDiagnosticInfo(), "\n");
+       }
+ 
+@@ -1608,7 +1614,7 @@ public ContainerState transition(final ContainerImpl container,
+         new KilledForReInitializationTransition().transition(container, event);
+         return ContainerState.SCHEDULED;
+       } else {
+-        new ExitedWithFailureTransition(true).transition(container, event);
++        new ExitedWithFailureTransition(true, false).transition(container, event);
+         return ContainerState.EXITED_WITH_FAILURE;
+       }
+     }

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -79,6 +79,8 @@ COPY hadoop-ai-fix.patch /
 
 COPY YARN-8896-2.9.0.patch /
 
+COPY hadoop-2.9.0-fix.patch /
+
 COPY build.sh /
 
 RUN chmod u+x build.sh


### PR DESCRIPTION
More readable patch: https://github.com/mzmssg/hadoop/pull/4/files
There will no duplicate stderr in diagnostics:
Original
![image](https://user-images.githubusercontent.com/11887940/55864262-bc1d8880-5bae-11e9-89d9-db4095b93f10.png)

Fixed
![image](https://user-images.githubusercontent.com/11887940/55863803-d9058c00-5bad-11e9-9f3e-87e733b5a164.png)


