### PR TITLE
[Protocol] Support secrets in protocol

### DIFF
--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -31,7 +31,8 @@ parameters: # Optional, can be omitted.
 
 # If sensitive information including password or API key is needed in the protocol,
 # it should be specified here in secrets section and referenced as `$secrets`.
-# All secrets will be hidden in the plain text and won't be shared.
+# A system that supports PAI protocol should not keep information marked as secretes.
+# For example, the yaml file used for job cloning, the stdout/stderr should remove all information marked as secrets.
 secrets: # Optional, can be omitted.
   <secret1>: password # Specify name and value of all secrets that will be used in the whole job template.
   <secret2>: key # Can be referenced by `<% $secrets.secret1 %>`, `<% $secrets.secret2 %>`.

--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -232,5 +232,5 @@ deployments:
           # Assume the model is output locally, and this command copies the local output to hdfs. One can output to hdfs directly.
           # In this case, you will have to change "--train_dir=$PAI_WORK_DIR/output_<% $output.name %>".
 
-default:
+defaults:
   deployment: prod # Use prod deployment in job submission.

--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -31,6 +31,7 @@ parameters: # Optional, can be omitted.
 
 # If sensitive information including password or API key is needed in the protocol,
 # it should be specified here in secrets section and referenced as `$secrets`.
+# Scope of reference `$secrets`: the reference is global, shared among all task roles and docker image's `auth` field.
 # A system that supports PAI protocol should keep the secret information away from
 # unauthorized users (how to define unauthorized user is out of the scope of this protocol).
 # For example, the yaml file used for job cloning, the stdout/stderr should protect all information marked as secrets.

--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -31,8 +31,9 @@ parameters: # Optional, can be omitted.
 
 # If sensitive information including password or API key is needed in the protocol,
 # it should be specified here in secrets section and referenced as `$secrets`.
-# A system that supports PAI protocol should not keep information marked as secretes.
-# For example, the yaml file used for job cloning, the stdout/stderr should remove all information marked as secrets.
+# A system that supports PAI protocol should keep the secret information away from
+# unauthorized users (how to define unauthorized user is out of the scope of this protocol).
+# For example, the yaml file used for job cloning, the stdout/stderr should protect all information marked as secrets.
 secrets: # Optional, can be omitted.
   <secret1>: password # Specify name and value of all secrets that will be used in the whole job template.
   <secret2>: key # Can be referenced by `<% $secrets.secret1 %>`, `<% $secrets.secret2 %>`.

--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -120,7 +120,7 @@ prerequisites:
     version: 84820935288cab696c9c2ac409cbd46a1f24723d
     contributor: MaggieQi
     description: tensorflow benchmarks
-    uri: https://github.com/MaggieQi/benchmarks
+    uri: github.com/MaggieQi/benchmarks
   - protocolVersion: 2
     name: cifar10
     type: data
@@ -136,7 +136,7 @@ parameters:
 
 secrets:
   docker_password: password
-  api_token: cGFzc3dvcmQ=
+  github_token: cGFzc3dvcmQ=
 
 jobRetryCount: 1
 taskRoles:
@@ -215,14 +215,14 @@ deployments:
         preCommands:
           - wget <% $data.uri[0] %> -P data_<% $data.name %> # If local data cache deployed, one can copy data from local cache, only wget in case of cache miss.
           - >
-            git clone <% $script.uri %> script_<% $script.name %> &&
+            git clone https://<% $script.contributor %>:<% $secrets.github_token %>@<% $script.uri %> script_<% $script.name %> &&
             cd script_<% $script.name %> && git checkout <% $script.version %> && cd ..
             # Then the system will go ahead to execute worker's command.
       ps_server:
         preCommands:
           - wget <% $data.uri[0] %> -P data_<% $data.name %>
           - >
-            git clone <% $script.uri %> script_<% $script.name %> &&
+            git clone https://<% $script.contributor %>:<% $secrets.github_token %>@<% $script.uri %> script_<% $script.name %> &&
             cd script_<% $script.name %> && git checkout <% $script.version %> && cd ..
             # Then the system will go ahead to execute ps_server's command.
         postCommands:

--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -19,15 +19,22 @@ prerequisites: # Optional
     description: String, optional
     auth: Object, optional # Only available when the type is dockerimage.
       username: String, optional
