### PR TITLE
[REST server]Use framework name as job name

### DIFF
--- a/src/rest-server/src/config/job.js
+++ b/src/rest-server/src/config/job.js
@@ -21,7 +21,7 @@ const Joi = require('joi');
 // define job config schema
 const jobConfigSchema = Joi.object().keys({
   jobName: Joi.string()
-    .regex(/^[A-Za-z0-9\-._]+$/)
+    .regex(/^([A-Za-z0-9\-._]+~)?[A-Za-z0-9\-._]+$/)
     .required(),
   image: Joi.string()
     .required(),

--- a/src/rest-server/src/controllers/job.js
+++ b/src/rest-server/src/controllers/job.js
@@ -47,7 +47,7 @@ const load = (req, res, next, jobName) => {
 
 const init = (req, res, next) => {
   let jobName = req.body.jobName;
-  if (req.query.username !== undefined) {
+  if (jobName.indexOf('~') === -1 && req.query.username !== undefined) {
     jobName = `${req.query.username}~${jobName}`;
   }
   new Job(jobName, (job, error) => {

--- a/src/rest-server/src/controllers/job.js
+++ b/src/rest-server/src/controllers/job.js
@@ -26,7 +26,7 @@ const logger = require('../config/logger');
  * Load job and append to req.
  */
 const load = (req, res, next, jobName) => {
-  new Job(jobName, req.params.username, (job, error) => {
+  new Job(jobName, (job, error) => {
     if (error) {
       if (error.code === 'NoJobError') {
         if (req.method !== 'PUT') {
@@ -46,8 +46,11 @@ const load = (req, res, next, jobName) => {
 };
 
 const init = (req, res, next) => {
-  const jobName = req.body.jobName;
-  new Job(jobName, req.params.username, (job, error) => {
+  let jobName = req.body.jobName;
+  if (req.query.username !== undefined) {
+    jobName = `${req.query.username}~${jobName}`;
+  }
+  new Job(jobName, (job, error) => {
     if (error) {
       if (error.code === 'NoJobError') {
         req.job = job;
@@ -65,7 +68,7 @@ const init = (req, res, next) => {
  * Get list of jobs.
  */
 const list = (req, res, next) => {
-  Job.prototype.getJobList(req._query, req.params.username, (jobList, err) => {
+  Job.prototype.getJobList(req._query, (jobList, err) => {
     if (err) {
       return next(createError.unknown(err));
     } else if (jobList === undefined) {
@@ -96,7 +99,7 @@ const update = (req, res, next) => {
   let data = req.body;
   data.originalData = req.originalBody;
   data.userName = req.user.username;
-  Job.prototype.putJob(name, req.params.username, data, (err) => {
+  Job.prototype.putJob(name, data, (err) => {
     if (err) {
       return next(createError.unknown(err));
     }
@@ -105,7 +108,7 @@ const update = (req, res, next) => {
       host: req.get('Host'),
       pathname: req.baseUrl + '/' + name,
     });
-    new Job(name, req.params.username, (job, err) => {
+    new Job(name, (job, err) => {
       if (err) {
         if (err.code === 'NoJobError') {
           return res.status(202).location(location).json({
@@ -126,7 +129,7 @@ const update = (req, res, next) => {
 const remove = (req, res, next) => {
   req.body.username = req.user.username;
   req.body.admin = req.user.admin;
-  Job.prototype.deleteJob(req.job.name, req.params.username, req.body, (err) => {
+  Job.prototype.deleteJob(req.job.name, req.body, (err) => {
     if (err) {
       return next(createError.unknown(err));
     } else {
@@ -143,7 +146,7 @@ const remove = (req, res, next) => {
 const execute = (req, res, next) => {
   req.body.username = req.user.username;
   req.body.admin = req.user.admin;
-  Job.prototype.putJobExecutionType(req.job.name, req.params.username, req.body, (err) => {
+  Job.prototype.putJobExecutionType(req.job.name, req.body, (err) => {
     if (err) {
       return next(createError.unknown(err));
     } else {
@@ -160,7 +163,6 @@ const execute = (req, res, next) => {
 const getConfig = (req, res, next) => {
   Job.prototype.getJobConfig(
     req.job.jobStatus.username,
-    req.params.username,
     req.job.name,
     (error, result) => {
       if (!error) {
@@ -183,7 +185,6 @@ const getConfig = (req, res, next) => {
 const getSshInfo = (req, res, next) => {
   Job.prototype.getJobSshInfo(
     req.job.jobStatus.username,
-    req.params.username,
     req.job.name,
     req.job.jobStatus.appId,
     (error, result) => {

--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -31,10 +31,19 @@ const Hdfs = require('../util/hdfs');
 const azureEnv = require('../config/azure');
 const paiConfig = require('../config/paiConfig');
 
+const getNamespace = (jobName) => {
+  const tildeIndex = jobName.indexOf('~');
+  if (tildeIndex > -1) {
+    return jobName.slice(0, tildeIndex);
+  } else {
+    return null;
+  }
+};
+
 class Job {
-  constructor(name, namespace, next) {
+  constructor(name, next) {
     this.name = name;
-    this.getJob(name, namespace, (jobDetail, error) => {
+    this.getJob(name, (jobDetail, error) => {
       if (error === null) {
         for (let key of Object.keys(jobDetail)) {
           this[key] = jobDetail[key];
@@ -93,12 +102,11 @@ class Job {
     }
   }
 
-  getJobList(query, namespace, next) {
+  getJobList(query, next) {
     let reqPath = launcherConfig.frameworksPath();
+    const namespace = query.username;
     if (namespace) {
       reqPath = `${reqPath}?UserName=${namespace}`;
-    } else if (query.username) {
-      reqPath = `${reqPath}?UserName=${query.username}`;
     }
     unirest.get(reqPath)
       .headers(launcherConfig.webserviceRequestHeaders(namespace))
@@ -143,15 +151,7 @@ class Job {
               totalTaskRoleNumber: frameworkInfo.totalTaskRoleNumber,
             };
 
-            const tildeIndex = job.name.indexOf('~');
-            if (tildeIndex > -1) {
-              const namespace = job.name.slice(0, tildeIndex);
-              if (namespace !== job.username) {
-                logger.warn('Found a job with different namespace and username: ', job.name, job.username);
-                job.namespace = namespace;
-              }
-              job.name = job.name.slice(tildeIndex + 1);
-            } else {
+            if (job.name.indexOf('~') === -1) {
               job.legacy = true;
             }
 
@@ -165,8 +165,9 @@ class Job {
       });
   }
 
-  getJob(name, namespace, next) {
-    const frameworkName = namespace ? `${namespace}~${name}` : name;
+  getJob(name, next) {
+    const frameworkName = name;
+    const namespace = getNamespace(frameworkName);
     unirest.get(launcherConfig.frameworkPath(frameworkName))
       .headers(launcherConfig.webserviceRequestHeaders(namespace))
       .end((requestRes) => {
@@ -188,8 +189,9 @@ class Job {
       });
   }
 
-  putJob(name, namespace, data, next) {
-    const frameworkName = namespace ? `${namespace}~${name}` : name;
+  putJob(name, data, next) {
+    const frameworkName = name;
+    const namespace = getNamespace(frameworkName);
     data.jobName = frameworkName;
     if (!data.originalData.outputDir) {
       data.outputDir = `${launcherConfig.hdfsUri}/Output/${data.userName}/${name}`;
@@ -221,8 +223,9 @@ class Job {
     });
   }
 
-  deleteJob(name, namespace, data, next) {
-    const frameworkName = namespace ? `${namespace}~${name}` : name;
+  deleteJob(name, data, next) {
+    const frameworkName = name;
+    const namespace = getNamespace(name);
     unirest.get(launcherConfig.frameworkRequestPath(frameworkName))
       .headers(launcherConfig.webserviceRequestHeaders(namespace))
       .end((requestRes) => {
@@ -245,8 +248,9 @@ class Job {
       });
   }
 
-  putJobExecutionType(name, namespace, data, next) {
-    const frameworkName = namespace ? `${namespace}~${name}` : name;
+  putJobExecutionType(name, data, next) {
+    const frameworkName = name;
+    const namespace = getNamespace(name);
     unirest.get(launcherConfig.frameworkRequestPath(frameworkName))
       .headers(launcherConfig.webserviceRequestHeaders(namespace))
       .end((requestRes) => {
@@ -270,10 +274,7 @@ class Job {
       });
   }
 
-  getJobConfig(userName, namespace, jobName, next) {
-    if (namespace) {
-      jobName = `${namespace}~${jobName}`;
-    }
+  getJobConfig(userName, jobName, next) {
     const hdfs = new Hdfs(launcherConfig.webhdfsUri);
     hdfs.readFile(
       `/Container/${userName}/${jobName}/JobConfig.yaml`,
@@ -298,10 +299,7 @@ class Job {
     );
   }
 
-  getJobSshInfo(userName, namespace, jobName, applicationId, next) {
-    if (namespace) {
-      jobName = `${namespace}~${jobName}`;
-    }
+  getJobSshInfo(userName, jobName, applicationId, next) {
     const folderPathPrefix = `/Container/${userName}/${jobName}/ssh/${applicationId}`;
     const hdfs = new Hdfs(launcherConfig.webhdfsUri);
     hdfs.list(

--- a/src/rest-server/src/routes/rewrite.js
+++ b/src/rest-server/src/routes/rewrite.js
@@ -15,28 +15,11 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-// module dependencies
 const express = require('express');
-const controller = require('../controllers/index');
-const rewriteRouter = require('./rewrite');
-const tokenRouter = require('./token');
-const userRouter = require('./user');
-const jobRouter = require('./job');
-const vcRouter = require('./vc');
-const kubernetesProxy = require('../controllers/kubernetes-proxy');
+const rewriteController = require('../controllers/rewrite');
 
-const router = new express.Router();
+const router = module.exports = new express.Router();
 
-router.route('/')
-    .all(controller.index);
-
-router.use(rewriteRouter);
-router.use('/token', tokenRouter);
-router.use('/user', userRouter);
-router.use('/jobs', jobRouter);
-router.use('/virtual-clusters', vcRouter);
-router.use('/kubernetes', kubernetesProxy);
-
-// module exports
-module.exports = router;
+router.all('/user/:username/jobs', rewriteController.userJob);
+router.all('/user/:username/jobs/:jobName', rewriteController.userJob);
+router.all('/user/:username/jobs/:jobName/*', rewriteController.userJob);

--- a/src/rest-server/src/routes/user.js
+++ b/src/rest-server/src/routes/user.js
@@ -21,7 +21,6 @@ const token = require('../middlewares/token');
 const userConfig = require('../config/user');
 const userController = require('../controllers/user');
 const param = require('../middlewares/parameter');
-const jobRouter = require('./job');
 
 const router = new express.Router();
 
@@ -40,8 +39,6 @@ router.route('/:username/virtualClusters')
 
 router.route('/:username/githubPAT')
     .put(token.check, param.validate(userConfig.userGithubPATUpdateInputSchema), userController.updateUserGithubPAT);
-
-router.use('/:username/jobs', jobRouter);
 
 // module exports
 module.exports = router;

--- a/src/rest-server/test/job.js
+++ b/src/rest-server/test/job.js
@@ -97,8 +97,8 @@ describe('Jobs API /api/v1/user/:username/jobs', () => {
         expect(res, 'status code').to.have.status(200);
         expect(res, 'json response').be.json;
         expect(res.body.length, 'job list length').to.equal(3);
-        expect(res.body[0].name, 'job name').to.equal('job1');
-        expect(res.body[1].name, 'job name').to.equal('job2');
+        expect(res.body[0].name, 'job name').to.equal('test1~job1');
+        expect(res.body[1].name, 'job name').to.equal('test1~job2');
         expect(res.body[2].name, 'job name').to.equal('job3');
         expect(res.body[2].legacy, 'job legacy').to.equal(true);
         done();
@@ -188,7 +188,7 @@ describe('Jobs API /api/v1/jobs', () => {
         expect(res.body[0].legacy, 'job legacy').to.equal(true);
         expect(res.body[1].name, 'job name').to.equal('job2');
         expect(res.body[1].legacy, 'job legacy').to.equal(true);
-        expect(res.body[2].name, 'job name').to.equal('job3');
+        expect(res.body[2].name, 'job name').to.equal('test1~job3');
         done();
       });
   });

--- a/src/rest-server/test/jobDeletion.js
+++ b/src/rest-server/test/jobDeletion.js
@@ -31,7 +31,7 @@ describe('Delete job: DELETE /api/v1/user/:username/jobs/:jobName', () => {
   it('[P-01] should delete job by admin', (done) => {
     nock(launcherWebserviceUri)
       .get('/v1/Frameworks/test_user~job')
-      .reply(200, 
+      .reply(200,
         mustache.render(frameworkDetailTemplate, {
           'frameworkName': 'job',
           'userName': 'test_user',
@@ -62,7 +62,7 @@ describe('Delete job: DELETE /api/v1/user/:username/jobs/:jobName', () => {
   it('[P-02] should delete own job', (done) => {
     nock(launcherWebserviceUri)
       .get('/v1/Frameworks/test_user~job')
-      .reply(200, 
+      .reply(200,
         mustache.render(frameworkDetailTemplate, {
           'frameworkName': 'job',
           'userName': 'test',
@@ -90,10 +90,41 @@ describe('Delete job: DELETE /api/v1/user/:username/jobs/:jobName', () => {
       });
   });
 
+  it('[P-02] should delete with compat API', (done) => {
+    nock(launcherWebserviceUri)
+      .get('/v1/Frameworks/test_user~job')
+      .reply(200,
+        mustache.render(frameworkDetailTemplate, {
+          'frameworkName': 'job',
+          'userName': 'test',
+          'applicationId': 'app1',
+        }
+      ))
+      .get('/v1/Frameworks/test_user~job/FrameworkRequest')
+      .reply(200, {
+        'frameworkDescriptor': {
+          'user': {
+            'name': 'test_user',
+          },
+        },
+      })
+      .delete(`/v1/Frameworks/test_user~job`)
+      .matchHeader('UserName', 'test_user')
+      .reply(202);
+
+    chai.request(server)
+      .delete('/api/v1/user/test_user/jobs/test_user~job')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        expect(res).to.have.status(202);
+        done();
+      });
+  });
+
   it('[N-01] should forbid non-admin delete other\'s job', (done) => {
     nock(launcherWebserviceUri)
       .get('/v1/Frameworks/test_user~job')
-      .reply(200, 
+      .reply(200,
         mustache.render(frameworkDetailTemplate, {
           'frameworkName': 'job',
           'userName': 'test',
@@ -153,7 +184,7 @@ describe('Delete job: DELETE /api/v1/jobs/:jobName', () => {
   it('[P] should firbid delete job without namespace', (done) => {
     nock(launcherWebserviceUri)
       .get('/v1/Frameworks/job')
-      .reply(200, 
+      .reply(200,
         mustache.render(frameworkDetailTemplate, {
           'frameworkName': 'job',
           'userName': 'test',

--- a/src/rest-server/test/jobDetail.js
+++ b/src/rest-server/test/jobDetail.js
@@ -28,6 +28,7 @@ describe('JobDetail API /api/v1/user/:username/jobs/:jobName', () => {
   before(() => {
     nock(launcherWebserviceUri)
       .get('/v1/Frameworks/test~test_job')
+      .twice()
       .reply(200, mustache.render(
         frameworkDetailTemplate,
         {
@@ -61,13 +62,25 @@ describe('JobDetail API /api/v1/user/:username/jobs/:jobName', () => {
   // Positive cases
   //
 
-  it('[P-01] Should return test_job detail info', (done) => {
+  it('[P-01] Should return test_job detail info (/user/test/jobs/test_job)', (done) => {
     chai.request(server)
       .get('/api/v1/user/test/jobs/test_job')
       .end((err, res) => {
         expect(res, 'status code').to.have.status(200);
         expect(res, 'json response').be.json;
-        expect(res.body).to.have.property('name', 'test_job');
+        expect(res.body).to.have.property('name', 'test~test_job');
+        expect(res.body).to.nested.include({ 'jobStatus.virtualCluster': 'vc3' });
+        done();
+      });
+  });
+
+  it('[P-02] Should return test_job detail info (/user/test/jobs/test~test_job)', (done) => {
+    chai.request(server)
+      .get('/api/v1/user/test/jobs/test~test_job')
+      .end((err, res) => {
+        expect(res, 'status code').to.have.status(200);
+        expect(res, 'json response').be.json;
+        expect(res.body).to.have.property('name', 'test~test_job');
         expect(res.body).to.nested.include({ 'jobStatus.virtualCluster': 'vc3' });
         done();
       });

--- a/src/rest-server/test/jobExecutionType.js
+++ b/src/rest-server/test/jobExecutionType.js
@@ -114,7 +114,7 @@ describe('Job execution type API /api/v1/user/:username/jobs/:jobName/executionT
       .end((err, res) => {
         expect(res, 'status code').to.have.status(202);
         expect(res, 'json response').be.json;
-        expect(res.body.message, 'response message').equal('execute job test1 successfully');
+        expect(res.body.message, 'response message').equal('execute job iamadmin~test1 successfully');
         done();
       });
   });
@@ -129,7 +129,7 @@ describe('Job execution type API /api/v1/user/:username/jobs/:jobName/executionT
       .end((err, res) => {
         expect(res, 'status code').to.have.status(202);
         expect(res, 'json response').be.json;
-        expect(res.body.message, 'response message').equal('execute job test2 successfully');
+        expect(res.body.message, 'response message').equal('execute job test2~test2 successfully');
         done();
       });
   });

--- a/src/rest-server/test/jobSubmission.js
+++ b/src/rest-server/test/jobSubmission.js
@@ -149,6 +149,7 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
   };
 
   const prepareNockForCaseP05 = prepareNockForCaseP03;
+  const prepareNockForCaseP06 = prepareNockForCaseP01;
 
   const prepareNockForCaseN03 = () => {
     global.nock(global.launcherWebserviceUri)
@@ -408,6 +409,23 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
       .set('Authorization', 'Bearer ' + validToken)
       .set('Host', 'example.test')
       .send(JSON.parse(global.mustache.render(global.jobConfigTemplate, { 'jobName': 'new_job' })))
+      .end((err, res) => {
+        global.chai.expect(res, 'status code').to.have.status(201);
+        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job');
+        global.chai.expect(res, 'response format').be.json;
+        global.chai.expect(res.body.name, 'response job name').equal('user1~new_job');
+        done();
+      });
+  });
+
+  it('[P-06] Submit a job using POST method with namespaced job name', (done) => {
+    prepareNockForCaseP06('user1', 'new_job');
+    let jobConfig = global.mustache.render(global.jobConfigTemplate, {'jobName': 'user1~new_job'});
+    global.chai.request(global.server)
+      .post('/api/v1/user/user1/jobs')
+      .set('Authorization', 'Bearer ' + validToken)
+      .set('Host', 'example.test')
+      .send(JSON.parse(jobConfig))
       .end((err, res) => {
         global.chai.expect(res, 'status code').to.have.status(201);
         global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job');

--- a/src/rest-server/test/jobSubmission.js
+++ b/src/rest-server/test/jobSubmission.js
@@ -148,15 +148,17 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
     }
   };
 
+  const prepareNockForCaseP05 = prepareNockForCaseP03;
+
   const prepareNockForCaseN03 = () => {
     global.nock(global.launcherWebserviceUri)
-      .get('/v1/Frameworks/test~job1')
+      .get('/v1/Frameworks/user1~job1')
       .reply(
         200,
         global.mustache.render(
           global.frameworkDetailTemplate,
           {
-            'frameworkName': 'job1',
+            'frameworkName': 'user1~job1',
             'username': 'test',
             'applicationId': 'app1',
           }
@@ -342,9 +344,9 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
       .send(JSON.parse(jobConfig))
       .end((err, res) => {
         global.chai.expect(res, 'status code').to.have.status(201);
-        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/user/user1/jobs/new_job');
+        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job');
         global.chai.expect(res, 'response format').be.json;
-        global.chai.expect(res.body.name, 'response job name').equal('new_job');
+        global.chai.expect(res.body.name, 'response job name').equal('user1~new_job');
         done();
       });
   });
@@ -360,9 +362,9 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
       .send(JSON.parse(jobConfig))
       .end((err, res) => {
         global.chai.expect(res, 'status code').to.have.status(201);
-        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/user/user1/jobs/new_job_in_vc1');
+        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job_in_vc1');
         global.chai.expect(res, 'response format').be.json;
-        global.chai.expect(res.body.name, 'response job name').equal('new_job_in_vc1');
+        global.chai.expect(res.body.name, 'response job name').equal('user1~new_job_in_vc1');
         done();
       });
   });
@@ -376,14 +378,14 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
       .send(JSON.parse(global.mustache.render(global.jobConfigTemplate, { 'jobName': 'new_job' })))
       .end((err, res) => {
         global.chai.expect(res, 'status code').to.have.status(201);
-        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/user/user1/jobs/new_job');
+        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job');
         global.chai.expect(res, 'response format').be.json;
-        global.chai.expect(res.body.name, 'response job name').equal('new_job');
+        global.chai.expect(res.body.name, 'response job name').equal('user1~new_job');
         done();
       });
   });
 
-  it('[P-03] Submit a job using PUT method, but not created in launcher on time', (done) => {
+  it('[P-04] Submit a job using PUT method, but not created in launcher on time', (done) => {
     prepareNockForCaseP04('user1', 'new_job');
     global.chai.request(global.server)
       .put('/api/v1/user/user1/jobs/new_job')
@@ -392,9 +394,25 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
       .send(JSON.parse(global.mustache.render(global.jobConfigTemplate, { 'jobName': 'new_job' })))
       .end((err, res) => {
         global.chai.expect(res, 'status code').to.have.status(202);
-        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/user/user1/jobs/new_job');
+        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job');
         global.chai.expect(res, 'response format').be.json;
-        global.chai.expect(res.body.message, 'response message').equal('update job new_job successfully');
+        global.chai.expect(res.body.message, 'response message').equal('update job user1~new_job successfully');
+        done();
+      });
+  });
+
+  it('[P-05] Submit a job using PUT method with compat API', (done) => {
+    prepareNockForCaseP05('user1', 'new_job');
+    global.chai.request(global.server)
+      .put('/api/v1/user/user1/jobs/user1~new_job')
+      .set('Authorization', 'Bearer ' + validToken)
+      .set('Host', 'example.test')
+      .send(JSON.parse(global.mustache.render(global.jobConfigTemplate, { 'jobName': 'new_job' })))
+      .end((err, res) => {
+        global.chai.expect(res, 'status code').to.have.status(201);
+        global.chai.expect(res, 'location header').to.have.header('location', 'http://example.test/api/v1/jobs/user1~new_job');
+        global.chai.expect(res, 'response format').be.json;
+        global.chai.expect(res.body.name, 'response job name').equal('user1~new_job');
         done();
       });
   });
@@ -432,7 +450,7 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
   it('[N-03] Duplicated job name', (done) => {
     prepareNockForCaseN03();
     global.chai.request(global.server)
-      .post('/api/v1/user/test/jobs')
+      .post('/api/v1/user/user1/jobs')
       .set('Authorization', 'Bearer ' + validToken)
       .send(JSON.parse(global.mustache.render(global.jobConfigTemplate, {'jobName': 'job1'})))
       .end((err, res) => {
@@ -517,7 +535,7 @@ describe('Submit job: POST /api/v1/user/:username/jobs', () => {
   it('[N-09] Duplicated job name using PUT method', (done) => {
     prepareNockForCaseN09();
     global.chai.request(global.server)
-      .put('/api/v1/user/test/jobs/job1')
+      .put('/api/v1/user/user1/jobs/job1')
       .set('Authorization', 'Bearer ' + validToken)
       .send(JSON.parse(global.mustache.render(global.jobConfigTemplate, {'jobName': 'job1'})))
       .end((err, res) => {


### PR DESCRIPTION
Closes #2439 

# This is a (theoretical) compatible API change, includes:

## Deprecated `/user/:user/jobs`-family APIs

Rewrite them to `/jobs/:user~:jobname`-family.

<a name="tip">*</a>: If a namespace is already provided in job name, the `:user` param will be ignored, this is for e2e compatibility: a job created by `POST /user/:user/jobs` with un-namespaced job name would be able to retrieved by the following ways:

1. `GET /user/:user/jobs/:jobname`: client may hard coded the job name.
2. `GET /user/:user/jobs/:user~:jobname`: client may retrieve the job name from creating response.
3. `GET /jobs/:user~:jobname`: the new recommended way.

### Rewrite `/user/:user/jobs` as `/jobs?username=:user`

Including `GET` and `POST` requests.

The `POST` one is newly added for distinguish with legacy (pre-0.7.0) `POST /jobs` API

- If `POST /jobs` with **un-namespaced** job name is called, the legacy (pre-0.7.0) job without namespace will be created. This is the compatible way to create a legacy job and have no change.
- If `POST /jobs?username=:user` with **un-namespaced** job name is called, the modern job `:user~:jobname` will be created, which is rewritten from `POST /user/:user/jobs` for compatibility with current version.
- If `POST /jobs` with **namespaced** job name is called, the modern job `:jobname` will be created, which is the recommended way.
- If `POST /jobs?username=:user` with **namespaced** job name is called, the user query is ignored, see [*](#tip)

### Rewrite `/user/:user/jobs/:job` as `/jobs/:user~:job`

Including `GET`, `PUT`, `DELETE` (undocumented API)

### Rewrite `/user/:user1/jobs/:user2~:job` as `/jobs/:user2~:job`

Including `GET`, `PUT`, `DELETE` (undocumented API), See [*](#tip)

### Rewrite `/user/:user/jobs/:job/*` as `/jobs/:user~:job/*`

Including `GET`, `PUT`

### Rewrite `/user/:user1/jobs/:user2~:job/*` as `/jobs/:user2~:job/*`

Including `GET`, `PUT`, See [*](#tip)

## When requested job name contains namespace, REST server will request launcher with `UserName` header

## There will be no namespace-wiper in the job responses

Previously, if the job name includes "~", to compatible with pre-0.7.0 legacy job, the namespace will be wiped, which makes the job name in rest-server / webportal differs with other services, now it will not be wiped automatically.
