### PR TITLE
add alert for gpu count changes

### DIFF
--- a/src/prometheus/deploy/alerting/gpu.rules
+++ b/src/prometheus/deploy/alerting/gpu.rules
@@ -56,3 +56,8 @@ groups:
         annotations:
           summary: "found nvidia used by zombie container in {{$labels.instance}}"
 
+      - alert: NodeGpuCountChanged
+        expr: changes(node:nvidiasmi_utilization_gpu:count[5m]) > 0
+        annotations:
+          summary: "found gpu count changes in {{$labels.instance}}"
+

--- a/src/prometheus/deploy/prometheus-configmap.yaml.template
+++ b/src/prometheus/deploy/prometheus-configmap.yaml.template
@@ -28,6 +28,7 @@ data:
     # Scrape config for cluster components.
     rule_files:
       - "/etc/prometheus-alert/*.rules"
+      - "/etc/prometheus-record/*.rules"
     scrape_configs:
     - job_name: 'pai_serivce_exporter'
       scrape_interval: {{ prom_info["scrape_interval"] }}s

--- a/src/prometheus/deploy/prometheus-deployment.yaml.template
+++ b/src/prometheus/deploy/prometheus-deployment.yaml.template
@@ -69,8 +69,10 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus
-        - name: rules-volume
+        - name: alert-rules-volume
           mountPath: /etc/prometheus-alert
+        - name: record-rules-volume
+          mountPath: /etc/prometheus-record
         - name: prometheus-data
           mountPath: /prometheus-data
       imagePullSecrets:
@@ -79,9 +81,12 @@ spec:
       - name: config-volume
         configMap:
           name: prometheus-configmap
-      - name: rules-volume
+      - name: alert-rules-volume
         configMap:
           name: prometheus-alert
+      - name: record-rules-volume
+        configMap:
+          name: prometheus-record
       - name: prometheus-data
         hostPath:
           path: {{ cluster_cfg["cluster"]["common"]["data-path"] }}/prometheus/data

--- a/src/prometheus/deploy/recording/gpu.rules
+++ b/src/prometheus/deploy/recording/gpu.rules
@@ -1,7 +1,3 @@
-#!/bin/bash
-
-#!/bin/bash
-
 # Copyright (c) Microsoft Corporation
 # All rights reserved.
 #
@@ -19,15 +15,10 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pushd $(dirname "$0") > /dev/null
+# Rule Syntax Reference: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
 
-kubectl create configmap prometheus-alert --from-file=alerting --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl create configmap prometheus-record --from-file=recording --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl apply --overwrite=true -f prometheus-configmap.yaml || exit $?
-kubectl apply --overwrite=true -f prometheus-deployment.yaml || exit $?
-
-sleep 10
-# Wait until the service is ready.
-PYTHONPATH="../../../deployment" python -m  k8sPaiLibrary.monitorTool.check_pod_ready_status -w -k app -v prometheus || exit $?
-
-popd > /dev/null
+groups:
+    - name: gpu_related
+      rules:
+      - record: node:nvidiasmi_utilization_gpu:count
+        expr: count(nvidiasmi_utilization_gpu) by (instance)


### PR DESCRIPTION
Add alert when node GPU count is changed. This may caused by driver issue.

Add a record rule to generate a new metric: `node:nvidiasmi_utilization_gpu:count`, which is calculated by: `count(nvidiasmi_utilization_gpu) by (instance)`

Add a new alert when `changes(node:nvidiasmi_utilization_gpu:count) > 0`