### PR TITLE
[Bug]Add empty pid checker when kill user's container

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -55,7 +55,7 @@ function exit_handler()
 
   # After all necessary steps, do a best effort kill here
   pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
-  if [ $pid -gt 0 ]; then
+  if [ "$pid" -gt 0 ]; then
     kill -15 $pid &&\
       printf "[DEBUG] Docker container $docker_name killed successfully." ||\
       printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -55,7 +55,7 @@ function exit_handler()
 
   # After all necessary steps, do a best effort kill here
   pid=$(docker inspect --format={{{ inspectPidFormat }}} $docker_name 2>/dev/null)
-  if [ "$pid" -gt 0 ]; then
+  if [[ -n "$pid" && "$pid" -gt 0 ]]; then
     kill -15 $pid &&\
       printf "[DEBUG] Docker container $docker_name killed successfully." ||\
       printf "[DEBUG] Try to kill the container $docker_name but failed. Maybe it has already exited."


### PR DESCRIPTION
Test case:
```json
{
  "jobName": "test_failure",
  "image": "openpai/pai.example.tensorflow:stable",
  "authFile": "",
  "dataDir": "",
  "outputDir": "",
  "codeDir": "",
  "virtualCluster": "default",
  "gpuType": "",
  "retryCount": 0,
  "taskRoles": [
    {
      "name": "111",
      "taskNumber": 1,
      "cpuNumber": 1,
      "memoryMB": 1024,
      "shmMB": 64,
      "gpuNumber": 0,
      "minFailedTaskCount": 1,
      "minSucceededTaskCount": null,
      "command": "sleep 5; exit 1",
      "portList": []
    }
  ],
  "jobEnvs": {},
  "extras": {}
}
```
Submit above job, 
before this PR, there are some false diagnostic in stderr or application summary:
```
YarnContainerScripts/0.sh: line 58: [: -gt: unary operator expected
```
After this PR, such diagnostic will disappear
