### PR TITLE
support per vc gpu available count

### DIFF
--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -575,7 +575,7 @@ def process_pods(k8s_api_addr, ca_path, headers, pods_info, service_endpoints, v
         process_vc_info(vc_info, vc_usage, vc_total, vc_avail, vc_preemptive_avail)
     except Exception as e:
         error_counter.labels(type="parse").inc()
-        logger.exception("failed to process pods from namespace %s", ns)
+        logger.exception("failed to process pods")
 
     return [pai_pod_gauge, pai_container_gauge, vc_total, vc_avail, vc_preemptive_avail]
 

--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -61,6 +61,9 @@ list_pods_histogram = Histogram("k8s_api_list_pods_latency_seconds",
 list_nodes_histogram = Histogram("k8s_api_list_nodes_latency_seconds",
         "Response latency for list nodes from k8s api (seconds)")
 
+list_vc_quota_histogram = Histogram("list_vc_quota_latency_seconds",
+        "Response latency for list vc quota from restful api (seconds)")
+
 def gen_pai_pod_gauge():
     return GaugeMetricFamily("pai_pod_count", "count of pai pod",
             labels=["service_name", "name", "namespace", "phase", "host_ip",
@@ -100,6 +103,20 @@ service_response_histogram = Histogram("service_response_latency_seconds",
 
 service_response_counter = Counter("service_response_code",
         "total count of http return code", ["service_name", "service_ip", "code"])
+
+def gen_k8s_vc_gpu_total():
+    return GaugeMetricFamily("k8s_vc_gpu_total", "gpu total in vc",
+            labels=["vc_name"])
+
+def gen_k8s_vc_gpu_available():
+    return GaugeMetricFamily("k8s_vc_gpu_available",
+            "gpu available for non preemptable job in vc",
+            labels=["vc_name"])
+
+def gen_k8s_vc_gpu_preemptive_available():
+    return GaugeMetricFamily("k8s_vc_gpu_preemptive_availabe",
+            "gpu available for preemptable job in vc",
+            labels=["vc_name"])
 
 ##### watchdog will generate above metrics
 
@@ -202,7 +219,6 @@ class PodInfo(object):
     def __repr__(self):
         return "%s: %s" % (self.name, self.gpu)
 
-
 def process_service_endpoints(service_name, host_ip, annotations, service_endpoints):
     annotation_ns = "monitor.watchdog"
     port_key = annotation_ns + "/port"
@@ -231,7 +247,7 @@ def process_service_endpoints(service_name, host_ip, annotations, service_endpoi
                 ServiceEndpoint(service_name, host_ip, port, path, timeout))
 
 
-def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info, service_endpoints):
+def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info, service_endpoints, vc_usage):
     """ add metrics to pai_pod_gauge or pai_container_gauge if successfully paesed pod.
     Because we are parsing json outputed by k8s, its format is subjected to change,
     we should test if field exists before accessing it to avoid KeyError """
@@ -250,6 +266,15 @@ def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info, service_e
                     "nvidia.com/gpu") or 0)
             used_gpu += max(req_gpu, limit_gpu)
     pods_info[host_ip].append(PodInfo(pod_name, used_gpu))
+
+    vc = walk_json_field_safe(pod, "metadata", "labels", "vcName")
+    preemptable = walk_json_field_safe(pod, "metadata", "labels", "preemptionAllowed")
+
+    if vc is not None and preemptable is not None:
+        if preemptable == "True" or preemptable == "true":
+            vc_usage.add_preemptable_used(vc, used_gpu)
+        else:
+            vc_usage.add_used(vc, used_gpu)
 
     labels = pod["metadata"].get("labels")
     if labels is None or "app" not in labels:
@@ -317,14 +342,14 @@ def parse_pod_item(pod, pai_pod_gauge, pai_container_gauge, pods_info, service_e
 
 
 def process_pods_status(pods_object, pai_pod_gauge, pai_container_gauge,
-        pods_info, service_endpoints):
+        pods_info, service_endpoints, vc_usage):
     def _map_fn(item):
         return catch_exception(parse_pod_item,
                 "catch exception when parsing pod item",
                 None,
                 item,
                 pai_pod_gauge, pai_container_gauge,
-                pods_info, service_endpoints)
+                pods_info, service_endpoints, vc_usage)
 
     list(map(_map_fn, pods_object["items"]))
 
