### PR TITLE
Fix the issue of failed to install the kubectl on single box.

### DIFF
--- a/deployment/k8sPaiLibrary/maintaintool/kubectl-install.sh
+++ b/deployment/k8sPaiLibrary/maintaintool/kubectl-install.sh
@@ -37,4 +37,4 @@ pathofusllocalbin="/usr/local/bin"
     mkdir -p /usr/local/bin
 }
 
-mv ./kubectl /usr/local/bin/kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
When I deployed the OpenPAI in a single box, I faced a permission denied problem. And it releases the error "deployment.k8sPaiLibrary.maintainlib.common : Failed to install kubectl on your dev-box".
After I checked the file kubectl-install.sh, I found that in line 40 the request mv does not combine with sudo. Therefore, it does not have permission when deploying kubernetes cluster with OpenPAI.
After I add sudo to "mv ./kubectl /usr/local/bin/kubectl", this problem solved.