### PR TITLE
add pod_name to task related resource usage metrics

### DIFF
--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -101,7 +101,8 @@ class ResourceGauges(object):
                 "username",
                 "job_name",
                 "role_name",
-                "task_index"
+                "task_index",
+                "pod_name",
                 ]
         self.service_labels = ["name"]
 
@@ -510,6 +511,7 @@ class ContainerCollector(Collector):
         result_labels["job_name"] = inspect_info.job_name or "unknown"
         result_labels["role_name"] = inspect_info.role_name or "unknown"
         result_labels["task_index"] = inspect_info.task_index or "unknown"
+        result_labels["pod_name"] = inspect_info.pod_name or "unknown"
 
         if inspect_info.gpu_ids:
             ids = inspect_info.gpu_ids.replace("\"", "").split(",")

--- a/src/job-exporter/src/docker_inspect.py
+++ b/src/job-exporter/src/docker_inspect.py
@@ -27,29 +27,32 @@ logger = logging.getLogger(__name__)
 
 class InspectResult(object):
     """ Represents a task meta data, parsed from docker inspect result """
-    def __init__(self, username, job_name, role_name, task_index, gpu_ids, pid):
+    def __init__(self, username, job_name, role_name, task_index, pod_name,
+            gpu_ids, pid):
         self.username = username
         self.job_name = job_name
         self.role_name = role_name
         self.task_index = task_index
+        self.pod_name = pod_name
         self.gpu_ids = gpu_ids # comma seperated str, str may be minor_number or UUID
         self.pid = pid
 
     def __repr__(self):
-        return "username %s, job_name %s, role_name %s, task_index %s, gpu_ids %s, pid %s" % \
-                (self.username, self.job_name, self.role_name, self.task_index, self.gpu_ids, self.pid)
+        return "username %s, job_name %s, role_name %s, task_index %s, pod_name %s, gpu_ids %s, pid %s" % \
+                (self.username, self.job_name, self.role_name, self.task_index, self.pod_name, self.gpu_ids, self.pid)
 
     def __eq__(self, o):
         return self.username == o.username and \
                 self.job_name == o.job_name and \
                 self.role_name == o.role_name and \
                 self.task_index == o.task_index and \
+                self.pod_name == o.pod_name and \
                 self.gpu_ids == o.gpu_ids and \
                 self.pid == o.pid
 
 
 keys = {"PAI_JOB_NAME", "PAI_USER_NAME", "PAI_CURRENT_TASK_ROLE_NAME", "GPU_ID",
-        "PAI_TASK_INDEX", "DLWS_JOB_ID", "DLWS_USER_NAME"}
+        "PAI_TASK_INDEX", "DLWS_JOB_ID", "DLWS_USER_NAME", "POD_NAME"}
 
 
 def parse_docker_inspect(inspect_output):
@@ -83,6 +86,7 @@ def parse_docker_inspect(inspect_output):
             m.get("PAI_JOB_NAME") or m.get("DLWS_JOB_ID"),
             m.get("PAI_CURRENT_TASK_ROLE_NAME"),
             m.get("PAI_TASK_INDEX"),
+            m.get("POD_NAME") or m.get("PAI_JOB_NAME"),
             m.get("GPU_ID"),
             pid)
 

--- a/src/job-exporter/test/test_collector.py
+++ b/src/job-exporter/test/test_collector.py
@@ -45,6 +45,7 @@ class TestContainerCollector(base.TestBase):
                 "trialslot_nnimain_d65bc5ac",
                 "tuner",
                 "0",
+                "this_is_pod_name_val",
                 "0,1,",
                 12345)
 
@@ -55,7 +56,8 @@ class TestContainerCollector(base.TestBase):
                 "username": "openmindstudio",
                 "job_name": "trialslot_nnimain_d65bc5ac",
                 "role_name": "tuner",
-                "task_index": "0"}
+                "task_index": "0",
+                "pod_name": "this_is_pod_name_val"}
 
         self.assertEqual(target_labels, labels)
 

--- a/src/job-exporter/test/test_docker_inspect.py
+++ b/src/job-exporter/test/test_docker_inspect.py
@@ -41,6 +41,7 @@ class TestDockerInspect(base.TestBase):
                 "trialslot_nnimain_d65bc5ac",
                 "tuner",
                 "0",
+                "trialslot_nnimain_d65bc5ac",
                 "0,1,",
                 95539)
 
@@ -57,6 +58,7 @@ class TestDockerInspect(base.TestBase):
                 "core~tensorflowcifar10",
                 "worker",
                 "0",
+                "core~tensorflowcifar10",
                 "GPU-dc0671b0-61a4-443e-f456-f8fa6359b788",
                 23774)
         self.assertEqual(target_inspect_info, inspect_info)
@@ -72,6 +74,7 @@ class TestDockerInspect(base.TestBase):
                 "sokoya~train-exp_offrl_sc_discard_0231-10th-beta07-lrfixed_13e9bf5_gCYv",
                 "train",
                 "0",
+                "sokoya~train-exp_offrl_sc_discard_0231-10th-beta07-lrfixed_13e9bf5_gCYv",
                 "3,2,1,0",
                 30332)
         self.assertEqual(target_inspect_info, inspect_info)
@@ -87,6 +90,7 @@ class TestDockerInspect(base.TestBase):
                 "0c435eee-d31f-43d5-a1b3-442845fa1d0c",
                 None,
                 None,
+                "0c435eee-d31f-43d5-a1b3-442845fa1d0c",
                 "GPU-7c583998-b3ff-a885-8979-2d32d334cde4",
                 3533)
         self.assertEqual(target_inspect_info, inspect_info)


### PR DESCRIPTION
Distributed job's resource usage requires pod_name to exist.