@@ -460,22 +485,88 @@ def process_nodes_status(nodes_object, pods_info):
             node_gpu_avail, node_gpu_total, node_gpu_reserved]
 
 
-def process_pods(k8s_api_addr, ca_path, headers, pods_info, service_endpoints):
+def process_vc_quota(vc_object):
+    result = {}
+
+    for vc_info in vc_object["result"]:
+        name = vc_info["vcName"]
+        quota = json.loads(vc_info["quota"])
+        count = sum(quota.values()) # ignore gpu type
+        result[name] = count
+
+    return result
+
+
+def query_vc_quota_info(vc_quota_url):
+    if vc_quota_url is None:
+        return {}
+
+    vc_object = request_with_histogram(vc_quota_url, list_vc_quota_histogram,
+            None, None)
+    return process_vc_quota(vc_object)
+
+
+class VcUsage(object):
+    def __init__(self):
+        # key is vc_name, value is array of two int.
+        # The first is total used, the second is those non-preemptable used
+        self.map = collections.defaultdict(lambda : [0, 0])
+
+    def add_preemptable_used(self, vc, count):
+        self.map[vc][0] += count
+
+    def add_used(self, vc, count):
+        self.map[vc][0] += count
+        self.map[vc][1] += count
+
+
+def process_vc_info(vc_info, vc_usage, vc_total_gauge, vc_avail_gauge,
+    vc_preemptive_avail_gauge):
+    for vc_name, total in vc_info.items():
+        vc_total_gauge.add_metric([vc_name], total)
+
+        if vc_name not in vc_usage.map:
+            # no job running in this vc, emit total as available
+            vc_avail_gauge.add_metric([vc_name], total)
+            vc_preemptive_avail_gauge.add_metric([vc_name], total)
+
+    for vc_name, vc_used in vc_usage.map.items():
+        if vc_name not in vc_info:
+            logger.warning("ignore used gpu in %s, but vc quota do not have this vc, possible due to job template error", vc_name)
+            continue
+
+        total = vc_info[vc_name]
+        total_used, non_preemptable_used = vc_used
+        vc_avail_gauge.add_metric([vc_name], total - total_used)
+        vc_preemptive_avail_gauge.add_metric([vc_name],
+                total - non_preemptable_used)
+
+
+def process_pods(k8s_api_addr, ca_path, headers, pods_info, service_endpoints, vc_quota_url):
     list_pods_url = "{}/api/v1/pods".format(k8s_api_addr)
 
     pai_pod_gauge = gen_pai_pod_gauge()
     pai_container_gauge = gen_pai_container_gauge()
 
+    vc_total = gen_k8s_vc_gpu_total()
+    vc_avail = gen_k8s_vc_gpu_available()
+    vc_preemptive_avail = gen_k8s_vc_gpu_preemptive_available()
+
+    vc_usage = VcUsage()
+
     try:
+        vc_info = query_vc_quota_info(vc_quota_url)
+
         pods_object = request_with_histogram(list_pods_url, list_pods_histogram,
                 ca_path, headers)
         process_pods_status(pods_object, pai_pod_gauge, pai_container_gauge,
-                pods_info, service_endpoints)
+                pods_info, service_endpoints, vc_usage)
+        process_vc_info(vc_info, vc_usage, vc_total, vc_avail, vc_preemptive_avail)
     except Exception as e:
         error_counter.labels(type="parse").inc()
         logger.exception("failed to process pods from namespace %s", ns)
 
