### PR TITLE
[Deployment] Allow user to use Backspace in paictl input

### DIFF
--- a/deployment/clusterCmd.py
+++ b/deployment/clusterCmd.py
@@ -1,6 +1,25 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 import os
 import sys
 import time
+import readline
 import logging
 import logging.config
 

--- a/deployment/confStorage/download.py
+++ b/deployment/confStorage/download.py
@@ -22,6 +22,7 @@ import sys
 import subprocess
 import jinja2
 import argparse
+import readline
 import logging
 import logging.config
 

--- a/deployment/confStorage/external_version_control/external_config.py
+++ b/deployment/confStorage/external_version_control/external_config.py
@@ -19,6 +19,7 @@
 import os
 import sys
 import yaml
+import readline
 import logging
 import logging.config
 

--- a/deployment/confStorage/upload.py
+++ b/deployment/confStorage/upload.py
@@ -22,6 +22,7 @@ import sys
 import subprocess
 import jinja2
 import argparse
+import readline
 import logging
 import logging.config
 

--- a/deployment/k8sPaiLibrary/maintainlib/kubectl_install.py
+++ b/deployment/k8sPaiLibrary/maintainlib/kubectl_install.py
@@ -17,9 +17,10 @@
 
 import os
 import sys
-import common
-import logging
 import time
+import common
+import readline
+import logging
 import logging.config
 
 

--- a/deployment/machineCmd.py
+++ b/deployment/machineCmd.py
@@ -1,6 +1,25 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 import os
 import sys
 import time
+import readline
 import logging
 import logging.config
 

--- a/deployment/serviceCmd.py
+++ b/deployment/serviceCmd.py
@@ -1,4 +1,23 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 import os
+import readline
 import logging
 import logging.config
 

--- a/deployment/utility/sftp_copy.py
+++ b/deployment/utility/sftp_copy.py
@@ -19,6 +19,7 @@ from ..clusterObjectModel import cluster_object_model
 from ..k8sPaiLibrary.maintainlib import common
 
 import sys
+import readline
 import logging
 import logging.config
 

--- a/deployment/utility/ssh.py
+++ b/deployment/utility/ssh.py
@@ -18,6 +18,7 @@
 from ..clusterObjectModel import cluster_object_model
 from ..k8sPaiLibrary.maintainlib import common
 import sys
+import readline
 import logging
 import logging.config
 


### PR DESCRIPTION
Allow user to use <kbd>Backspace</kbd> when inputing in paictl.
Currently, <kbd>Backspace</kbd> will results `^H` in stdin.