### PR TITLE
ignore network based file systems in node-exporter

### DIFF
--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -78,6 +78,8 @@ spec:
           - '--no-collector.wifi'
           - '--no-collector.xfs'
           - '--no-collector.zfs'
+          - '--collector.filesystem.ignored-fs-types'
+          - 'autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|tmpfs|cifs|nfs4?|lxcfs'
         ports:
         - containerPort: {{ cluster_cfg["node-exporter"]["port"] }}
           hostPort: {{ cluster_cfg["node-exporter"]["port"] }}

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -79,7 +79,7 @@ spec:
           - '--no-collector.xfs'
           - '--no-collector.zfs'
           - '--collector.filesystem.ignored-fs-types'
-          - 'autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|tmpfs|cifs|nfs4?|lxcfs'
+          - '^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|tmpfs|cifs|nfs4?|fuse.lxcfs)$'
         ports:
         - containerPort: {{ cluster_cfg["node-exporter"]["port"] }}
           hostPort: {{ cluster_cfg["node-exporter"]["port"] }}

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -79,7 +79,7 @@ spec:
           - '--no-collector.xfs'
           - '--no-collector.zfs'
           - '--collector.filesystem.ignored-fs-types'
-          - '^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|tmpfs|cifs|nfs4?|fuse.lxcfs)$'
+          - '^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|tmpfs|cifs|nfs4?|fuse\.lxcfs)$'
         ports:
         - containerPort: {{ cluster_cfg["node-exporter"]["port"] }}
           hostPort: {{ cluster_cfg["node-exporter"]["port"] }}


### PR DESCRIPTION
related to #2117 , ignore those network based filesystems in node-exporter. So the source down will not affect node-exporter.

We append `cifs|nfs4?|lxcfs` to the [`defIgnoredFSTypes`](https://github.com/prometheus/node_exporter/blob/v0.18.0/collector/filesystem_linux.go#L33).