-    return [pai_pod_gauge, pai_container_gauge]
+    return [pai_pod_gauge, pai_container_gauge, vc_total, vc_avail, vc_preemptive_avail]
 
 
 def process_nodes(k8s_api_addr, ca_path, headers, pods_info):
@@ -605,6 +696,8 @@ def loop(args, services_ref, result_ref):
     api_server_ip = parse_result.hostname
     api_server_port = parse_result.port or 80
 
+    vc_quota_url = args.vc_url
+
     ca_path = args.ca
     bearer_path = args.bearer
     if (ca_path is None and bearer_path is not None) or (ca_path is not None and bearer_path is None):
@@ -626,8 +719,10 @@ def loop(args, services_ref, result_ref):
             pods_info = collections.defaultdict(lambda : [])
 
             service_endpoints = []
+
             result.extend(process_pods(address, ca_path, headers, pods_info,
-                service_endpoints))
+                service_endpoints, vc_quota_url))
+
             services_ref.set(service_endpoints, datetime.datetime.now())
 
             result.extend(process_nodes(address, ca_path, headers, pods_info))
@@ -669,6 +764,7 @@ if __name__ == "__main__":
     parser.add_argument("--port", "-p", help="port to expose metrics", default="9101")
     parser.add_argument("--ca", "-c", help="ca file path")
     parser.add_argument("--bearer", "-b", help="bearer token file path")
+    parser.add_argument("--vc_url", "-u", required=False, help="url to list vc quota")
     args = parser.parse_args()
 
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)s - %(message)s",

--- a/src/watchdog/test/data/dlts_non_preemptable_pod.json
+++ b/src/watchdog/test/data/dlts_non_preemptable_pod.json
@@ -14,7 +14,8 @@
             "run": "27cd4600-692e-4410-b514-a2547d88ad71",
             "userName": "dixu",
             "vcName": "some_vc_name",
