### PR TITLE
[REST Server] Remove jessie-backports source

### DIFF
--- a/src/rest-server/build/rest-server.dockerfile
+++ b/src/rest-server/build/rest-server.dockerfile
@@ -17,11 +17,8 @@
 
 FROM node:carbon
 
-RUN echo "deb http://http.debian.net/debian jessie-backports main" > \
-    /etc/apt/sources.list.d/jessie-backports.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends -t \
-      jessie-backports \
+RUN apt-get update && \
+    apt-get install --assume-yes --no-install-recommends \
       dos2unix \
       openssh-server \
       && \


### PR DESCRIPTION
Installed versions (on 2019/4/24)

- `dos2unix`
  - In `openpai/rest-server:v0.12.0`: dos2unix 7.3.4 (2016-05-24)
  - Manual remove jessie-backports source: dos2unix 7.3.4 (2016-05-24)
- `openssh-server`
  - In `openpai/rest-server:v0.12.0`: OpenSSH_7.4p1 Debian-10+deb9u5, OpenSSL 1.0.2q  20 Nov 2018
  - Manual remove jessie-backports source: OpenSSH_7.4p1 Debian-10+deb9u6, OpenSSL 1.0.2r  26 Feb 2019