### PR TITLE
[Rest Server] Support framework controller

### DIFF
--- a/src/rest-server/src/config/launcher.js
+++ b/src/rest-server/src/config/launcher.js
@@ -97,6 +97,9 @@ const k8sLauncherConfigSchema = Joi.object().keys({
   runtimeImage: Joi.string()
     .required(),
   requestHeaders: Joi.object(),
+  healthCheckPath: Joi.func()
+    .arity(0)
+    .required(),
   frameworksPath: Joi.func()
     .arity(0)
     .required(),
@@ -174,6 +177,9 @@ if (launcherType === 'yarn') {
     requestHeaders: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
+    },
+    healthCheckPath: () => {
+      return `${launcherConfig.apiServerUri}/apis/${launcherConfig.apiVersion}`;
     },
     frameworksPath: (namespace='default') => {
       return `${launcherConfig.apiServerUri}/apis/${launcherConfig.apiVersion}/namespaces/${namespace}/frameworks`;

--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -24,6 +24,11 @@ const job = require('@pai/models/v2/job');
 const createError = require('@pai/utils/error');
 
 
+const get = asyncHandler(async (req, res) => {
+  const data = await job.get(req.params.frameworkName);
+  res.json(data);
+});
+
 const update = asyncHandler(async (req, res) => {
   const jobName = res.locals.protocol.name;
   const userName = req.user.username;
@@ -63,6 +68,7 @@ const getConfig = asyncHandler(async (req, res) => {
 
 // module exports
 module.exports = {
+  get,
   update,
   getConfig,
 };

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -16,12 +16,198 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+// module dependencies
+const axios = require('axios');
+const status = require('statuses');
+const launcherConfig = require('@pai/config/launcher');
+const createError = require('@pai/utils/error');
+
+
+const generateTaskRole = (taskRole, config) => {
+  const frameworkTaskRole = {
+    name: taskRole,
+    taskNumber: config.taskRoles[taskRole].instances || 1,
+    task: {
+      retryPolicy: {
+        fancyRetryPolicy: true,
+        maxRetryCount: 0,
+      },
+      pod: {
+        metadata: {
+          labels: {
+            type: 'kube-launcher-task',
+          },
+          annotations: {
+            'container.apparmor.security.beta.kubernetes.io/main': 'unconfined',
+          },
+        },
+        spec: {
+          restartPolicy: 'Never',
+          serviceAccountName: 'frameworkbarrier',
+          initContainers: [
+            {
+              name: 'init',
+              imagePullPolicy: 'Always',
+              image: launcherConfig.runtimeImage,
+              env: [
+                {
+                  name: 'USER_CMD',
+                  value: config.taskRoles[taskRole].entrypoint,
+                },
+                {
+                  name: 'KUBE_APISERVER_ADDRESS',
+                  value: launcherConfig.apiServerUri,
+                },
+              ],
+              volumeMounts: [
+                {
+                  name: 'pai-vol',
+                  mountPath: '/usr/local/pai',
+                },
+                {
+                  name: 'host-log',
+                  mountPath: '/usr/local/pai/logs',
+                },
+              ],
+            },
+          ],
+          containers: [
+            {
+              name: 'main',
+              image: config.prerequisites.dockerimage[config.taskRoles[taskRole].dockerImage].uri,
+              command: ['/usr/local/pai/run'],
+              resources: {
+                limits: {
+                  cpu: config.taskRoles[taskRole].resourcePerInstance.cpu,
+                  memory: `${config.taskRoles[taskRole].resourcePerInstance.memoryMB}Mi`,
+                  'nvidia.com/gpu': config.taskRoles[taskRole].resourcePerInstance.gpu,
+                },
+              },
+              securityContext: {
+                capabilities: {
+                  add: ['SYS_ADMIN', 'DAC_READ_SEARCH', 'DAC_OVERRIDE'],
+                },
+              },
+              volumeMounts: [
+                {
+                  name: 'pai-vol',
+                  mountPath: '/usr/local/pai',
+                },
+                {
+                  name: 'host-log',
+                  mountPath: '/usr/local/pai/logs',
+                },
+              ],
+            }
+          ],
+          volumes: [
+            {
+              name: 'pai-vol',
+              emptyDir: {},
+            },
+            {
+              name: 'host-log',
+              hostPath: {
+                path: `/var/log/pai/job/${taskRole}`,
+              },
+            },
+          ],
+          hostNetwork: true,
+        },
+      },
+    },
+  };
+  // fill in completion policy
+  if ('completion' in config.taskRoles[taskRole]) {
+    frameworkTaskRole.frameworkAttemptCompletionPolicy = {
+      minFailedTaskCount: ('minFailedInstances' in config.taskRoles[taskRole].completion) ?
+        config.taskRoles[taskRole].completion.minFailedInstances : 1,
+      minSucceededTaskCount: ('minSucceededInstances' in config.taskRoles[taskRole].completion) ?
+        config.taskRoles[taskRole].completion.minSucceededInstances : -1,
+    };
+  } else {
+    frameworkTaskRole.frameworkAttemptCompletionPolicy = {
+      minFailedTaskCount: 1,
+      minSucceededTaskCount: -1,
+    };
+  }
+  return frameworkTaskRole;
+};
+
+const generateFrameworkDescription = (frameworkName, config) => {
+  const frameworkDescription = {
+    apiVersion: launcherConfig.apiVersion,
+    kind: 'Framework',
+    metadata: {
+      name: frameworkName,
+    },
+    spec: {
+      executionType: 'Start',
+      retryPolicy: {
+        fancyRetryPolicy: (config.jobRetryCount !== -2),
+        maxRetryCount: config.jobRetryCount || 0,
+      },
+      taskRoles: [],
+    },
+  };
+  // fill in task roles
+  for (let taskRole of Object.keys(config.taskRoles)) {
+    frameworkDescription.spec.taskRoles.push(generateTaskRole(taskRole, config));
+  }
+  return frameworkDescription;
+};
+
 const get = async (frameworkName) => {
-  return null;
+  const name = frameworkName.replace(/[-_\~]/g, '');
+  // send request to framework controller
+  let response;
+  try {
+    response = await axios({
+      method: 'get',
+      url: launcherConfig.frameworkPath(name),
+      headers: launcherConfig.requestHeaders,
+    });
+  } catch (error) {
+    if (error.response != null) {
+      response = error.response;
+    } else {
+      throw error;
+    }
+  }
+
+  if (response.status === status('OK')) {
+    return response.data;
+  }
+  if (response.status === status('Not Found')) {
+    throw createError('Not Found', 'NoJobError', `Job ${frameworkName} is not found.`);
+  } else {
+    throw createError(response.status, 'UnknownError', response.data.message);
+  }
 };
 
 const put = async (frameworkName, config, rawConfig) => {
-  return null;
+  const name = frameworkName.replace(/[-_\~]/g, '');
+  const frameworkDescription = generateFrameworkDescription(name, config);
+
+  // send request to framework controller
+  let response;
+  try {
+    response = await axios({
+      method: 'post',
+      url: launcherConfig.frameworksPath(),
+      headers: launcherConfig.requestHeaders,
+      data: frameworkDescription,
+    });
+  } catch (error) {
+    if (error.response != null) {
+      response = error.response;
+    } else {
+      throw error;
+    }
+  }
+  if (response.status !== status('Created')) {
+    throw createError(response.status, 'UnknownError', response.data.message);
+  }
 };
 
 const getConfig = (frameworkName) => {

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -46,6 +46,7 @@ const generateTaskRole = (taskRole, config) => {
           },
         },
         spec: {
+          privileged: false,
           restartPolicy: 'Never',
           serviceAccountName: 'frameworkbarrier',
           initContainers: [
@@ -89,7 +90,8 @@ const generateTaskRole = (taskRole, config) => {
               },
               securityContext: {
                 capabilities: {
-                  add: ['SYS_ADMIN', 'DAC_READ_SEARCH', 'DAC_OVERRIDE'],
+                  add: ['SYS_ADMIN', 'IPC_LOCK', 'DAC_READ_SEARCH'],
+                  drop: ['MKNOD'],
                 },
               },
               volumeMounts: [

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -78,8 +78,8 @@ const generateTaskRole = (taskRole, config) => {
               command: ['/usr/local/pai/run'],
               resources: {
                 limits: {
-                  cpu: config.taskRoles[taskRole].resourcePerInstance.cpu,
-                  memory: `${config.taskRoles[taskRole].resourcePerInstance.memoryMB}Mi`,
+                  'cpu': config.taskRoles[taskRole].resourcePerInstance.cpu,
+                  'memory': `${config.taskRoles[taskRole].resourcePerInstance.memoryMB}Mi`,
                   'nvidia.com/gpu': config.taskRoles[taskRole].resourcePerInstance.gpu,
                 },
               },
@@ -98,7 +98,7 @@ const generateTaskRole = (taskRole, config) => {
                   mountPath: '/usr/local/pai/logs',
                 },
               ],
-            }
+            },
           ],
           volumes: [
             {
@@ -158,7 +158,7 @@ const generateFrameworkDescription = (frameworkName, config) => {
 };
 
 const get = async (frameworkName) => {
-  const name = frameworkName.replace(/[-_\~]/g, '');
+  const name = frameworkName.replace(/[-_~]/g, '');
   // send request to framework controller
   let response;
   try {
@@ -186,7 +186,7 @@ const get = async (frameworkName) => {
 };
 
 const put = async (frameworkName, config, rawConfig) => {
-  const name = frameworkName.replace(/[-_\~]/g, '');
+  const name = frameworkName.replace(/[-_~]/g, '');
   const frameworkDescription = generateFrameworkDescription(name, config);
 
   // send request to framework controller

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -23,9 +23,13 @@ const launcherConfig = require('@pai/config/launcher');
 const createError = require('@pai/utils/error');
 
 
+const convertName = (name) => {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+};
+
 const generateTaskRole = (taskRole, config) => {
   const frameworkTaskRole = {
-    name: taskRole,
+    name: convertName(taskRole),
     taskNumber: config.taskRoles[taskRole].instances || 1,
     task: {
       retryPolicy: {
@@ -158,7 +162,7 @@ const generateFrameworkDescription = (frameworkName, config) => {
 };
 
 const get = async (frameworkName) => {
-  const name = frameworkName.replace(/[-_~]/g, '');
+  const name = convertName(frameworkName);
   // send request to framework controller
   let response;
   try {
@@ -186,7 +190,7 @@ const get = async (frameworkName) => {
 };
 
 const put = async (frameworkName, config, rawConfig) => {
-  const name = frameworkName.replace(/[-_~]/g, '');
+  const name = convertName(frameworkName);
   const frameworkDescription = generateFrameworkDescription(name, config);
 
   // send request to framework controller

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -33,6 +33,10 @@ router.route('/')
     controller.update
   );
 
+router.route('/:frameworkName')
+  /** GET /api/v2/jobs/:frameworkName - Get job */
+  .get(controller.get);
+
 router.route('/:frameworkName/config')
   /** GET /api/v2/jobs/:frameworkName/config - Get job config */
   .get(controller.getConfig);


### PR DESCRIPTION
Part of #2933, moved from #2979.

Support framework controller in rest server, migrate api v2:
* POST /api/v2/jobs
* GET /api/v2/jobs