### PR TITLE
[Hotfix] Disable clone for old yaml jobs

### DIFF
--- a/src/webportal/src/app/job/job-view/fabric/job-detail/components/summary.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/components/summary.jsx
@@ -33,7 +33,7 @@ import MonacoPanel from './monaco-panel';
 import StatusBadge from './status-badge';
 import Timer from './timer';
 import {getJobMetricsUrl, cloneJob, openJobAttemptsPage} from '../conn';
-import {printDateTime, getHumanizedJobStateString, getDurationString} from '../util';
+import {printDateTime, getHumanizedJobStateString, getDurationString, isClonable} from '../util';
 
 const StoppableStatus = [
   'Running',
@@ -345,7 +345,7 @@ export default class Summary extends React.Component {
               <DefaultButton
                 text='Clone'
                 onClick={() => cloneJob(jobConfig)}
-                disabled={isNil(jobConfig)}
+                disabled={!isClonable(jobConfig)}
               />
               <DefaultButton
                 className={c(t.ml3)}

--- a/src/webportal/src/app/job/job-view/fabric/job-detail/util.js
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/util.js
@@ -90,6 +90,12 @@ export function isJobV2(jobConfig) {
   return !isNil(jobConfig.protocolVersion);
 }
 
+export function isClonable(jobConfig) {
+  // disable clone for old yaml job
+  // do not support protocol job at present
+  return !isNil(jobConfig) && isNil(jobConfig.protocol_version) && !isJobV2(jobConfig);
+}
+
 export function getTaskConfig(jobConfig, name) {
   if (jobConfig && jobConfig.taskRoles) {
     if (isJobV2(jobConfig)) {


### PR DESCRIPTION
Disable clone for old yaml jobs.
Do not support protocol job at present.