### PR TITLE
[hadoop-ai] port conflict

### DIFF
--- a/src/hadoop-ai/build/build-pre.sh
+++ b/src/hadoop-ai/build/build-pre.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0") > /dev/null
 hadoopBinaryDir="/hadoop-binary"
 
 # When changing the patch id, please update it.
-patchId="12940533-12933562-docker_executor-12944563-fix1-20190426"
+patchId="12940533-12933562-docker_executor-12944563-fix1-20190627"
 
 hadoopBinaryPath="${hadoopBinaryDir}/hadoop-2.9.0.tar.gz"
 cacheVersion="${hadoopBinaryDir}/${patchId}-done"

--- a/src/hadoop-ai/build/build.sh
+++ b/src/hadoop-ai/build/build.sh
@@ -36,6 +36,7 @@ git apply /docker-executor.patch
 git apply /YARN-8896-2.9.0.patch
 git apply /hadoop-ai-fix.patch
 git apply /hadoop-2.9.0-fix.patch
+git apply /hadoop-ai-port-conflict.patch
 
 mvn package -Pdist,native -DskipTests -Dmaven.javadoc.skip=true -Dtar
 

--- a/src/hadoop-ai/build/hadoop-ai
+++ b/src/hadoop-ai/build/hadoop-ai
@@ -73,13 +73,7 @@ RUN wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.
 ## The build environment of hadoop has been prepared above.
 ## Copy your build script here. Default script will build our hadoop-ai.
 
-COPY docker-executor.patch /
-
-COPY hadoop-ai-fix.patch /
-
-COPY YARN-8896-2.9.0.patch /
-
-COPY hadoop-2.9.0-fix.patch /
+COPY *.patch /
 
 COPY build.sh /
 

--- a/src/hadoop-ai/build/hadoop-ai-port-conflict.patch
+++ b/src/hadoop-ai/build/hadoop-ai-port-conflict.patch
@@ -1,0 +1,32 @@
+diff --git a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+index 60443f4..fa30cca 100644
+--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
++++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+@@ -174,6 +174,7 @@
+ import org.apache.hadoop.yarn.util.Clock;
+ import org.apache.hadoop.yarn.util.Records;
+ import org.apache.hadoop.yarn.util.UTCClock;
++import org.apache.hadoop.yarn.util.resource.Resources;
+ import org.apache.hadoop.yarn.util.timeline.TimelineUtils;
+ 
+ import com.google.common.annotations.VisibleForTesting;
+@@ -1028,12 +1029,17 @@ private NodeReport createNodeReports(RMNode rmNode) {
+     if (schedulerNodeReport != null) {
+       used = schedulerNodeReport.getUsedResource();
+       numContainers = schedulerNodeReport.getNumContainers();
+-    } 
++    }
++
++    Resource total = Resources.clone(rmNode.getTotalCapability());
++    if (total.getPorts() != null) {
++      total.setPorts(total.getPorts().minusSelf(rmNode.getLocalUsedPortsSnapshot()));
++    }
+ 
+     NodeReport report =
+         BuilderUtils.newNodeReport(rmNode.getNodeID(), rmNode.getState(),
+             rmNode.getHttpAddress(), rmNode.getRackName(), used,
+-            rmNode.getTotalCapability(), numContainers,
++            total, numContainers,
+             rmNode.getHealthReport(), rmNode.getLastHealthReportTime(),
+             rmNode.getNodeLabels(), rmNode.getAggregatedContainersUtilization(),
+             rmNode.getNodeUtilization());


### PR DESCRIPTION
Fix #1983 
patch at https://github.com/mzmssg/hadoop/pull/5/files
Cause:
RM doesn't exclude localused port in nodeReport

