### PR TITLE
Add capability/device for jobs to use InfiniBand

### DIFF
--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -95,6 +95,10 @@ gpu_id=$(echo $gpu_id | sed "s/,$//g")
 printf "%s %s\n%s\n\n" "[INFO]" "GPU_ID" "$gpu_id"
 printf "%s %s\n%s\n\n" "[INFO]" "NVIDIA_DEVICES" "$nvidia_devices"
 
+infiniband_flags=''
+if [[ -d "/dev/infiniband" ]]; then
+  infiniband_flags+='--cap-add=IPC_LOCK --device=/dev/infiniband'
+fi
 
 {{# jobData.authFile }}
 IFS=$'\r\n' GLOBIGNORE='*' \
@@ -311,6 +315,7 @@ docker run --name $docker_name \
   --cpus={{ taskData.cpuNumber }} \
   --memory={{ taskData.memoryMB }}m \
   --shm-size={{ taskData.shmMB }}m \
+  $infiniband_flags \
   $nvidia_devices \
   --device=/dev/fuse \
 {{# isDebug }}
@@ -322,8 +327,6 @@ docker run --name $docker_name \
 {{# azRDMA }}
   --volume /var/lib/hyperv:/var/lib/hyperv \
   --volume /etc/dat.conf:/etc/dat.conf \
-  --device=/dev/infiniband/rdma_cm \
-  --device=/dev/infiniband/uverbs0 \
   --ulimit memlock=-1  \
 {{/ azRDMA }}
 {{/ reqAzRDMA }}


### PR DESCRIPTION
Add IPC_LOCK capability `--cap-add IPC_LOCK` and /dev/infiniband devices `--device=/dev/infiniband` for jobs to use InfiniBand in non privileged Docker. Will check the IB device automatically.

Before this PR, host can install IB OFED drivers but jobs cannot use infiniband network inside container. With this PR, infiniband network will be enabled automatically for jobs if IB device is available.

Reference: https://community.mellanox.com/s/article/how-to-create-a-docker-container-with-rdma-accelerated-applications-over-100gb-infiniband-network#jive_content_id_Option_2