-      passward: String, optional
+      password: String, optional # If a password is needed, it should be referenced as a secret
       registryuri: String, optional
     uri: String or list, required # Only when the type is data can the uri be a list.
 
 # If specified, the whole parameters object can be referenced as `$parameters`.
-# Scope of reference `$parameters`: the refercen is global and shared among all task roles.
+# Scope of reference `$parameters`: the reference is global and shared among all task roles.
 parameters: # Optional, can be omitted.
   <param1>: value1 # Specify name and value of all the referencable parameters that will be used in the whole job template.
   <param2>: value2 # Can be referenced by `<% $parameters.param1 %>`, `<% $parameters.param2 %>`.
+
+# If sensitive information including password or API key is needed in the protocol,
+# it should be specified here in secrets section and referenced as `$secrets`.
+# All secrets will be hidden in the plain text and won't be shared.
+secrets: # Optional, can be omitted.
+  <secret1>: password # Specify name and value of all secrets that will be used in the whole job template.
+  <secret2>: key # Can be referenced by `<% $secrets.secret1 %>`, `<% $secrets.secret2 %>`.
 
 jobRetryCount: Integer, optional # Default is 0.
 # Task roles are different types of task in the protocol.
@@ -95,8 +102,8 @@ prerequisites:
     contributor: Alice
     description: python3.5, tensorflow
     auth:
-      username: 81f1fd6a-2844-4072-982d-62371fa37bd3
-      passward: user1
+      username: user
+      password: <% $secrets.docker_password %>
       registryuri: openpai.azurecr.io
     uri: openpai/pai.example.tensorflow
   - protocolVersion: 2
@@ -125,6 +132,10 @@ prerequisites:
 parameters:
   model: resnet20
   batchsize: 32
+
+secrets:
+  docker_password: password
+  api_token: cGFzc3dvcmQ=
 
 jobRetryCount: 1
 taskRoles:

--- a/docs/pai-job-protocol.yaml
+++ b/docs/pai-job-protocol.yaml
@@ -24,14 +24,14 @@ prerequisites: # Optional
     uri: String or list, required # Only when the type is data can the uri be a list.
 
 # If specified, the whole parameters object can be referenced as `$parameters`.
-# Scope of reference `$parameters`: the reference is global and shared among all task roles.
+# Scope of reference `$parameters`: the reference is shared among all task roles.
 parameters: # Optional, can be omitted.
   <param1>: value1 # Specify name and value of all the referencable parameters that will be used in the whole job template.
   <param2>: value2 # Can be referenced by `<% $parameters.param1 %>`, `<% $parameters.param2 %>`.
 
 # If sensitive information including password or API key is needed in the protocol,
 # it should be specified here in secrets section and referenced as `$secrets`.
-# Scope of reference `$secrets`: the reference is global, shared among all task roles and docker image's `auth` field.
+# Scope of reference `$secrets`: the reference is shared among all task roles and docker image's `auth` field.
 # A system that supports PAI protocol should keep the secret information away from
 # unauthorized users (how to define unauthorized user is out of the scope of this protocol).
 # For example, the yaml file used for job cloning, the stdout/stderr should protect all information marked as secrets.

--- a/src/rest-server/src/config/v2/protocol.js
+++ b/src/rest-server/src/config/v2/protocol.js
@@ -164,6 +164,10 @@ const protocolSchema = {
       type: 'object',
       additionalProperties: true,
     },
