### PR TITLE
add DLTS services names to job-exporter white list

### DIFF
--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -456,7 +456,16 @@ class ContainerCollector(Collector):
         "job-exporter",
         "yarn-exporter",
         "nvidia-drivers",
-        "docker-cleaner"
+        "docker-cleaner",
+
+        # Below are DLTS services
+        "nginx",
+        "restfulapi",
+        "weave",
+        "weave-npc",
+        "nvidia-device-plugin-ctr",
+        "mysql",
+        "jobmanager",
         ]))
 
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter, gpu_info_ref,


### PR DESCRIPTION
Add DLTS services names to job-exporter white list so job-exporter could also monitor dlts service's resource usage.