### PR TITLE
[CI/CD] Fix travis CI node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         - npm run coveralls
 
     - language: node_js
-      node_js: node
+      node_js: "11"
       env: NODE_ENV=test
       before_install:
         - cd src/rest-server
@@ -117,7 +117,7 @@ matrix:
         - npm test
 
     - language: node_js
-      node_js: node
+      node_js: "11"
       before_install:
         - cd src/webportal
       install:
@@ -139,7 +139,7 @@ matrix:
       script: yarn build
 
     - language: node_js
-      node_js: node
+      node_js: "11"
       before_install: cd contrib/submit-protocol
       install: yarn --frozen-lockfiles
       script: yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         - npm run coveralls
 
     - language: node_js
-      node_js: "11"
+      node_js: lts/dubnium
       env: NODE_ENV=test
       before_install:
         - cd src/rest-server
@@ -117,7 +117,7 @@ matrix:
         - npm test
 
     - language: node_js
-      node_js: "11"
+      node_js: lts/dubnium
       before_install:
         - cd src/webportal
       install:
@@ -139,7 +139,7 @@ matrix:
       script: yarn build
 
     - language: node_js
-      node_js: "11"
+      node_js: lts/dubnium
       before_install: cd contrib/submit-protocol
       install: yarn --frozen-lockfiles
       script: yarn build


### PR DESCRIPTION
Because of the release of [node 12](https://nodejs.org/en/blog/release/v12.0.0/) on April 23rd, current travis CI broke due to [nan](https://github.com/nodejs/nan) issues in node 12.

Following packages will be affected in node 12 nan issue:
* [node-sass](https://github.com/sass/node-sass/issues?q=is%3Aissue+is%3Aopen+label%3A%22Node+12%22)
* deasync

Fix travis CI node version to 11 until the problem has been solved in upstream.