+    secrets: {
+      type: 'object',
+      additionalProperties: true,
+    },
     jobRetryCount: {
       type: 'integer',
       minimum: 0,

--- a/src/rest-server/src/middlewares/v2/protocol.js
+++ b/src/rest-server/src/middlewares/v2/protocol.js
@@ -39,6 +39,27 @@ const prerequisiteFields = [
   'dockerImage',
 ];
 
+
+const render = (template, dict, tags=['<%', '%>']) => {
+  const tokens = mustacheWriter.parse(template, tags);
+  const context = new mustache.Context(dict);
+  let result = '';
+  for (let token of tokens) {
+    const symbol = token[0];
+    let tokenStr = token[1];
+    if (symbol === 'text') {
+      result += tokenStr;
+    } else if (symbol === 'name') {
+      tokenStr = tokenStr.replace(/\[(\d+)\]/g, '.$1');
+      const value = context.lookup(tokenStr);
+      if (value != null) {
+        result += value;
+      }
+    }
+  }
+  return result.trim();
+};
+
 const protocolValidate = (protocolYAML) => {
   const protocolObj = yaml.safeLoad(protocolYAML);
   if (!protocolSchema.validate(protocolObj)) {
@@ -107,6 +128,18 @@ const protocolValidate = (protocolYAML) => {
 };
 
 const protocolRender = (protocolObj) => {
+  // render auth for Docker image
+  for (let name of Object.keys(protocolObj.prerequisites.dockerimage)) {
+    if ('auth' in protocolObj.prerequisites.dockerimage[name]) {
+      for (let prop of Object.keys(protocolObj.prerequisites.dockerimage[name].auth)) {
+        protocolObj.prerequisites.dockerimage[name].auth[prop] = render(
+          protocolObj.prerequisites.dockerimage[name].auth[prop],
+          {'$secrets': protocolObj.secrets},
+        );
+      }
+    }
+  }
+  // render commands
   let deployment = null;
   if ('defaults' in protocolObj && 'deployment' in protocolObj.defaults) {
     deployment = protocolObj.deployments[protocolObj.defaults.deployment];
@@ -121,29 +154,15 @@ const protocolRender = (protocolObj) => {
         commands = commands.concat(deployment.taskRoles[taskRole].postCommands);
       }
     }
-    let entrypoint = '';
     commands = commands.map((command) => command.trim()).join(' && ');
-    const tokens = mustacheWriter.parse(commands, ['<%', '%>']);
-    const context = new mustache.Context({
+    const entrypoint = render(commands, {
       '$parameters': protocolObj.parameters,
+      '$secrets': protocolObj.secrets,
       '$script': protocolObj.prerequisites['script'][protocolObj.taskRoles[taskRole].script],
       '$output': protocolObj.prerequisites['output'][protocolObj.taskRoles[taskRole].output],
       '$data': protocolObj.prerequisites['data'][protocolObj.taskRoles[taskRole].data],
     });
-    for (let token of tokens) {
-      const symbol = token[0];
-      let tokenStr = token[1];
-      if (symbol === 'text') {
-        entrypoint += tokenStr;
-      } else if (symbol === 'name') {
-        tokenStr = tokenStr.replace(/\[(\d+)\]/g, '.$1');
-        const value = context.lookup(tokenStr);
-        if (value != null) {
-          entrypoint += value;
-        }
-      }
-    }
-    protocolObj.taskRoles[taskRole].entrypoint = entrypoint.trim();
+    protocolObj.taskRoles[taskRole].entrypoint = entrypoint;
   }
   return protocolObj;
 };

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -311,6 +311,13 @@ if [[ -d "/dev/infiniband" ]]; then
   infiniband_flags+='--cap-add=IPC_LOCK --device=/dev/infiniband'
 fi
 
+{{# jobData.auth }}
+set +x
+docker login --username {{ jobData.auth.username }} --password {{ jobData.auth.password }} {{ jobData.auth.registryuri }} \
+  || { echo 'Authorized failed' ; exit 1; }
+set -x
+{{/ jobData.auth }}
+
 {{# jobData.authFile }}
 IFS=$'\r\n' GLOBIGNORE='*' \
   eval 'cred=($(hdfs dfs -cat {{ jobData.authFile }}))' \

--- a/src/rest-server/src/util/protocolSecret.js
+++ b/src/rest-server/src/util/protocolSecret.js
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+const mask = (protocolYAML) => {
+  let maskYAML = protocolYAML + '\nZ';
+  maskYAML = maskYAML.replace(/(^secrets:)[^]*?(^\w)/m, '$1 ******\n$2');
+  maskYAML = maskYAML.slice(0, -2);
+  return maskYAML;
+};
+
+// module exports
+module.exports = {
+  mask,
+};

--- a/src/rest-server/test/protocolSecret.js
+++ b/src/rest-server/test/protocolSecret.js
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the 'Software'), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// module dependencies
+const protocolSecret = require('../src/util/protocolSecret');
+
+const protocolYAMLs = {
+  secrets_example: `
+protocolVersion: 2
+name: secret_example
+type: job
+version: !!str 1.0
+contributor: OpenPAI
+secrets:
+  registry:
+    username: testuser
+    password: testpass
+prerequisites:
+  - protocolVersion: 2
+    name: secret_example
+    type: dockerimage
+    version: !!str 1.0
+    contributor: OpenPAI
+    description: caffe
+    auth:
+      username: <% $secrets.registry.username %>
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+  `,
+
+  secrets_in_the_end: `
+protocolVersion: 2
+name: secret_example
+type: job
+prerequisites:
+  - name: secret_example
+    type: dockerimage
+    auth:
+      username: testuser
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+secrets:
+  password: testpass
+  `,
+};
+
+const maskYAMLs = {
+  secrets_example: `
+protocolVersion: 2
+name: secret_example
+type: job
+version: !!str 1.0
+contributor: OpenPAI
+secrets: ******
+prerequisites:
+  - protocolVersion: 2
+    name: secret_example
+    type: dockerimage
+    version: !!str 1.0
+    contributor: OpenPAI
+    description: caffe
+    auth:
+      username: <% $secrets.registry.username %>
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+  `,
+
+  secrets_in_the_end: `
+protocolVersion: 2
+name: secret_example
+type: job
+prerequisites:
+  - name: secret_example
+    type: dockerimage
+    auth:
+      username: testuser
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+secrets: ******
+  `,
+};
+
+// unit tests for protocol secrets mask
+describe('Protocol secrets mask Unit Tests', () => {
+  // protocol secrets mask test
+  it('test protocol secrets mask for protocol configs', () => {
+    for (let [name, protocolYAML] of Object.entries(protocolYAMLs)) {
+      const maskYAML = protocolSecret.mask(protocolYAML);
+      expect(maskYAML.trim()).to.equal(maskYAMLs[name].trim());
+    }
+  });
+});

--- a/src/rest-server/test/v2/protocol.js
+++ b/src/rest-server/test/v2/protocol.js
@@ -139,6 +139,60 @@ const validprotocolObjs = {
     },
     'deployments': {},
   },
+
+  secret_example: {
+    'protocolVersion': 2,
+    'name': 'secret_example',
+    'type': 'job',
+    'version': '1.0',
+    'contributor': 'OpenPAI',
+    'secrets': {
+      'registry': {
+        'username': 'testuser',
+        'password': 'testpass',
+      },
+    },
+    'prerequisites': {
+      'data': {},
+      'output': {},
+      'script': {},
+      'dockerimage': {
+        'secret_example': {
+          'protocolVersion': 2,
+          'name': 'secret_example',
+          'type': 'dockerimage',
+          'version': '1.0',
+          'contributor': 'OpenPAI',
+          'description': 'caffe',
+          'auth': {
+            'username': 'testuser',
+            'password': 'testpass',
+            'registryuri': 'docker.io',
+          },
+          'uri': 'openpai/pai.example.caffe',
+        },
+      },
+    },
+    'taskRoles': {
+      'train': {
+        'instances': 1,
+        'completion': {
+          'minSucceededTaskCount': 1,
+        },
+        'dockerImage': 'secret_example',
+        'resourcePerInstance': {
+          'cpu': 4,
+          'memoryMB': 8192,
+          'gpu': 1,
+        },
+        'commands': [
+          'exit',
+        ],
+        'entrypoint': 'exit',
+      },
+    },
+    "deployments": {},
+  },
 };
 
 const validProtocolYAMLs = {
@@ -221,6 +275,42 @@ taskRoles:
         --epochs <% $parameters.epochs %>
         --lr <% $parameters.lr %>
         --batch-size <% $parameters.batchsize %>
+  `,
+
+  secret_example: `
+protocolVersion: 2
+name: secret_example
+type: job
+version: !!str 1.0
+contributor: OpenPAI
+secrets:
+  registry:
+    username: testuser
+    password: testpass
+prerequisites:
+  - protocolVersion: 2
+    name: secret_example
+    type: dockerimage
+    version: !!str 1.0
+    contributor: OpenPAI
+    description: caffe
+    auth:
+      username: <% $secrets.registry.username %>
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
   `,
 };
 


### PR DESCRIPTION
Support secrets in protocol
------------------------------

Users may need sensitive information including password or API key in their jobs, `secrets` section is used to help user hide those sensitive information in plain text and avoid sharing.

Work items
------------
- [x] Agree on an approach to add secrets in protocol.
- [x] Update the protocol implementation to support read secret from yaml and mask with `*` when storing.
- [x] Hide the secrets in webportal, including submission, config view, and job clone.