### PR TITLE
add response time & response code monitoring for services

### DIFF
--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -30,6 +30,7 @@ import faulthandler
 import gc
 import re
 import collections
+import datetime
 
 import yaml
 import prometheus_client
@@ -92,6 +93,14 @@ def gen_k8s_node_gpu_total():
     return GaugeMetricFamily("k8s_node_gpu_total", "gpu total on k8s node",
             labels=["host_ip"])
 
+service_response_histogram = Histogram("service_response_latency_seconds",
+            "response latency of each service",
+            labelnames=("service_name", "service_ip"),
+            buckets=(.1, .5, 1.0, 2.0, 4.0, 6.0, 8.0, 10.0, 16.0, 32.0, float("inf")))
+
+service_response_counter = Counter("service_response_code",
+        "total count of http return code", ["service_name", "service_ip", "code"])
+
 ##### watchdog will generate above metrics
 
 def walk_json_field_safe(obj, *fields):
@@ -128,31 +137,45 @@ def convert_to_byte(data):
     else:
         return number
 
+
 class AtomicRef(object):
-    """ a thread safe way to store and get object, should not modify data get from this ref """
-    def __init__(self):
+    """ a thread safe way to store and get object,
+    should not modify data get from this ref,
+    each get and set method should provide a time obj,
+    so this ref decide whether the data is out of date or not,
+    return None on expired """
+    def __init__(self, decay_time):
         self.data = None
+        self.date_in_produced = datetime.datetime.now()
+        self.decay_time = decay_time
         self.lock = threading.RLock()
 
-    def get_and_set(self, new_data):
-        data = None
+    def set(self, data, now):
         with self.lock:
-            data, self.data = self.data, new_data
-        return data
+            self.data, self.date_in_produced = data, now
 
-    def get(self):
+    def get(self, now):
         with self.lock:
+            if self.date_in_produced + self.decay_time < now:
+                return None
             return self.data
 
 
 class CustomCollector(object):
-    def __init__(self, atomic_ref):
-        self.atomic_ref = atomic_ref
+    def __init__(self, atomic_refs):
+        self.atomic_refs = atomic_refs
 
     def collect(self):
-        data = self.atomic_ref.get()
+        data = []
 
-        if data is not None:
+        now = datetime.datetime.now()
+
+        for ref in self.atomic_refs:
+            d = ref.get(now)
+            if d is not None:
+                data.extend(d)
+
+        if len(data) > 0:
             for datum in data:
                 yield datum
         else:
@@ -179,7 +202,36 @@ class PodInfo(object):
     def __repr__(self):
         return "%s: %s" % (self.name, self.gpu)
 
-def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info):
+
+def process_service_endpoints(service_name, host_ip, annotations, service_endpoints):
+    annotation_ns = "monitor.watchdog"
+    port_key = annotation_ns + "/port"
+    path_key = annotation_ns + "/path"
+    timeout_key = annotation_ns + "/timeout"
+
+    if port_key in annotations and path_key in annotations:
+        try:
+            port = int(annotations[port_key])
+        except ValueError:
+            logger.warning("illegal value %s in %s, expect port",
+                    annotations[port_key], port_key)
+            return
+
+        path = annotations[path_key]
+
+        timeout = 10 # default
+        if annotations.get(timeout_key) is not None:
+            try:
+                timeout = int(annotations.get(timeout_key))
+            except ValueError:
+                logger.warning("illegal value %s in %s, expect int. Ignore it",
+                        annotations[timeout_key], timeout_key)
+
+        service_endpoints.append(
+                ServiceEndpoint(service_name, host_ip, port, path, timeout))
+
+
+def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info, service_endpoints):
     """ add metrics to pai_pod_gauge or pai_container_gauge if successfully paesed pod.
     Because we are parsing json outputed by k8s, its format is subjected to change,
     we should test if field exists before accessing it to avoid KeyError """
@@ -205,6 +257,10 @@ def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info):
         return None
 
     service_name = labels["app"] # get pai service name from label
+
+    annotations = walk_json_field_safe(pod, "metadata", "annotations") or {}
+    if host_ip != "unscheduled":
+        process_service_endpoints(service_name, host_ip, annotations, service_endpoints)
 
     status = pod["status"]
 
