### PR TITLE
Trap SIGTERM in entrypoint to avoid yarn container early stop

### DIFF
--- a/src/rest-server/src/models/job.js
+++ b/src/rest-server/src/models/job.js
@@ -631,7 +631,7 @@ class Job {
         'taskNumber': data.taskRoles[i].taskNumber,
         'taskService': {
           'version': 0,
-          'entryPoint': `bash YarnContainerScripts/${i}.sh`,
+          'entryPoint': `trap \\"\\" TERM; bash YarnContainerScripts/${i}.sh`,
           'sourceLocations': [`/Container/${data.userName}/${data.jobName}/YarnContainerScripts`],
           'resource': {
             'cpuNumber': data.taskRoles[i].cpuNumber,


### PR DESCRIPTION
fix #2910 