### PR TITLE
[Rest Server] Add secrets field in protocol

### DIFF
--- a/src/rest-server/src/config/v2/protocol.js
+++ b/src/rest-server/src/config/v2/protocol.js
@@ -164,6 +164,10 @@ const protocolSchema = {
       type: 'object',
       additionalProperties: true,
     },
+    secrets: {
+      type: 'object',
+      additionalProperties: true,
+    },
     jobRetryCount: {
       type: 'integer',
       minimum: 0,

--- a/src/rest-server/src/middlewares/v2/protocol.js
+++ b/src/rest-server/src/middlewares/v2/protocol.js
@@ -129,9 +129,9 @@ const protocolValidate = (protocolYAML) => {
 
 const protocolRender = (protocolObj) => {
   // render auth for Docker image
-  for (let name of protocolObj.prerequisites.dockerimage) {
+  for (let name of Object.keys(protocolObj.prerequisites.dockerimage)) {
     if ('auth' in protocolObj.prerequisites.dockerimage[name]) {
-      for (let prop of protocolObj.prerequisites.dockerimage[name].auth) {
+      for (let prop of Object.keys(protocolObj.prerequisites.dockerimage[name].auth)) {
         protocolObj.prerequisites.dockerimage[name].auth[prop] = render(
           protocolObj.prerequisites.dockerimage[name].auth[prop],
           {'$secrets': protocolObj.secrets},

--- a/src/rest-server/src/models/v2/job.js
+++ b/src/rest-server/src/models/v2/job.js
@@ -119,6 +119,7 @@ const generateYarnContainerScript = (frameworkName, userName, config, frameworkD
       jobName: frameworkName,
       userName: userName,
       image: config.prerequisites.dockerimage[config.taskRoles[taskRole].dockerImage].uri,
+      auth: config.prerequisites.dockerimage[config.taskRoles[taskRole].dockerImage].auth,
       authFile: null,
       virtualCluster: frameworkDescription.platformSpecificParameters.queue,
     },
@@ -232,9 +233,13 @@ const prepareContainerScripts = async (frameworkName, userName, config, rawConfi
     JSON.stringify(frameworkDescription, null, 2), userName, '644')
   );
   // upload original config file to hdfs
+  // mask secrets field before uploading
+  let maskRawConfig = rawConfig + '\nZ';
+  maskRawConfig = maskRawConfig.replace(/(^secrets:)[^]*?(^\w)/m, '$1 ******\n$2');
+  maskRawConfig = maskRawConfig.slice(0, -2);
   hdfsPromises.push(
     upload(`${pathPrefix}/${launcherConfig.jobConfigFileName}`.replace(/json$/, 'yaml'),
-    rawConfig, userName, '644')
+    maskRawConfig, userName, '644')
   );
 
   // generate ssh key

--- a/src/rest-server/src/models/v2/job.js
+++ b/src/rest-server/src/models/v2/job.js
@@ -25,6 +25,7 @@ const mustache = require('mustache');
 const userModel = require('../user');
 const HDFS = require('../../util/hdfs');
 const createError = require('../../util/error');
+const protocolSecret = require('../../util/protocolSecret');
 const logger = require('../../config/logger');
 const azureEnv = require('../../config/azure');
 const paiConfig = require('../../config/paiConfig');
@@ -234,12 +235,9 @@ const prepareContainerScripts = async (frameworkName, userName, config, rawConfi
   );
   // upload original config file to hdfs
   // mask secrets field before uploading
-  let maskRawConfig = rawConfig + '\nZ';
-  maskRawConfig = maskRawConfig.replace(/(^secrets:)[^]*?(^\w)/m, '$1 ******\n$2');
-  maskRawConfig = maskRawConfig.slice(0, -2);
   hdfsPromises.push(
     upload(`${pathPrefix}/${launcherConfig.jobConfigFileName}`.replace(/json$/, 'yaml'),
-    maskRawConfig, userName, '644')
+    protocolSecret.mask(rawConfig), userName, '644')
   );
 
   // generate ssh key

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -311,6 +311,13 @@ if [[ -d "/dev/infiniband" ]]; then
   infiniband_flags+='--cap-add=IPC_LOCK --device=/dev/infiniband'
 fi
 
+{{# jobData.auth }}
+set +x
+docker login --username {{ jobData.auth.username }} --password {{ jobData.auth.password }} {{ jobData.auth.registryuri }} \
+  || { echo 'Authorized failed' ; exit 1; }
+set -x
+{{/ jobData.auth }}
+
 {{# jobData.authFile }}
 IFS=$'\r\n' GLOBIGNORE='*' \
   eval 'cred=($(hdfs dfs -cat {{ jobData.authFile }}))' \

--- a/src/rest-server/src/util/protocolSecret.js
+++ b/src/rest-server/src/util/protocolSecret.js
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+const mask = (protocolYAML) => {
+  let maskYAML = protocolYAML + '\nZ';
+  maskYAML = maskYAML.replace(/(^secrets:)[^]*?(^\w)/m, '$1 ******\n$2');
+  maskYAML = maskYAML.slice(0, -2);
+  return maskYAML;
+};
+
+// module exports
+module.exports = {
+  mask,
+};

--- a/src/rest-server/test/protocolSecret.js
+++ b/src/rest-server/test/protocolSecret.js
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the 'Software'), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// module dependencies
+const protocolSecret = require('../src/util/protocolSecret');
+
+const protocolYAMLs = {
+  secrets_example: `
+protocolVersion: 2
+name: secret_example
+type: job
+version: !!str 1.0
+contributor: OpenPAI
+secrets:
+  registry:
+    username: testuser
+    password: testpass
+prerequisites:
+  - protocolVersion: 2
+    name: secret_example
+    type: dockerimage
+    version: !!str 1.0
+    contributor: OpenPAI
+    description: caffe
+    auth:
+      username: <% $secrets.registry.username %>
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+  `,
+
+  secrets_in_the_end: `
+protocolVersion: 2
+name: secret_example
+type: job
+prerequisites:
+  - name: secret_example
+    type: dockerimage
+    auth:
+      username: testuser
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+secrets:
+  password: testpass
+  `,
+};
+
+const maskYAMLs = {
+  secrets_example: `
+protocolVersion: 2
+name: secret_example
+type: job
+version: !!str 1.0
+contributor: OpenPAI
+secrets: ******
+prerequisites:
+  - protocolVersion: 2
+    name: secret_example
+    type: dockerimage
+    version: !!str 1.0
+    contributor: OpenPAI
+    description: caffe
+    auth:
+      username: <% $secrets.registry.username %>
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+  `,
+
+  secrets_in_the_end: `
+protocolVersion: 2
+name: secret_example
+type: job
+prerequisites:
+  - name: secret_example
+    type: dockerimage
+    auth:
+      username: testuser
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
+secrets: ******
+  `,
+};
+
+// unit tests for protocol secrets mask
+describe('Protocol secrets mask Unit Tests', () => {
+  // protocol secrets mask test
+  it('test protocol secrets mask for protocol configs', () => {
+    for (let [name, protocolYAML] of Object.entries(protocolYAMLs)) {
+      const maskYAML = protocolSecret.mask(protocolYAML);
+      expect(maskYAML.trim()).to.equal(maskYAMLs[name].trim());
+    }
+  });
+});

--- a/src/rest-server/test/v2/protocol.js
+++ b/src/rest-server/test/v2/protocol.js
@@ -139,6 +139,60 @@ const validprotocolObjs = {
     },
     'deployments': {},
   },
+
+  secret_example: {
+    'protocolVersion': 2,
+    'name': 'secret_example',
+    'type': 'job',
+    'version': '1.0',
+    'contributor': 'OpenPAI',
+    'secrets': {
+      'registry': {
+        'username': 'testuser',
+        'password': 'testpass',
+      },
+    },
+    'prerequisites': {
+      'data': {},
+      'output': {},
+      'script': {},
+      'dockerimage': {
+        'secret_example': {
+          'protocolVersion': 2,
+          'name': 'secret_example',
+          'type': 'dockerimage',
+          'version': '1.0',
+          'contributor': 'OpenPAI',
+          'description': 'caffe',
+          'auth': {
+            'username': 'testuser',
+            'password': 'testpass',
+            'registryuri': 'docker.io',
+          },
+          'uri': 'openpai/pai.example.caffe',
+        },
+      },
+    },
+    'taskRoles': {
+      'train': {
+        'instances': 1,
+        'completion': {
+          'minSucceededTaskCount': 1,
+        },
+        'dockerImage': 'secret_example',
+        'resourcePerInstance': {
+          'cpu': 4,
+          'memoryMB': 8192,
+          'gpu': 1,
+        },
+        'commands': [
+          'exit',
+        ],
+        'entrypoint': 'exit',
+      },
+    },
+    "deployments": {},
+  },
 };
 
 const validProtocolYAMLs = {
@@ -221,6 +275,42 @@ taskRoles:
         --epochs <% $parameters.epochs %>
         --lr <% $parameters.lr %>
         --batch-size <% $parameters.batchsize %>
+  `,
+
+  secret_example: `
+protocolVersion: 2
+name: secret_example
+type: job
+version: !!str 1.0
+contributor: OpenPAI
+secrets:
+  registry:
+    username: testuser
+    password: testpass
+prerequisites:
+  - protocolVersion: 2
+    name: secret_example
+    type: dockerimage
+    version: !!str 1.0
+    contributor: OpenPAI
+    description: caffe
+    auth:
+      username: <% $secrets.registry.username %>
+      password: <% $secrets.registry.password %>
+      registryuri: docker.io
+    uri : openpai/pai.example.caffe
+taskRoles:
+  train:
+    instances: 1
+    completion:
+      minSucceededTaskCount: 1
+    dockerImage: secret_example
+    resourcePerInstance:
+      cpu: 4
+      memoryMB: 8192
+      gpu: 1
+    commands:
+      - exit
   `,
 };
 


### PR DESCRIPTION
Add secrets field in protocol, implement #2729:

* Update protocol schema
* Parse and render secrets field in commands/auth
* Support Docker login using secrets, remove credentials from `set -x` debug log
* Mask secrets field when storing yaml