### PR TITLE
[Hotfix] Fix travis CI node version (#2650)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         - npm run coveralls
 
     - language: node_js
-      node_js: node
+      node_js: lts/dubnium
       env: NODE_ENV=test
       before_install:
         - cd src/rest-server
@@ -117,7 +117,7 @@ matrix:
         - npm test
 
     - language: node_js
-      node_js: node
+      node_js: lts/dubnium
       before_install:
         - cd src/webportal
       install:


### PR DESCRIPTION
Because of the release of [node 12](https://nodejs.org/en/blog/release/v12.0.0/), current travis CI broke due to [nan](https://github.com/nodejs/nan) issues in node 12.

Following packages will be affected in node 12 nan issue:
* node-sass
* deasync

Fix travis CI node version to 10 until the problem has been solved in upstream.