### PR TITLE
[Deployment] Disable IB driver installation by default

### DIFF
--- a/src/drivers/build/install-all-drivers
+++ b/src/drivers/build/install-all-drivers
@@ -43,7 +43,7 @@ else
     echo NVIDIA gpu not detected, skipping driver installation
 fi
 
-if [ -z ${SKIP_IB} ]; then
+if [ -n ${ENABLE_IB} ]; then
     if lspci | grep -qE '(Network|Infiniband) controller.*Mellanox.*ConnectX'; then
         echo Infiniband hardware detected
         # Installing InfiniBand drivers and GPU direct RDMA drivers
@@ -53,7 +53,7 @@ if [ -z ${SKIP_IB} ]; then
         echo Infiniband hardware is not detected, skipping driver installation
     fi
 else
-    echo "Depending on configuration, the variable SKIP_IB is set. So the ib installation will be skipped!"
+    echo "Depending on configuration, the variable ENABLE_IB is not set. So the ib installation will be skipped!"
 fi
 
 

--- a/src/drivers/config/drivers.py
+++ b/src/drivers/config/drivers.py
@@ -49,8 +49,8 @@ class Drivers:
             return False, "set-nvidia-runtime is miss in service-configuration -> drivers."
         if self.service_configuration["set-nvidia-runtime"] not in [False, True]:
             return False, "Value of set-nvidia-runtme should be false or true."
-        if self.service_configuration["skip-ib-installation"] not in [False, True]:
-            return False, "Value of skip-ib-installation should be false or true."
+        if self.service_configuration["enable-ib-installation"] not in [False, True]:
+            return False, "Value of enable-ib-installation should be false or true."
         if "version" not in self.service_configuration:
             return False, "version is miss in service-configuration -> drivers."
         if self.service_configuration["version"] not in ["384.111", "390.25", "410.73"]:

--- a/src/drivers/config/drivers.yaml
+++ b/src/drivers/config/drivers.yaml
@@ -27,8 +27,6 @@ version: "384.111"
 
 pre-installed-nvidia-path: /usr/local/nvidia
 
-# Azure VM builtin IB kernel modules into vmlinux image,
-# IB driver installation will fail in this case.
-# If IB installation is needed during deployment,
-# you can set `enable-ib-installation` field to true.
+# IB driver installation will fail when VM builtin IB kernel modules into vmlinux image.
+# If IB installation is needed during deployment, you can set the following field to true.
 enable-ib-installation: false

--- a/src/drivers/config/drivers.yaml
+++ b/src/drivers/config/drivers.yaml
@@ -28,4 +28,4 @@ version: "384.111"
 pre-installed-nvidia-path: /usr/local/nvidia
 
 
-skip-ib-installation: false
+skip-ib-installation: true

--- a/src/drivers/config/drivers.yaml
+++ b/src/drivers/config/drivers.yaml
@@ -27,5 +27,8 @@ version: "384.111"
 
 pre-installed-nvidia-path: /usr/local/nvidia
 
-
-skip-ib-installation: true
+# Azure VM builtin IB kernel modules into vmlinux image,
+# IB driver installation will fail in this case.
+# If IB installation is needed during deployment,
+# you can set `enable-ib-installation` field to true.
+enable-ib-installation: false

--- a/src/drivers/deploy/drivers.yaml.template
+++ b/src/drivers/deploy/drivers.yaml.template
@@ -57,8 +57,8 @@ spec:
         - mountPath: {{ cluster_cfg["drivers"]["pre-installed-nvidia-path"] }}
           name: pre-install-nv-driver-path
         env:
-        {% if cluster_cfg['drivers']['skip-ib-installation'] %}
-        - name: SKIP_IB
+        {% if cluster_cfg['drivers']['enable-ib-installation'] %}
+        - name: ENABLE_IB
           value: "true"
         {%- endif %}
         - name: DRIVER_PATH


### PR DESCRIPTION
Disable IB driver installation by default.

Azure VM builtin IB kernel modules into vmlinux image,
IB driver installation will fail in this case.

If IB installation is needed during deployment,
set `enable-ib-installation` field to `true` in config.