### PR TITLE
[paictl] Unify cluster ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,13 +159,13 @@ sleep 6s
 
 # Step 3. Upload cluster-configuration into kubernetes cluster. And set cluster-id
 ./paictl.py config push -p /cluster-configuration << EOF
-openpai-test
+pai
 EOF
 
 # Step 4. Start all PAI services
 # start pai services
 ./paictl.py service start << EOF
-openpai-test
+pai
 EOF
 EOF_DEV_BOX
 sudo chown core:core -R $JENKINS_HOME
@@ -249,13 +249,13 @@ sleep 6s
 
 # Step 3. Upload cluster configuration into kubernetes cluster. And set cluster-id
 ./paictl.py config push -p /cluster-configuration << EOF
-openpai-test
+pai
 EOF
 
 # Step 4. Start all PAI services
 # start pai services
 ./paictl.py service start << EOF
-openpai-test
+pai
 EOF
 EOF_DEV_BOX
 sudo chown core:core -R $JENKINS_HOME
@@ -524,12 +524,12 @@ cd /pai
 
 # delete service for next install
 ./paictl.py service start -n cluster-configuration << EOF
-openpai-test
+pai
 EOF
 
 ./paictl.py service delete << EOF
 Y
-openpai-test
+pai
 EOF
 
 # clean k8s
@@ -558,12 +558,12 @@ cd /pai
 
 # delete service for next install
 ./paictl.py service start -n cluster-configuration << EOF
-openpai-test
+pai
 EOF
 
 ./paictl.py service delete << EOF
 Y
-openpai-test
+pai
 EOF
 
 # clean k8s

--- a/deployment/confStorage/conf_storage_util.py
+++ b/deployment/confStorage/conf_storage_util.py
@@ -61,6 +61,14 @@ def read_file_from_path(file_path):
     return file_data
 
 
+def load_yaml_config(config_path):
+
+    with open(config_path, "r") as f:
+        cluster_data = yaml.load(f)
+
+    return cluster_data
+
+
 def write_generated_file(generated_file, file_path):
 
     with open(file_path, "w+") as fout:

--- a/deployment/confStorage/conf_storage_util.py
+++ b/deployment/confStorage/conf_storage_util.py
@@ -24,6 +24,7 @@ import time
 import errno
 import logging
 import logging.config
+import yaml
 
 from pprint import pprint
 

--- a/deployment/confStorage/upload.py
+++ b/deployment/confStorage/upload.py
@@ -56,8 +56,8 @@ class upload_configuration:
         cluster_id = conf_storage_util.get_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION)
 
         if cluster_id is None:
-            self.logger.warning("No cluster_id found in your cluster.")
-            self.logger.warning("cluster_id [ {0} ] in configuration will be updated into your cluster.".format(cluster_id_in_config))
+            self.logger.warning("No cluster-id found in your cluster.")
+            self.logger.warning("cluster-id [ {0} ] in configuration will be updated into your cluster.".format(cluster_id_in_config))
             if cluster_id_in_config == 'pai':
                 self.logger.warning("cluster_id [ pai ] is the default ID in configuration.")
                 self.logger.warning("Because no cluster-id found in your configuration, it [pai] will be used.")

--- a/deployment/confStorage/upload.py
+++ b/deployment/confStorage/upload.py
@@ -62,8 +62,9 @@ class upload_configuration:
                 self.logger.warning("cluster_id [ pai ] is the default ID in configuration.")
                 self.logger.warning("Because no cluster-id found in your configuration, it [pai] will be used.")
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
-            self.logger.warning("Waiting 10s to update cluster-id.")
-            time.sleep(10)
+            self.logger.warning("Waiting 5s to update cluster-id.")
+            time.sleep(5)
+            cluster_id = cluster_id_in_config
 
         user_input = raw_input("Please input the cluster-id which you wanna operate: ")
         if user_input != cluster_id:
@@ -75,8 +76,8 @@ class upload_configuration:
             self.logger.warning("The old one will be overwrote!")
             self.logger.warning("The new one is [ {0} ]!".format(cluster_id_in_config))
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
-            self.logger.warning("Waiting 10s to update cluster-id.")
-            time.sleep(10)
+            self.logger.warning("Waiting 5s to update cluster-id.")
+            time.sleep(5)
 
         self.logger.info("Congratulations: Cluster-id checking passed.")
         return True

--- a/deployment/confStorage/upload.py
+++ b/deployment/confStorage/upload.py
@@ -62,8 +62,8 @@ class upload_configuration:
                 self.logger.warning("cluster_id [ pai ] is the default ID in configuration.")
                 self.logger.warning("Because no cluster-id found in your configuration, it [pai] will be used.")
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
-            time.sleep(10)
             self.logger.warning("Waiting 10s to update cluster-id.")
+            time.sleep(10)
 
         user_input = raw_input("Please input the cluster-id which you wanna operate: ")
         if user_input != cluster_id:
@@ -75,8 +75,8 @@ class upload_configuration:
             self.logger.warning("The old one will be overwrote!")
             self.logger.warning("The new one is [ {0} ]!".format(cluster_id_in_config))
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
-            time.sleep(10)
             self.logger.warning("Waiting 10s to update cluster-id.")
+            time.sleep(10)
 
         self.logger.info("Congratulations: Cluster-id checking passed.")
         return True

--- a/deployment/confStorage/upload.py
+++ b/deployment/confStorage/upload.py
@@ -25,6 +25,7 @@ import argparse
 import readline
 import logging
 import logging.config
+import time
 
 from . import conf_storage_util
 from ..paiLibrary.common import file_handler, directory_handler
@@ -61,6 +62,8 @@ class upload_configuration:
                 self.logger.warning("cluster_id [ pai ] is the default ID in configuration.")
                 self.logger.warning("Because no cluster-id found in your configuration, it [pai] will be used.")
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
+            time.sleep(10)
+            self.logger.warning("Waiting 10s to update cluster-id.")
 
         user_input = raw_input("Please input the cluster-id which you wanna operate: ")
         if user_input != cluster_id:
@@ -72,6 +75,8 @@ class upload_configuration:
             self.logger.warning("The old one will be overwrote!")
             self.logger.warning("The new one is [ {0} ]!".format(cluster_id_in_config))
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
+            time.sleep(10)
+            self.logger.warning("Waiting 10s to update cluster-id.")
 
         self.logger.info("Congratulations: Cluster-id checking passed.")
         return True

--- a/deployment/confStorage/upload.py
+++ b/deployment/confStorage/upload.py
@@ -70,6 +70,7 @@ class upload_configuration:
         if cluster_id != cluster_id_in_config:
             self.logger.warning("Cluster ID's update is detected from your service-configuration!")
             self.logger.warning("The old one will be overwrote!")
+            self.logger.warning("The new one is [ {0} ]!".format(cluster_id_in_config))
             conf_storage_util.update_cluster_id(self.KUBE_CONFIG_DEFAULT_LOCATION, cluster_id_in_config)
 
         self.logger.info("Congratulations: Cluster-id checking passed.")


### PR DESCRIPTION
After this change

1. New cluster's id will be got from service-configuration.yaml->cluster->common
2. The default cluster-id will be 'pai'
3. If admin update the cluster-id in service-configuration.yaml, and then push the latest configuration into k8s. Paictl will detect it, and update the id in cluster.

