### PR TITLE
[Rest Server] ignore get job config's accept header

### DIFF
--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -1399,7 +1399,7 @@ Status: 500
 ### `GET user/:username/jobs/:jobName/config`
 
 Get job config content.
-This API returns the original format (plain text) of submitted job config.
+This API returns the original format (text/plain) of submitted job config.
 
 *Request*
 

--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -1399,18 +1399,17 @@ Status: 500
 ### `GET user/:username/jobs/:jobName/config`
 
 Get job config content.
-This API returns the original format of submitted job config.
+This API returns the original format (plain text) of submitted job config.
 
 *Request*
 
 ```json
 GET /api/v1/user/:username/jobs/:jobName/config
-Accept: application/json | text/yaml (default: application/json)
 ```
 
 *Response if succeeded*
 
-```json
+```text
 Status: 200
 
 {
@@ -1980,28 +1979,17 @@ Status: 500
 ### `GET jobs/:frameworkName/config`
 
 Get job config content.
-This API always returns job config in v2 format. Old job config in v1 format will be converted automatically.
+This API always returns job config in v2 format (text/yaml). Old job config in v1 format will be converted automatically.
 
 *Request*
 
 ```json
 GET /api/v2/jobs/:frameworkName/config
-Accept: application/json | text/yaml (default: application/json)
 ```
 
 *Response if succeeded*
 
-```json
-Status: 200
-
-{
-  "jobName": "test",
-  "image": "pai.run.tensorflow",
-  ...
-}
-
-or
-
+```yaml
 jobName: test
 protocolVersion: 2
 ...

--- a/src/rest-server/package.json
+++ b/src/rest-server/package.json
@@ -64,12 +64,6 @@
   "_moduleAliases": {
     "@pai": "src"
   },
-  "_moduleAliases": {
-    "@pai": "src"
-  },
-  "_moduleAliases": {
-    "@pai": "src"
-  },
   "scripts": {
     "coveralls": "nyc report --reporter=text-lcov | coveralls ..",
     "lint": "eslint \"src/**/*.js\"",

--- a/src/rest-server/src/controllers/job.js
+++ b/src/rest-server/src/controllers/job.js
@@ -16,7 +16,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // module dependencies
-const yaml = require('js-yaml');
 const url = require('url');
 const Job = require('@pai/models/v1/job/yarn');
 const createError = require('@pai/utils/error');
@@ -197,14 +196,7 @@ const getConfig = (req, res, next) => {
     req.job.name,
     (error, result) => {
       if (!error) {
-        try {
-          const data = yaml.safeLoad(result);
-          const type = req.accepts(['json', 'yaml']) || 'json';
-          const body = type === 'json' ? JSON.stringify(data) : yaml.safeDump(data);
-          return res.status(200).type(type).send(body);
-        } catch (e) {
-          return next(createError.unknown(e));
-        }
+        return res.status(200).type('text/plain').send(result);
       } else if (error.message.startsWith('[WebHDFS] 404')) {
         return next(createError('Not Found', 'NoJobConfigError', `Config of job ${req.job.name} is not found.`));
       } else {

--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -17,7 +17,6 @@
 
 
 // module dependencies
-const yaml = require('js-yaml');
 const status = require('statuses');
 const asyncHandler = require('@pai/middlewares/v2/asyncHandler');
 const job = require('@pai/models/v2/job');
@@ -49,9 +48,7 @@ const update = asyncHandler(async (req, res) => {
 const getConfig = asyncHandler(async (req, res) => {
   try {
     const data = await job.getConfig(req.params.frameworkName);
-    const type = req.accepts(['json', 'yaml']) || 'json';
-    const body = type === 'json' ? JSON.stringify(data) : yaml.safeDump(data);
-    return res.status(200).type(type).send(body);
+    return res.status(200).type('text/yaml').send(data);
   } catch (error) {
     if (error.message.startsWith('[WebHDFS] 404')) {
       throw createError('Not Found', 'NoJobConfigError', `Config of job ${req.params.frameworkName} is not found.`);

--- a/src/rest-server/src/models/v2/job/yarn.js
+++ b/src/rest-server/src/models/v2/job/yarn.js
@@ -325,7 +325,7 @@ async function getConfig(frameworkName) {
   // try to get v2
   try {
     const res = await readFile(`/Container/${userName}/${frameworkName}/JobConfig.yaml`);
-    return yaml.safeLoad(res.content);
+    return res;
   } catch (e) {
     // pass
   }

--- a/src/rest-server/src/utils/converter.js
+++ b/src/rest-server/src/utils/converter.js
@@ -113,7 +113,7 @@ const protocolConvert = async (jobConfig, submission=false) => {
         registryuri: authCreds[0],
       };
     } else {
-      protocolObj.secrets = "******";
+      protocolObj.secrets = '******';
     }
   }
   if (jobConfig.jobEnvs) {

--- a/src/rest-server/test/jobConfig.js
+++ b/src/rest-server/test/jobConfig.js
@@ -118,8 +118,8 @@ describe('Get job config: GET /api/v2/user/:username/jobs/:jobName/config', () =
       .get('/api/v2/user/test/jobs/job1/config')
       .end((err, res) => {
         expect(res, 'status code').to.have.status(200);
-        expect(res, 'response format').be.json;
-        expect(JSON.stringify(res.body), 'response body content').include('jobName');
+        expect(res, 'response format').be.text;
+        expect(res.text, 'response body content').include('jobName');
         done();
       });
   });
@@ -272,8 +272,8 @@ describe('Get job config: GET /api/v1/jobs/:jobName/config', () => {
       .get('/api/v1/jobs/job1/config')
       .end((err, res) => {
         expect(res, 'status code').to.have.status(200);
-        expect(res, 'response format').be.json;
-        expect(JSON.stringify(res.body), 'response body content').include('jobName');
+        expect(res, 'response format').be.text;
+        expect(res.text, 'response body content').include('jobName');
         done();
       });
   });


### PR DESCRIPTION
BREAKING CHANGE !!!

- The rest server should treat job config file as plain text, so accept header feature should not be implemented
