### PR TITLE
Mitigate vc update failure

### DIFF
--- a/src/hadoop-resource-manager/deploy/hadoop-resource-manager-configuration/core-site.xml
+++ b/src/hadoop-resource-manager/deploy/hadoop-resource-manager-configuration/core-site.xml
@@ -36,22 +36,6 @@
 </property>
 
 <property>
-  <name>hadoop.http.cross-origin.enabled</name>
-  <value>true</value>
-  <description>
-         Enables cross origin support for all web-services
-  </description>
-</property>
-
-<property>
-  <name>hadoop.http.filter.initializers</name>
-  <value>org.apache.hadoop.security.HttpCrossOriginFilterInitializer</value>
-  <description>
-         Add to this property the org.apache.hadoop.security.AuthenticationFilterInitializer initializer class.
-  </description>
-</property>
-
-<property>
   <name>ipc.server.max.response.size</name>
   <value>5242880</value>
   <description>


### PR DESCRIPTION
There are some exception when we enable both cross origin and queue api, as below, since we havn't used RM cross origin, disable it here:

```
19/05/14 09:54:54 DEBUG mortbay.log: REQUEST /ws/v1/cluster/scheduler on org.mortbay.jetty.HttpConnection@12829025
19/05/14 09:54:54 DEBUG mortbay.log: sessionManager=org.mortbay.jetty.servlet.HashSessionManager@3be4fcc0
19/05/14 09:54:54 DEBUG mortbay.log: session=null
19/05/14 09:54:54 DEBUG mortbay.log: servlet=org.mortbay.jetty.servlet.DefaultServlet-1005331061
19/05/14 09:54:54 DEBUG mortbay.log: chain=NoCacheFilter->NoCacheFilter->safety->Cross Origin Filter->org.apache.hadoop.security.http.XFrameOptionsFilter->guice->org.mortbay.jetty.servlet.DefaultServlet-1005331061
19/05/14 09:54:54 DEBUG mortbay.log: servlet holder=org.mortbay.jetty.servlet.DefaultServlet-1005331061
19/05/14 09:54:54 DEBUG mortbay.log: call filter NoCacheFilter
19/05/14 09:54:54 DEBUG mortbay.log: call filter NoCacheFilter
19/05/14 09:54:54 DEBUG mortbay.log: call filter safety
19/05/14 09:54:54 DEBUG mortbay.log: call filter Cross Origin Filter
19/05/14 09:54:54 DEBUG http.CrossOriginFilter: Header origin is null. Returning
19/05/14 09:54:54 DEBUG mortbay.log: call filter org.apache.hadoop.security.http.XFrameOptionsFilter
19/05/14 09:54:54 DEBUG mortbay.log: call filter guice
19/05/14 09:54:54 DEBUG mortbay.log: RESPONSE /ws/v1/cluster/scheduler  200
19/05/14 09:54:54 DEBUG mortbay.log: EOF
19/05/14 09:54:54 DEBUG mortbay.log: REQUEST /ws/v1/cluster/scheduler-conf on org.mortbay.jetty.HttpConnection@2c92df5a
19/05/14 09:54:54 DEBUG mortbay.log: sessionManager=org.mortbay.jetty.servlet.HashSessionManager@3be4fcc0
19/05/14 09:54:54 DEBUG mortbay.log: session=null
19/05/14 09:54:54 DEBUG mortbay.log: servlet=org.mortbay.jetty.servlet.DefaultServlet-1005331061
19/05/14 09:54:54 DEBUG mortbay.log: chain=NoCacheFilter->NoCacheFilter->safety->Cross Origin Filter->org.apache.hadoop.security.http.XFrameOptionsFilter->guice->org.mortbay.jetty.servlet.DefaultServlet-1005331061
19/05/14 09:54:54 DEBUG mortbay.log: servlet holder=org.mortbay.jetty.servlet.DefaultServlet-1005331061
19/05/14 09:54:54 DEBUG mortbay.log: call filter NoCacheFilter
19/05/14 09:54:54 DEBUG mortbay.log: call filter NoCacheFilter
19/05/14 09:54:54 DEBUG mortbay.log: call filter safety
19/05/14 09:54:54 DEBUG mortbay.log: call filter Cross Origin Filter
19/05/14 09:54:54 DEBUG http.CrossOriginFilter: Header origin is null. Returning
19/05/14 09:54:54 DEBUG mortbay.log: call filter org.apache.hadoop.security.http.XFrameOptionsFilter
19/05/14 09:54:54 DEBUG mortbay.log: call filter guice
19/05/14 09:54:54 DEBUG mortbay.log: getResource(META-INF/services/javax.xml.bind.JAXBContext)=jar:file:/usr/local/hadoop-2.9.0/share/hadoop/common/lib/jaxb-impl-2.2.3-1.jar!/META-INF/services/javax.xml.bind.JAXBContext
19/05/14 09:54:54 DEBUG mortbay.log: loaded class com.sun.xml.bind.v2.ContextFactory from sun.misc.Launcher$AppClassLoader@7fbe847c
19/05/14 09:54:54 DEBUG mortbay.log: loaded class org.apache.xerces.parsers.XIncludeAwareParserConfiguration from sun.misc.Launcher$AppClassLoader@7fbe847c
19/05/14 09:54:54 DEBUG mortbay.log: loaded class org.apache.xerces.impl.dv.dtd.DTDDVFactoryImpl from sun.misc.Launcher$AppClassLoader@7fbe847c
19/05/14 09:54:54 DEBUG mortbay.log: loaded class org.apache.xerces.parsers.XIncludeAwareParserConfiguration from sun.misc.Launcher$AppClassLoader@7fbe847c
19/05/14 09:54:54 DEBUG mortbay.log: loaded class org.apache.xerces.impl.dv.dtd.DTDDVFactoryImpl from sun.misc.Launcher$AppClassLoader@7fbe847c
19/05/14 09:54:54 WARN webapp.GenericExceptionHandler: INTERNAL_SERVER_ERROR
java.lang.NullPointerException
	at org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWebServices.updateSchedulerConfiguration(RMWebServices.java:2444)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60)
	at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:205)
	at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75)
	at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:288)
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
	at com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:108)
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
	at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1469)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1400)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1349)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1339)
	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:416)
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:537)
	at com.sun.jersey.spi.container.servlet.ServletContainer.doFilter(ServletContainer.java:886)
	at com.sun.jersey.spi.container.servlet.ServletContainer.doFilter(ServletContainer.java:834)
	at org.apache.hadoop.yarn.server.resourcemanager.webapp.RMWebAppFilter.doFilter(RMWebAppFilter.java:178)
	at com.sun.jersey.spi.container.servlet.ServletContainer.doFilter(ServletContainer.java:795)
	at com.google.inject.servlet.FilterDefinition.doFilter(FilterDefinition.java:163)
	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:58)
	at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:118)
	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:113)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1212)
	at org.apache.hadoop.security.http.XFrameOptionsFilter.doFilter(XFrameOptionsFilter.java:57)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1212)
	at org.apache.hadoop.security.http.CrossOriginFilter.doFilter(CrossOriginFilter.java:96)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1212)
	at org.apache.hadoop.http.HttpServer2$QuotingInputFilter.doFilter(HttpServer2.java:1440)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1212)
	at org.apache.hadoop.http.NoCacheFilter.doFilter(NoCacheFilter.java:45)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1212)
	at org.apache.hadoop.http.NoCacheFilter.doFilter(NoCacheFilter.java:45)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1212)
	at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:399)
	at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
	at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
	at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:766)
	at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:450)
	at org.mortbay.jetty.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:230)
	at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
	at org.mortbay.jetty.Server.handle(Server.java:322)
	at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
	at org.mortbay.jetty.HttpConnection$RequestHandler.content(HttpConnection.java:945)
	at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:756)
	at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:218)
	at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
	at org.mortbay.io.nio.SelectChannelEndPoint.run(SelectChannelEndPoint.java:410)
	at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)
19/05/14 09:54:54 DEBUG mortbay.log: RESPONSE /ws/v1/cluster/scheduler-conf  500
19/05/14 09:54:54 DEBUG mortbay.log: EOF
```