### PR TITLE
[Rest Server] Add quotes for masked secrets field in protocol

### DIFF
--- a/src/rest-server/src/util/protocolSecret.js
+++ b/src/rest-server/src/util/protocolSecret.js
@@ -18,7 +18,7 @@
 
 const mask = (protocolYAML) => {
   let maskYAML = protocolYAML + '\nZ';
-  maskYAML = maskYAML.replace(/(^secrets:)[^]*?(^\w)/m, '$1 ******\n$2');
+  maskYAML = maskYAML.replace(/(^secrets:)[^]*?(^\w)/m, '$1 "******"\n$2');
   maskYAML = maskYAML.slice(0, -2);
   return maskYAML;
 };

--- a/src/rest-server/test/protocolSecret.js
+++ b/src/rest-server/test/protocolSecret.js
@@ -91,7 +91,7 @@ name: secret_example
 type: job
 version: !!str 1.0
 contributor: OpenPAI
-secrets: ******
+secrets: "******"
 prerequisites:
   - protocolVersion: 2
     name: secret_example
@@ -142,7 +142,7 @@ taskRoles:
       gpu: 1
     commands:
       - exit
-secrets: ******
+secrets: "******"
   `,
 };
 


### PR DESCRIPTION
Add quotes for masked secrets field in protocol to avoid "unidentified alias" exception in getting v1 config.