### PR TITLE
[Web Portal] reduce bundle size

### DIFF
--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -244,8 +244,17 @@ const config = (env, argv) => ({
     new webpack.WatchIgnorePlugin([
       /css\.d\.ts$/,
     ]),
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^moment$/,
+      contextRegExp: /chart.js/,
+    }),
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^esprima$/,
+      contextRegExp: /js-yaml/,
+    }),
     new MonacoWebpackPlugin({
-      languages: ['json', 'css', 'ts', 'html'],
+      languages: ['json', 'yaml'],
+      features: ['smartSelect'],
     }),
     new CopyWebpackPlugin([
       {from: 'src/assets', to: 'assets'},

--- a/src/webportal/src/app/marketplace/job-submit/sub-components/user-template.js
+++ b/src/webportal/src/app/marketplace/job-submit/sub-components/user-template.js
@@ -18,7 +18,7 @@
 require('json-editor'); /* global JSONEditor */
 require('bootstrap/js/tooltip.js');
 
-const monaco = require('monaco-editor');
+const monaco = require('monaco-editor/esm/vs/editor/editor.api');
 
 const dockerScriptDataFormat = require('./docker-script-data-format.ejs');
 const taskFormat = require('./task-format.ejs');


### PR DESCRIPTION
## Result
job-detail gzipped size:  760.51KB -> 561.4KB

## Change
- monaco-editor: remove unused features and languages
- js-yaml: remove optional esprima dependency
- chart.js: remove optional moment dependency