### PR TITLE
change triggering rule for exporter hangs

### DIFF
--- a/src/prometheus/deploy/alerting/pai-services.rules
+++ b/src/prometheus/deploy/alerting/pai-services.rules
@@ -43,7 +43,7 @@ groups:
           summary: "{{$labels.pai_service_name}} in {{$labels.instance}} not up detected"
 
       - alert: JobExporterHangs
-        expr: irate(collector_iteration_count_total[5m]) == 0
+        expr: rate(collector_iteration_count_total[10m]) == 0
         for: 5m
         labels:
           type: pai_service


### PR DESCRIPTION
Previous rule triggered too frequently, since many are due to IO slow instead of IO hangs, and can mitigate automatically. This alert was intend to catch IO hangs and when triggered the node may need to be restarted, so change triggering rule to make it less frequent.