### PR TITLE
use api/v1/pods to get all pods

### DIFF
--- a/src/watchdog/test/test_watchdog.py
+++ b/src/watchdog/test/test_watchdog.py
@@ -67,8 +67,7 @@ class TestJobExporter(unittest.TestCase):
         container_gauge = watchdog.gen_pai_container_gauge()
         pod_info = collections.defaultdict(lambda : [])
 
-        watchdog.process_pods_status(obj, "default",
-                pod_gauge, container_gauge, pod_info)
+        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info)
 
         self.assertTrue(len(pod_gauge.samples) > 0)
         self.assertTrue(len(container_gauge.samples) > 0)
@@ -90,8 +89,7 @@ class TestJobExporter(unittest.TestCase):
         container_gauge = watchdog.gen_pai_container_gauge()
         pod_info = collections.defaultdict(lambda : [])
 
-        watchdog.process_pods_status(obj, "default",
-                pod_gauge, container_gauge, pod_info)
+        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info)
 
         self.assertTrue(len(pod_gauge.samples) > 0)
         self.assertEqual(0, len(container_gauge.samples))
@@ -105,7 +103,7 @@ class TestJobExporter(unittest.TestCase):
                 container_gauge = watchdog.gen_pai_container_gauge()
                 pod_info = collections.defaultdict(lambda : [])
 
-                watchdog.process_pods_status(obj, "default",
+                watchdog.process_pods_status(obj,
                         pod_gauge, container_gauge, pod_info)
 
                 yield pod_gauge


### PR DESCRIPTION
Previous watchdog use `/api/v1/namespaces/{}/pods` iterate all namespace to get all pods, simplify it to get via `/api/v1/pods`.

This can reduce number of http get watchdog issues.