### PR TITLE
[Rest Server] Check default runtime before starting Docker

### DIFF
--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -559,6 +559,7 @@ class Job {
           'taskData': data.taskRoles[idx],
           'jobData': data,
           'inspectPidFormat': '{{.State.Pid}}',
+          'infoDefaultRuntimeFormat': '{{json .DefaultRuntime}}',
           'jobEnvs': jobEnvs,
           'azRDMA': azureEnv.azRDMA === 'false' ? false : true,
           'isDebug': data.jobEnvs && data.jobEnvs.isDebug === true ? true : false,

--- a/src/rest-server/src/models/v2/job.js
+++ b/src/rest-server/src/models/v2/job.js
@@ -142,7 +142,7 @@ const generateYarnContainerScript = (frameworkName, userName, config, frameworkD
     azRDMA: azureEnv.azRDMA === 'true' ? true : false,
     reqAzRDMA: false,
     inspectPidFormat: '{{.State.Pid}}',
-    inspectOOMKilledFormat: '{{.State.OOMKilled}}',
+    infoDefaultRuntimeFormat: '{{json .DefaultRuntime}}',
   });
   return yarnContainerScript;
 };

--- a/src/rest-server/src/templates/yarnContainerScript.mustache
+++ b/src/rest-server/src/templates/yarnContainerScript.mustache
@@ -306,6 +306,15 @@ gpu_id=$(echo $gpu_id | sed "s/,$//g")
 printf "%s %s\n%s\n\n" "[INFO]" "GPU_ID" "$gpu_id"
 printf "%s %s\n%s\n\n" "[INFO]" "NVIDIA_DEVICES" "$nvidia_devices"
 
+nvidia_flags=''
+# check docker runtime
+default_runtime=$(docker info --format {{{ infoDefaultRuntimeFormat }}})
+if [ "$default_runtime" = "nvidia" ]; then
+  nvidia_flags+="--runtime=nvidia --env NVIDIA_VISIBLE_DEVICES=$gpu_id"
+else
+  nvidia_flags+="--runtime=runc --env NVIDIA_VISIBLE_DEVICES=void $nvidia_devices"
+fi
+
 infiniband_flags=''
 if [[ -d "/dev/infiniband" ]]; then
   infiniband_flags+='--cap-add=IPC_LOCK --device=/dev/infiniband'
@@ -512,7 +521,7 @@ mounted_path=$(docker inspect $container_id |\
   jq -r --arg hadoop_tmp_dir "$hadoop_tmp_dir" '.[] | .Mounts | .[] | select(.Destination==$hadoop_tmp_dir) | .Source')
 container_local_dir=$mounted_path/nm-local-dir/usercache/{{ jobData.userName }}/appcache/$APP_ID/$CONTAINER_ID
 
-# Pull docker image and run
+# pull docker image and run
 docker pull {{ jobData.image }} \
   || { echo "Can not pull Docker image"; exit 1; }
 
@@ -522,7 +531,6 @@ docker run --name $docker_name \
   --init \
   --tty \
   --rm \
-  --runtime=runc \
   --privileged=false \
   --oom-score-adj=1000 \
   --cap-add=SYS_ADMIN \
@@ -532,8 +540,8 @@ docker run --name $docker_name \
   --cpus={{ taskData.cpuNumber }} \
   --memory={{ taskData.memoryMB }}m \
   --shm-size={{ taskData.shmMB }}m \
+  $nvidia_flags \
   $infiniband_flags \
-  $nvidia_devices \
   --device=/dev/fuse \
 {{# isDebug }}
   --cap-add=SYS_PTRACE \
@@ -561,7 +569,6 @@ docker run --name $docker_name \
   --label PAI_JOB_VC_NAME={{ jobData.virtualCluster }} \
   --label PAI_USER_NAME={{ jobData.userName }} \
   --label PAI_CURRENT_TASK_ROLE_NAME={{ taskData.name }} \
-  --env NVIDIA_VISIBLE_DEVICES=void \
   --env-file $ENV_LIST \
   --entrypoint="" \
    {{ jobData.image }} \


### PR DESCRIPTION
Check default runtime before starting Docker, fix #2739.

If nvidia-docker is installed and nvidia runtime is enabled by default, start nvidia-docker and isolate GPU through `NVIDIA_VISIBLE_DEVICES` provided by nvidia runtime.