### PR TITLE
[HDFS] client tolerate datanode replacement failure

### DIFF
--- a/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/hdfs-site.xml
+++ b/src/hadoop-node-manager/deploy/hadoop-node-manager-configuration/hdfs-site.xml
@@ -234,7 +234,7 @@
           rejected. It is recommended that this setting be left on to prevent accidental
           registration of datanodes listed by hostname in the excludes file during a DNS
           outage. Only set this to false in environments where there is no infrastructure
-          to support reverse DNS lookup.  
+          to support reverse DNS lookup.
   </description>
 </property>
 
@@ -345,6 +345,19 @@
       NEVER: never add a new datanode. DEFAULT: Let r be the replication number.
       Let n be the number of existing datanodes. Add a new datanode only if r is greater than or equal to 3 and either
       (1) floor(r/2) is greater than or equal to n; or (2) r is greater than n and the block is hflushed/appended.
+  </description>
+</property>
+
+<property>
+  <name>dfs.client.block.write.replace-datanode-on-failure.best-effort</name>
+  <value>true</value>
+  <description>
+      This property is used only if the value of dfs.client.block.write.replace-datanode-on-failure.enable is true.
+      Best effort means that the client will try to replace a failed datanode in write pipeline (provided that the
+      policy is satisfied), however, it continues the write operation in case that the datanode replacement also fails.
+      Suppose the datanode replacement fails. false: An exception should be thrown so that the write will fail.
+      true : The write should be resumed with the remaining datandoes. Note that setting this property to true allows
+      writing to a pipeline with a smaller number of datanodes. As a result, it increases the probability of data loss.
   </description>
 </property>
 


### PR DESCRIPTION
This is an attempt to suppress the warning in tf gfile:
```
19/06/04 04:18:48 WARN hdfs.DFSClient: Error Recovery for block BP-1214599446-127.0.0.1-1542938874046:blk_1075798010_2071296 in pipeline DatanodeInfoWithStorage[10.0.0.11:5010,DS-cbdc31a9-41a2-4fe6-8bb0-feb70edf5edd,DISK], DatanodeInfoWithStorage[10.0.0.17:5010,DS-20f235bc-947e-4f79-b676-4d7fc13cafb5,DISK], DatanodeInfoWithStorage[10.0.0.20:5010,DS-e6f17471-5ee3-406b-a092-4ec6bb9cc38c,DISK]: bad datanode DatanodeInfoWithStorage[10.0.0.20:5010,DS-e6f17471-5ee3-406b-a092-4ec6bb9cc38c,DISK]
19/06/04 04:18:48 WARN hdfs.DFSClient: DataStreamer Exception
java.io.IOException: Failed to replace a bad datanode on the existing pipeline due to no more good datanodes being available to try. (Nodes: current=[DatanodeInfoWithStorage[10.0.0.11:5010,DS-cbdc31a9-41a2-4fe6-8bb0-feb70edf5edd,DISK], DatanodeInfoWithStorage[10.0.0.17:5010,DS-20f235bc-947e-4f79-b676-4d7fc13cafb5,DISK]], original=[DatanodeInfoWithStorage[10.0.0.11:5010,DS-cbdc31a9-41a2-4fe6-8bb0-feb70edf5edd,DISK], DatanodeInfoWithStorage[10.0.0.17:5010,DS-20f235bc-947e-4f79-b676-4d7fc13cafb5,DISK]]). The current failed datanode replacement policy is DEFAULT, and a client may configure this via 'dfs.client.block.write.replace-datanode-on-failure.policy' in its configuration.
       at org.apache.hadoop.hdfs.DFSOutputStream$DataStreamer.findNewDatanode(DFSOutputStream.java:918)
       at org.apache.hadoop.hdfs.DFSOutputStream$DataStreamer.addDatanode2ExistingPipeline(DFSOutputStream.java:992)
       at org.apache.hadoop.hdfs.DFSOutputStream$DataStreamer.setupPipelineForAppendOrRecovery(DFSOutputStream.java:1160)
       at org.apache.hadoop.hdfs.DFSOutputStream$DataStreamer.processDatanodeError(DFSOutputStream.java:876)
       at org.apache.hadoop.hdfs.DFSOutputStream$DataStreamer.run(DFSOutputStream.java:402)

```