@@ -261,14 +317,14 @@ def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info):
 
 
 def process_pods_status(pods_object, pai_pod_gauge, pai_container_gauge,
-        pods_info):
+        pods_info, service_endpoints):
     def _map_fn(item):
         return catch_exception(parse_pod_item,
                 "catch exception when parsing pod item",
                 None,
                 item,
                 pai_pod_gauge, pai_container_gauge,
-                pods_info)
+                pods_info, service_endpoints)
 
     list(map(_map_fn, pods_object["items"]))
 
@@ -404,7 +460,7 @@ def process_nodes_status(nodes_object, pods_info):
             node_gpu_avail, node_gpu_total, node_gpu_reserved]
 
 
-def process_pods(k8s_api_addr, ca_path, headers, pods_info):
+def process_pods(k8s_api_addr, ca_path, headers, pods_info, service_endpoints):
     list_pods_url = "{}/api/v1/pods".format(k8s_api_addr)
 
     pai_pod_gauge = gen_pai_pod_gauge()
@@ -414,7 +470,7 @@ def process_pods(k8s_api_addr, ca_path, headers, pods_info):
         pods_object = request_with_histogram(list_pods_url, list_pods_histogram,
                 ca_path, headers)
         process_pods_status(pods_object, pai_pod_gauge, pai_container_gauge,
-                pods_info)
+                pods_info, service_endpoints)
     except Exception as e:
         error_counter.labels(type="parse").inc()
         logger.exception("failed to process pods from namespace %s", ns)
@@ -479,13 +535,22 @@ def main(args):
 
     try_remove_old_prom_file(log_dir + "/watchdog.prom")
 
-    atomic_ref = AtomicRef()
+    decay_time = datetime.timedelta(seconds=float(args.interval) * 2)
 
-    t = threading.Thread(target=loop, name="loop", args=(args, atomic_ref))
+    services_ref = AtomicRef(decay_time)
+    loop_result_ref = AtomicRef(decay_time)
+
+    t = threading.Thread(target=loop, name="loop",
+            args=(args, services_ref, loop_result_ref))
     t.daemon = True
     t.start()
 
-    REGISTRY.register(CustomCollector(atomic_ref))
+    t = threading.Thread(target=requestor, name="requestor",
+            args=(args, services_ref))
+    t.daemon = True
+    t.start()
+
+    REGISTRY.register(CustomCollector([loop_result_ref]))
 
     root = Resource()
     root.putChild(b"metrics", MetricsResource())
@@ -496,7 +561,44 @@ def main(args):
     reactor.run()
 
 
-def loop(args, atomic_ref):
+class ServiceEndpoint(object):
+    def __init__(self, name, ip, port, path, timeout):
+        self.name = name
+        self.ip = ip
+        self.port = port
+        self.path = path
+        self.timeout = timeout
+
+    def __repr__(self):
+        return "http://%s:%s/%s" % (self.ip, self.port, self.path)
+
+
+def requestor(args, services_ref):
+    while True:
+        services = services_ref.get(datetime.datetime.now()) or ()
+
+        logger.debug("get %d of services", len(services))
+
+        result = []
+
+        for s in services:
+            url = urllib.parse.urljoin("http://{}:{}".format(s.ip, s.port),
+                    s.path)
+            try:
+                with service_response_histogram.labels(s.name, s.ip).time():
+                    resp = requests.get(url)
+                code = str(resp.status_code)
+            except Exception as e:
+                logger.exception("requesting %s failed", url)
+                code = str(e)
+
+            service_response_counter.labels(s.name, s.ip, code).inc()
+
+        # The minimal sleep time is 10s
+        time.sleep(max(10, float(args.interval) / 3))
+
+
+def loop(args, services_ref, result_ref):
     address = args.k8s_api
     parse_result = urllib.parse.urlparse(address)
     api_server_scheme = parse_result.scheme
@@ -523,7 +625,10 @@ def loop(args, atomic_ref):
         try:
             pods_info = collections.defaultdict(lambda : [])
 
-            result.extend(process_pods(address, ca_path, headers, pods_info))
+            service_endpoints = []
+            result.extend(process_pods(address, ca_path, headers, pods_info,
+                service_endpoints))
+            services_ref.set(service_endpoints, datetime.datetime.now())
 
             result.extend(process_nodes(address, ca_path, headers, pods_info))
 