-            "preemptionAllowed": "False"
+            "preemptionAllowed": "False",
+            "gpuType": "P40"
         }
     },
     "spec": {

--- a/src/watchdog/test/data/dlts_non_preemptable_pod.json
+++ b/src/watchdog/test/data/dlts_non_preemptable_pod.json
@@ -1,0 +1,259 @@
+{
+    "metadata": {
+        "name": "27cd4600-692e-4410-b514-a2547d88ad71-worker1",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/27cd4600-692e-4410-b514-a2547d88ad71-worker1",
+        "uid": "51b28641-61b9-11e9-9957-000d3a1707fc",
+        "resourceVersion": "14592494",
+        "creationTimestamp": "2019-04-18T09:06:57Z",
+        "labels": {
+            "distPort": "3040",
+            "distRole": "worker",
+            "jobName": "tutorialtensorflow",
+            "podName": "27cd4600-692e-4410-b514-a2547d88ad71-worker1",
+            "run": "27cd4600-692e-4410-b514-a2547d88ad71",
+            "userName": "dixu",
+            "vcName": "some_vc_name",
+            "preemptionAllowed": "False"
+        }
+    },
+    "spec": {
+        "volumes": [
+            {
+                "name": "resolv",
+                "hostPath": {
+                    "path": "/etc/resolv.conf",
+                    "type": ""
+                }
+            },
+            {
+                "name": "6aba981baa894bceaed0f041a123145e",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu",
+                    "type": ""
+                }
+            },
+            {
+                "name": "job",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu/jobs/190418/27cd4600-692e-4410-b514-a2547d88ad71/worker1",
+                    "type": ""
+                }
+            },
+            {
+                "name": "work",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu",
+                    "type": ""
+                }
+            },
+            {
+                "name": "data",
+                "hostPath": {
+                    "path": "/dlwsdata/storage/imagenet",
+                    "type": ""
+                }
+            },
+            {
+                "name": "rootsshkey",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu/.ssh",
+                    "type": ""
+                }
+            },
+            {
+                "name": "dshm",
+                "emptyDir": {
+                    "medium": "Memory"
+                }
+            },
+            {
+                "name": "default-token-xqzf9",
+                "secret": {
+                    "secretName": "default-token-xqzf9",
+                    "defaultMode": 420
+                }
+            }
+        ],
+        "containers": [
+            {
+                "name": "27cd4600-692e-4410-b514-a2547d88ad71",
+                "image": "dlws/tutorial-tensorflow:1.5",
+                "command": [
+                    "bash",
+                    "/job/launch-27cd4600-692e-4410-b514-a2547d88ad71-worker1.sh"
+                ],
+                "ports": [
+                    {
+                        "hostPort": 3040,
+                        "containerPort": 3040,
+                        "protocol": "TCP"
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "FAMILY_TOKEN",
+                        "value": "3b5817949c704aeeb0438516c2816fcf"
+                    },
+                    {
+                        "name": "DLWS_REST_API",
+                        "value": "None"
+                    },
+                    {
+                        "name": "DLWS_USER_NAME",
+                        "value": "dixu"
+                    },
+                    {
+                        "name": "DLWS_JOB_ID",
+                        "value": "27cd4600-692e-4410-b514-a2547d88ad71"
+                    },
+                    {
+                        "name": "DLWS_NUM_PS",
+                        "value": "1"
+                    },
+                    {
+                        "name": "DLWS_NUM_WORKER",
+                        "value": "2"
+                    },
+                    {
+                        "name": "DLWS_NUM_GPU_PER_WORKER",
+                        "value": "1"
+                    },
+                    {
+                        "name": "POD_NAME",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "metadata.name"
+                            }
+                        }
+                    },
+                    {
+                        "name": "POD_IP",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "status.podIP"
+                            }
+                        }
+                    },
+                    {
+                        "name": "LD_LIBRARY_PATH",
+                        "value": "/usr/local/nvidia/lib64/"
+                    }
+                ],
+                "resources": {
+                    "limits": {
+                        "nvidia.com/gpu": "1"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "nvidia.com/gpu": "1"
+                    }
+                },
+                "volumeMounts": [
+                    {
+                        "name": "6aba981baa894bceaed0f041a123145e",
+                        "mountPath": "/home/dixu"
+                    },
+                    {
+                        "name": "job",
+                        "mountPath": "/job"
+                    },
+                    {
+                        "name": "work",
+                        "mountPath": "/work"
+                    },
+                    {
+                        "name": "data",
+                        "mountPath": "/data"
+                    },
+                    {
+                        "name": "rootsshkey",
+                        "mountPath": "/sshkey/.ssh"
+                    },
+                    {
+                        "name": "resolv",
+                        "mountPath": "/etc/resolv.conf"
+                    },
+                    {
+                        "name": "dshm",
+                        "mountPath": "/dev/shm"
+                    },
+                    {
+                        "name": "default-token-xqzf9",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                    }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "Always"
+            }
+        ],
+        "restartPolicy": "Never",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "dltsp40-worker-bgbizu",
+        "securityContext": {
+        },
+        "imagePullSecrets": [
+            {
+                "name": "regcred"
+            }
+        ],
+        "schedulerName": "default-scheduler"
+    },
+    "status": {
+        "phase": "Failed",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2019-04-18T09:06:58Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2019-05-30T11:40:21Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [27cd4600-692e-4410-b514-a2547d88ad71]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2019-04-18T09:06:57Z"
+            }
+        ],
+        "hostIP": "192.168.0.7",
+        "podIP": "10.2.192.5",
+        "startTime": "2019-04-18T09:06:58Z",
+        "containerStatuses": [
+            {
+                "name": "27cd4600-692e-4410-b514-a2547d88ad71",
+                "state": {
+                    "terminated": {
+                        "exitCode": 137,
+                        "reason": "Error",
+                        "startedAt": "2019-04-18T09:07:00Z",
+                        "finishedAt": "2019-05-30T11:40:07Z",
+                        "containerID": "docker://107e0ed00d8c0a38ed4af1fcfe33cb0e259fe4e7009ebe03f7cbcdecbf3e35e1"
+                    }
+                },
+                "lastState": {
+                },
+                "ready": false,
+                "restartCount": 0,
+                "image": "dlws/tutorial-tensorflow:1.5",
+                "imageID": "docker-pullable://dlws/tutorial-tensorflow@sha256:cf850a71c7d54bdf0e41f544d2661677919ec6f26ab833ef8a7b39ec0ef429d1",
+                "containerID": "docker://107e0ed00d8c0a38ed4af1fcfe33cb0e259fe4e7009ebe03f7cbcdecbf3e35e1"
+            }
+        ],
+        "qosClass": "Burstable"
+    }
+}

