### PR TITLE
fix deployment field missing bug

### DIFF
--- a/src/webportal/src/app/job-submission/models/job-protocol.js
+++ b/src/webportal/src/app/job-submission/models/job-protocol.js
@@ -112,7 +112,7 @@ export class JobProtocol {
       res[secret.key] = secret.value;
       return res;
     }, {}));
-    const defaultsField = removeEmptyProperties(jobBasicInfo.getDefaults());
+    const defaultsField = {...this.defaults, ...removeEmptyProperties(jobBasicInfo.getDefaults())};
 
     return new JobProtocol({
       ...this,


### PR DESCRIPTION
When clone a job with deployment field. In new submission page, the origin deployment info will be cleaned. Fix this issue.