@@ -532,7 +637,7 @@ def loop(args, atomic_ref):
             error_counter.labels(type="unknown").inc()
             logger.exception("watchdog failed in one iteration")
 
-        atomic_ref.get_and_set(result)
+        result_ref.set(result, datetime.datetime.now())
 
         time.sleep(float(args.interval))
 

--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -586,7 +586,7 @@ def requestor(args, services_ref):
                     s.path)
             try:
                 with service_response_histogram.labels(s.name, s.ip).time():
-                    resp = requests.get(url)
+                    resp = requests.get(url, timeout=s.timeout)
                 code = str(resp.status_code)
             except Exception as e:
                 logger.exception("requesting %s failed", url)

--- a/src/watchdog/test/data/pods_with_response_time_monitor.json
+++ b/src/watchdog/test/data/pods_with_response_time_monitor.json
@@ -1,0 +1,446 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/pods",
+    "resourceVersion": "25956571"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "job-exporter-2cm8j",
+        "generateName": "job-exporter-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/job-exporter-2cm8j",
+        "uid": "87b37216-7863-11e9-9e00-000d3ab38724",
+        "resourceVersion": "25164752",
+        "creationTimestamp": "2019-05-17T05:20:48Z",
+        "labels": {
+          "app": "job-exporter",
+          "controller-revision-hash": "590349042",
+          "pod-template-generation": "2"
+        },
+        "annotations": {
+          "monitor.watchdog/path": "/healthz",
+          "monitor.watchdog/port": "9102",
+          "prometheus.io/path": "/metrics",
+          "prometheus.io/port": "9102",
+          "prometheus.io/scrape": "true"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "DaemonSet",
+            "name": "job-exporter",
+            "uid": "b06ece04-77d1-11e9-9e00-000d3ab38724",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "docker-socket",
+            "hostPath": {
+              "path": "/var/run/docker.sock",
+              "type": ""
+            }
+          },
+          {
+            "name": "device-mount",
+            "hostPath": {
+              "path": "/dev",
+              "type": ""
+            }
+          },
+          {
+            "name": "driver-path",
+            "hostPath": {
+              "path": "/var/drivers/nvidia/current",
+              "type": ""
+            }
+          },
+          {
+            "name": "collector-mount",
+            "hostPath": {
+              "path": "/datastorage/prometheus",
+              "type": ""
+            }
+          },
+          {
+            "name": "gpu-config",
+            "configMap": {
+              "name": "gpu-configuration",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "job-exporter",
+            "image": "openpai.azurecr.io/paiclusterint/job-exporter:protocol",
+            "command": [
+              "python",
+              "/job_exporter/main.py",
+              "--port",
+              "9102",
+              "--interval",
+              "30",
+              "--interface",
+              "eth0,eno2"
+            ],
+            "ports": [
+              {
+                "name": "main",
+                "hostPort": 9102,
+                "containerPort": 9102,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "HOST_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.hostIP"
+                  }
+                }
+              },
+              {
+                "name": "LOGGING_LEVEL",
+                "value": "INFO"
+              },
+              {
+                "name": "NV_DRIVER",
+                "value": "/var/drivers/nvidia/current"
+              },
+              {
+                "name": "NVIDIA_VISIBLE_DEVICES",
+                "value": "all"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "memory": "512Mi"
+              },
+              "requests": {
+                "memory": "512Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "docker-socket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "device-mount",
+                "mountPath": "/dev"
+              },
+              {
+                "name": "driver-path",
+                "mountPath": "/var/drivers/nvidia/current"
+              },
+              {
+                "name": "collector-mount",
+                "mountPath": "/datastorage/prometheus"
+              },
+              {
+                "name": "gpu-config",
+                "mountPath": "/gpu-config"
+              }
+            ],
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/healthz",
+                "port": 9102,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 10,
+              "periodSeconds": 30,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always",
+            "securityContext": {
+              "privileged": true
+            }
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "nodeName": "10.151.40.231",
+        "hostNetwork": true,
+        "hostPID": true
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-05-17T05:21:24Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-05-17T05:21:27Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-05-17T05:21:27Z"
+          }
+        ],
+        "hostIP": "10.151.40.231",
+        "podIP": "10.151.40.231",
+        "startTime": "2019-05-17T05:21:24Z",
+        "containerStatuses": [
+          {
+            "name": "job-exporter",
+            "state": {
+              "running": {
+                "startedAt": "2019-05-17T05:21:26Z"
+              }
+            },
+            "lastState": {
+              
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "openpai.azurecr.io/paiclusterint/job-exporter:protocol",
+            "imageID": "docker-pullable://openpai.azurecr.io/paiclusterint/job-exporter@sha256:5a79610923edca24d940a4b66bc6ec5d47b05ac2a91a441959e424de7edc54c1",
+            "containerID": "docker://75b8eeab86b363b9dcd5d4d531db8933beee6a05a5f747f25d77806e93c5181b"
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    },
+    {
+      "metadata": {
+        "name": "job-exporter-4w8jt",
+        "generateName": "job-exporter-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/job-exporter-4w8jt",
+        "uid": "d5d681af-7863-11e9-9e00-000d3ab38724",
+        "resourceVersion": "25165492",
+        "creationTimestamp": "2019-05-17T05:22:59Z",
+        "labels": {
+          "app": "job-exporter",
+          "controller-revision-hash": "590349042",
+          "pod-template-generation": "2"
+        },
+        "annotations": {
+          "monitor.watchdog/path": "/healthz",
+          "monitor.watchdog/port": "9102",
+          "prometheus.io/path": "/metrics",
+          "prometheus.io/port": "9102",
+          "prometheus.io/scrape": "true"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "DaemonSet",
+            "name": "job-exporter",
+            "uid": "b06ece04-77d1-11e9-9e00-000d3ab38724",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "docker-socket",
+            "hostPath": {
+              "path": "/var/run/docker.sock",
+              "type": ""
+            }
+          },
+          {
+            "name": "device-mount",
+            "hostPath": {
+              "path": "/dev",
+              "type": ""
+            }
+          },
+          {
+            "name": "driver-path",
+            "hostPath": {
+              "path": "/var/drivers/nvidia/current",
+              "type": ""
+            }
+          },
+          {
+            "name": "collector-mount",
+            "hostPath": {
+              "path": "/datastorage/prometheus",
+              "type": ""
+            }
+          },
+          {
+            "name": "gpu-config",
+            "configMap": {
+              "name": "gpu-configuration",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "job-exporter",
+            "image": "openpai.azurecr.io/paiclusterint/job-exporter:protocol",
+            "command": [
+              "python",
+              "/job_exporter/main.py",
+              "--port",
+              "9102",
+              "--interval",
+              "30",
+              "--interface",
+              "eth0,eno2"
+            ],
+            "ports": [
+              {
+                "name": "main",
+                "hostPort": 9102,
+                "containerPort": 9102,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "HOST_IP",
+                "valueFrom": {
+                  "fieldRef": {
+                    "apiVersion": "v1",
+                    "fieldPath": "status.hostIP"
+                  }
+                }
+              },
+              {
+                "name": "LOGGING_LEVEL",
+                "value": "INFO"
+              },
+              {
+                "name": "NV_DRIVER",
+                "value": "/var/drivers/nvidia/current"
+              },
+              {
+                "name": "NVIDIA_VISIBLE_DEVICES",
+                "value": "all"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "memory": "512Mi"
+              },
+              "requests": {
+                "memory": "512Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "docker-socket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "device-mount",
+                "mountPath": "/dev"
+              },
+              {
+                "name": "driver-path",
+                "mountPath": "/var/drivers/nvidia/current"
+              },
+              {
+                "name": "collector-mount",
+                "mountPath": "/datastorage/prometheus"
+              },
+              {
+                "name": "gpu-config",
+                "mountPath": "/gpu-config"
+              }
+            ],
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/healthz",
+                "port": 9102,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 30,
+              "timeoutSeconds": 10,
+              "periodSeconds": 30,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always",
+            "securityContext": {
+              "privileged": true
+            }
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "nodeName": "10.151.40.227",
+        "hostNetwork": true,
+        "hostPID": true,
+        "schedulerName": "default-scheduler"
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-05-17T05:23:25Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-05-17T05:23:27Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-05-17T05:23:27Z"
+          }
+        ],
+        "hostIP": "10.151.40.227",
+        "podIP": "10.151.40.227",
+        "startTime": "2019-05-17T05:23:25Z",
+        "containerStatuses": [
+          {
+            "name": "job-exporter",
+            "state": {
+              "running": {
+                "startedAt": "2019-05-17T05:23:26Z"
+              }
+            },
+            "lastState": {
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "openpai.azurecr.io/paiclusterint/job-exporter:protocol",
+            "imageID": "docker-pullable://openpai.azurecr.io/paiclusterint/job-exporter@sha256:5a79610923edca24d940a4b66bc6ec5d47b05ac2a91a441959e424de7edc54c1",
+            "containerID": "docker://ebe3632e4bd5573cea1adfccf55b0e37a3d5ba202dc8115c52c02f1c76a43736"
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    }
+  ]
+}

--- a/src/watchdog/test/test_watchdog.py
+++ b/src/watchdog/test/test_watchdog.py
@@ -167,5 +167,34 @@ class TestJobExporter(unittest.TestCase):
         for gauge in gauges[1:]:
             self.assertEqual("192.168.255.1", gauge.samples[0].labels["host_ip"])
 
+    def test_parse_monitor_response_time(self):
+        obj = json.loads(self.get_data_test_input("data/pods_with_response_time_monitor.json"))
+
+        pod_gauge = watchdog.gen_pai_pod_gauge()
+        container_gauge = watchdog.gen_pai_container_gauge()
+        pod_info = collections.defaultdict(lambda : [])
+        endpoints = []
+
+        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info, endpoints)
+
+        self.assertEqual(2, len(endpoints))
+        endpoint0 = endpoints[0]
+        endpoint1 = endpoints[1]
+
+        self.assertEqual("job-exporter", endpoint0.name)
+        self.assertEqual("job-exporter", endpoint1.name)
+
+        self.assertEqual("10.151.40.231", endpoint0.ip)
+        self.assertEqual("10.151.40.227", endpoint1.ip)
+
+        self.assertEqual(9102, endpoint0.port)
+        self.assertEqual(9102, endpoint1.port)
+
+        self.assertEqual("/healthz", endpoint0.path)
+        self.assertEqual("/healthz", endpoint1.path)
+
+        self.assertEqual(10, endpoint0.timeout)
+        self.assertEqual(10, endpoint1.timeout)
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/watchdog/test/test_watchdog.py
+++ b/src/watchdog/test/test_watchdog.py
@@ -67,7 +67,7 @@ class TestJobExporter(unittest.TestCase):
         container_gauge = watchdog.gen_pai_container_gauge()
         pod_info = collections.defaultdict(lambda : [])
 
-        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info)
+        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info, [])
 
         self.assertTrue(len(pod_gauge.samples) > 0)
         self.assertTrue(len(container_gauge.samples) > 0)
@@ -89,7 +89,7 @@ class TestJobExporter(unittest.TestCase):
         container_gauge = watchdog.gen_pai_container_gauge()
         pod_info = collections.defaultdict(lambda : [])
 
-        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info)
+        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info, [])
 
         self.assertTrue(len(pod_gauge.samples) > 0)
         self.assertEqual(0, len(container_gauge.samples))
@@ -104,7 +104,7 @@ class TestJobExporter(unittest.TestCase):
                 pod_info = collections.defaultdict(lambda : [])
 
                 watchdog.process_pods_status(obj,
-                        pod_gauge, container_gauge, pod_info)
+                        pod_gauge, container_gauge, pod_info, [])
 
                 yield pod_gauge
                 yield container_gauge


### PR DESCRIPTION
pods with label key of `app` and annotation `monitor.watchdog/port`, `monitor.watchdog/path` will be requested by watchdog, and watchdog will generate response related metrics like return code and latency.

With these metrics, we can write following alert rules:

* `rate(service_response_code_total{code="200"}[5m]) == 0` to alert service return not returning 200
* `histogram_quantile(0.9, sum(rate(service_response_latency_seconds_bucket[5m])) by (le, service_name, service_ip)) > 5` to alert 90% latency is larger than 5s.