--- a/src/watchdog/test/data/dlts_preemptable_pod.json
+++ b/src/watchdog/test/data/dlts_preemptable_pod.json
@@ -1,0 +1,259 @@
+{
+    "metadata": {
+        "name": "27cd4600-692e-4410-b514-a2547d88ad71-worker1",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/27cd4600-692e-4410-b514-a2547d88ad71-worker1",
+        "uid": "51b28641-61b9-11e9-9957-000d3a1707fc",
+        "resourceVersion": "14592494",
+        "creationTimestamp": "2019-04-18T09:06:57Z",
+        "labels": {
+            "distPort": "3040",
+            "distRole": "worker",
+            "jobName": "tutorialtensorflow",
+            "podName": "27cd4600-692e-4410-b514-a2547d88ad71-worker1",
+            "run": "27cd4600-692e-4410-b514-a2547d88ad71",
+            "userName": "dixu",
+            "vcName": "some_vc_name",
+            "preemptionAllowed": "True"
+        }
+    },
+    "spec": {
+        "volumes": [
+            {
+                "name": "resolv",
+                "hostPath": {
+                    "path": "/etc/resolv.conf",
+                    "type": ""
+                }
+            },
+            {
+                "name": "6aba981baa894bceaed0f041a123145e",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu",
+                    "type": ""
+                }
+            },
+            {
+                "name": "job",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu/jobs/190418/27cd4600-692e-4410-b514-a2547d88ad71/worker1",
+                    "type": ""
+                }
+            },
+            {
+                "name": "work",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu",
+                    "type": ""
+                }
+            },
+            {
+                "name": "data",
+                "hostPath": {
+                    "path": "/dlwsdata/storage/imagenet",
+                    "type": ""
+                }
+            },
+            {
+                "name": "rootsshkey",
+                "hostPath": {
+                    "path": "/dlwsdata/work/dixu/.ssh",
+                    "type": ""
+                }
+            },
+            {
+                "name": "dshm",
+                "emptyDir": {
+                    "medium": "Memory"
+                }
+            },
+            {
+                "name": "default-token-xqzf9",
+                "secret": {
+                    "secretName": "default-token-xqzf9",
+                    "defaultMode": 420
+                }
+            }
+        ],
+        "containers": [
+            {
+                "name": "27cd4600-692e-4410-b514-a2547d88ad71",
+                "image": "dlws/tutorial-tensorflow:1.5",
+                "command": [
+                    "bash",
+                    "/job/launch-27cd4600-692e-4410-b514-a2547d88ad71-worker1.sh"
+                ],
+                "ports": [
+                    {
+                        "hostPort": 3040,
+                        "containerPort": 3040,
+                        "protocol": "TCP"
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "FAMILY_TOKEN",
+                        "value": "3b5817949c704aeeb0438516c2816fcf"
+                    },
+                    {
+                        "name": "DLWS_REST_API",
+                        "value": "None"
+                    },
+                    {
+                        "name": "DLWS_USER_NAME",
+                        "value": "dixu"
+                    },
+                    {
+                        "name": "DLWS_JOB_ID",
+                        "value": "27cd4600-692e-4410-b514-a2547d88ad71"
+                    },
+                    {
+                        "name": "DLWS_NUM_PS",
+                        "value": "1"
+                    },
+                    {
+                        "name": "DLWS_NUM_WORKER",
+                        "value": "2"
+                    },
+                    {
+                        "name": "DLWS_NUM_GPU_PER_WORKER",
+                        "value": "1"
+                    },
+                    {
+                        "name": "POD_NAME",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "metadata.name"
+                            }
+                        }
+                    },
+                    {
+                        "name": "POD_IP",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "status.podIP"
+                            }
+                        }
+                    },
+                    {
+                        "name": "LD_LIBRARY_PATH",
+                        "value": "/usr/local/nvidia/lib64/"
+                    }
+                ],
+                "resources": {
+                    "limits": {
+                        "nvidia.com/gpu": "1"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "nvidia.com/gpu": "1"
+                    }
+                },
+                "volumeMounts": [
+                    {
+                        "name": "6aba981baa894bceaed0f041a123145e",
+                        "mountPath": "/home/dixu"
+                    },
+                    {
+                        "name": "job",
+                        "mountPath": "/job"
+                    },
+                    {
+                        "name": "work",
+                        "mountPath": "/work"
+                    },
+                    {
+                        "name": "data",
+                        "mountPath": "/data"
+                    },
+                    {
+                        "name": "rootsshkey",
+                        "mountPath": "/sshkey/.ssh"
+                    },
+                    {
+                        "name": "resolv",
+                        "mountPath": "/etc/resolv.conf"
+                    },
+                    {
+                        "name": "dshm",
+                        "mountPath": "/dev/shm"
+                    },
+                    {
+                        "name": "default-token-xqzf9",
+                        "readOnly": true,
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                    }
+                ],
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "Always"
+            }
+        ],
+        "restartPolicy": "Never",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "dltsp40-worker-bgbizu",
+        "securityContext": {
+        },
+        "imagePullSecrets": [
+            {
+                "name": "regcred"
+            }
+        ],
+        "schedulerName": "default-scheduler"
+    },
+    "status": {
+        "phase": "Failed",
+        "conditions": [
+            {
+                "type": "Initialized",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2019-04-18T09:06:58Z"
+            },
+            {
+                "type": "Ready",
+                "status": "False",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2019-05-30T11:40:21Z",
+                "reason": "ContainersNotReady",
+                "message": "containers with unready status: [27cd4600-692e-4410-b514-a2547d88ad71]"
+            },
+            {
+                "type": "PodScheduled",
+                "status": "True",
+                "lastProbeTime": null,
+                "lastTransitionTime": "2019-04-18T09:06:57Z"
+            }
+        ],
+        "hostIP": "192.168.0.7",
+        "podIP": "10.2.192.5",
+        "startTime": "2019-04-18T09:06:58Z",
+        "containerStatuses": [
+            {
+                "name": "27cd4600-692e-4410-b514-a2547d88ad71",
+                "state": {
+                    "terminated": {
+                        "exitCode": 137,
+                        "reason": "Error",
+                        "startedAt": "2019-04-18T09:07:00Z",
+                        "finishedAt": "2019-05-30T11:40:07Z",
+                        "containerID": "docker://107e0ed00d8c0a38ed4af1fcfe33cb0e259fe4e7009ebe03f7cbcdecbf3e35e1"
+                    }
+                },
+                "lastState": {
+                },
+                "ready": false,
+                "restartCount": 0,
+                "image": "dlws/tutorial-tensorflow:1.5",
+                "imageID": "docker-pullable://dlws/tutorial-tensorflow@sha256:cf850a71c7d54bdf0e41f544d2661677919ec6f26ab833ef8a7b39ec0ef429d1",
+                "containerID": "docker://107e0ed00d8c0a38ed4af1fcfe33cb0e259fe4e7009ebe03f7cbcdecbf3e35e1"
+            }
+        ],
+        "qosClass": "Burstable"
+    }
+}

