### PR TITLE
Update how-to-install-depdencey.md, replace the package realpath with coreutils.

### DIFF
--- a/docs/pai-management/doc/how-to-install-depdencey.md
+++ b/docs/pai-management/doc/how-to-install-depdencey.md
@@ -53,7 +53,7 @@ apt-get -y install \
       bash-completion \
       inotify-tools \
       rsync \
-      realpath \
+      coreutils \
       net-tools
 
 pip install python-etcd docker kubernetes GitPython


### PR DESCRIPTION
realpath is included by coreutils now, detail messages as following:

### install via apt
Package realpath is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

### install via dpkg
dpkg: error processing archive realpath_1.19_amd64.deb (--install):
 trying to overwrite '/usr/bin/realpath', which is also in package coreutils 8.28-1ubuntu1
Errors were encountered while processing:
 realpath_1.19_amd64.deb