### PR TITLE
fix hdfs delete failure

### DIFF
--- a/src/hadoop-data-node/deploy/delete.yaml.template
+++ b/src/hadoop-data-node/deploy/delete.yaml.template
@@ -15,6 +15,7 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+{% set folders = cluster_cfg[ "hadoop-data-node" ][ "storage_path" ] or cluster_cfg["cluster"]["common"][ "data-path" ] + "/hdfs/data" %}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -35,8 +36,10 @@ spec:
         image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}cleaning-image:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always
         volumeMounts:
-        - mountPath: /mnt
-          name: data-path
+        {% for folder in folders.split(",") %}
+        - mountPath: /mnt/hdfs/data-{{ loop.index }}
+          name: data-path-{{ loop.index }}
+        {% endfor %}
         - mountPath: /hadoop-data-node-delete
           name: hadoop-data-node-delete-config
         env:
@@ -54,9 +57,11 @@ spec:
       imagePullSecrets:
       - name: {{ cluster_cfg["cluster"]["docker-registry"]["secret-name"] }}
       volumes:
-      - name: data-path
+      {% for folder in folders.split(",") %}
+      - name: data-path-{{ loop.index }}
         hostPath:
-          path: {{ cluster_cfg["cluster"]["common"][ "data-path" ] }}
+          path: {{ folder }}
+      {% endfor %}
       - name: hadoop-data-node-delete-config
         configMap:
           name: hadoop-data-node-delete

--- a/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
+++ b/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
@@ -20,9 +20,9 @@
 
 echo "Clean the hadoop-data-node's data on the disk"
 
-if [ -d "/mnt/hdfs/data" ]; then
+if [ ls "/mnt/hdfs/data*" >/dev/null 2>/dev/null ]; then
 
-    rm -rf /mnt/hdfs/data
+    rm -rf /mnt/hdfs/data*
 
 fi
 

--- a/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
+++ b/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
@@ -22,7 +22,7 @@ echo "Clean the hadoop-data-node's data on the disk"
 
 if [ ls "/mnt/hdfs/data*" >/dev/null 2>/dev/null ]; then
 
-    rm -rf /mnt/hdfs/data*
+    rm -rf /mnt/hdfs/data*/*
 
 fi
 

--- a/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
+++ b/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
@@ -21,7 +21,7 @@
 echo "Clean the hadoop-data-node's data on the disk"
 
 
-rm -rf /mnt/hdfs/data*/*
+rm -rf /mnt/hdfs/data*/* 2>/dev/null
 
 
 

--- a/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
+++ b/src/hadoop-data-node/deploy/hadoop-data-node-delete/delete-data.sh
@@ -20,11 +20,9 @@
 
 echo "Clean the hadoop-data-node's data on the disk"
 
-if [ ls "/mnt/hdfs/data*" >/dev/null 2>/dev/null ]; then
 
-    rm -rf /mnt/hdfs/data*/*
+rm -rf /mnt/hdfs/data*/*
 
-fi
 
 
 if [ -d "/mnt/hadooptmp/datanode" ]; then


### PR DESCRIPTION
fix #2637 

Test case: 
**Don't test it on production** 
1. Stop data node
    `./paictl.py service stop -n hadoop-data-node`
2. Edit `service-configuration.yaml`, add following lines
    ```yaml
    hadoop-data-node:
       storage_path: /mnt/hdfs-test/data1,/mnt/hdfs-test/data2
    ```
3. Start data node
    `./paictl.py service start -n hadoop-data-node`
4. Delete name node & data node
     `./paictl.py service delete -n hadoop-data-node && ./paictl.py service delete -n hadoop-name-node`
5. Start name node & data node
     `./paictl.py service start -n hadoop-data-node && ./paictl.py service start -n hadoop-name-node`
   
Before this PR, data node should fail