### PR TITLE
match commented out sshd port

### DIFF
--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -137,7 +137,7 @@ function start_ssh_service()
   printf "%s %s\n" \
     "[INFO]" "start ssh service"
   cat /root/.ssh/{{ jobData.jobName }}.pub >> /root/.ssh/authorized_keys
-  sed -i 's/.Port.*/Port '$PAI_CONTAINER_SSH_PORT'/' /etc/ssh/sshd_config
+  sed -i 's/[# ]*Port.*/Port '$PAI_CONTAINER_SSH_PORT'/' /etc/ssh/sshd_config
   echo "sshd:ALL" >> /etc/hosts.allow
   service ssh restart
 }

--- a/src/rest-server/src/templates/dockerContainerScript.mustache
+++ b/src/rest-server/src/templates/dockerContainerScript.mustache
@@ -137,7 +137,7 @@ function start_ssh_service()
   printf "%s %s\n" \
     "[INFO]" "start ssh service"
   cat /root/.ssh/{{ jobData.jobName }}.pub >> /root/.ssh/authorized_keys
-  sed -i 's/Port.*/Port '$PAI_CONTAINER_SSH_PORT'/' /etc/ssh/sshd_config
+  sed -i 's/.Port.*/Port '$PAI_CONTAINER_SSH_PORT'/' /etc/ssh/sshd_config
   echo "sshd:ALL" >> /etc/hosts.allow
   service ssh restart
 }


### PR DESCRIPTION
In ubuntu18.04, the configuration of the default port of sshd service is commented out like "#Port 22".   Thus, sed -i 's/Port.*/Port '$PAI_CONTAINER_SSH_PORT'/' missed  ’#‘ and it cannot start sshd service on $PAI_CONTAINER_SSH_PORT.