--- a/src/watchdog/test/data/dlts_preemptable_pod.json
+++ b/src/watchdog/test/data/dlts_preemptable_pod.json
@@ -14,7 +14,8 @@
             "run": "27cd4600-692e-4410-b514-a2547d88ad71",
             "userName": "dixu",
             "vcName": "some_vc_name",
-            "preemptionAllowed": "True"
+            "preemptionAllowed": "True",
+            "gpuType": "P80"
         }
     },
     "spec": {

--- a/src/watchdog/test/data/vc_quota.json
+++ b/src/watchdog/test/data/vc_quota.json
@@ -1,0 +1,34 @@
+{
+  "result": [
+    {
+      "metadata": "{\"P40\":{\"num_gpu_per_node\":4}}",
+      "quota": "{\"P40\":20}",
+      "vcName": "platform"
+    },
+    {
+      "metadata": "{\"P40\":{\"num_gpu_per_node\":4}}",
+      "quota": "{\"P40\":6}",
+      "vcName": "vc1"
+    },
+    {
+      "metadata": "{\"P40\":{\"num_gpu_per_node\":4}}",
+      "quota": "{\"P40\":0}",
+      "vcName": "bert"
+    },
+    {
+      "metadata": "{\"P40\":{\"num_gpu_per_node\":4}}",
+      "quota": "{\"P40\":0}",
+      "vcName": "multimedia"
+    },
+    {
+      "metadata": "{\"P40\":{\"num_gpu_per_node\":4}}",
+      "quota": "{\"P40\":0}",
+      "vcName": "quantus"
+    },
+    {
+      "metadata": "{\"P40\":{\"num_gpu_per_node\":4}}",
+      "quota": "{\"P40\":0}",
+      "vcName": "relevance"
+    }
+  ]
+}

--- a/src/watchdog/test/test_watchdog.py
+++ b/src/watchdog/test/test_watchdog.py
@@ -247,7 +247,7 @@ class TestJobExporter(unittest.TestCase):
 
         vc_usage = watchdog.VcUsage()
 
-        watchdog.parse_pod_item(obj, pod_gauge, container_gauge, pod_info,
+        watchdog.parse_pod_item(obj, pod_gauge, container_gauge, pod_info, [],
                 vc_usage)
 
         self.assertEqual(1, len(vc_usage.map))
@@ -256,7 +256,7 @@ class TestJobExporter(unittest.TestCase):
         self.assertEqual(1, vc_usage.map["some_vc_name"]["P40"][1])
 
         obj = json.loads(self.get_data_test_input("data/dlts_preemptable_pod.json"))
-        watchdog.parse_pod_item(obj, pod_gauge, container_gauge, pod_info,
+        watchdog.parse_pod_item(obj, pod_gauge, container_gauge, pod_info, [],
                 vc_usage)
 
         self.assertEqual(1, len(vc_usage.map))
@@ -277,7 +277,9 @@ class TestJobExporter(unittest.TestCase):
 
         endpoints = []
 
-        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info, endpoints)
+        vc_usage = watchdog.VcUsage()
+
+        watchdog.process_pods_status(obj, pod_gauge, container_gauge, pod_info, endpoints, vc_usage)
 
         self.assertEqual(2, len(endpoints))
         endpoint0 = endpoints[0]


### PR DESCRIPTION
Add `vc_url` argument for watchdog to get per vc gpu quota.

Will emit three metrics:
* `k8s_vc_gpu_total`: quota of each gpu type from each VC
* `k8s_vc_gpu_available`: k8s_vc_gpu_total – (sum of gpu used by all jobs in this VC)
* `k8s_vc_gpu_preemptive_availabe`: k8s_vc_gpu_total – (sum of gpu used by all jobs with preemptionAllowed=False in this VC)

All these metrics have 2 labels: `vc_name` and `gpu_type`.