### PR TITLE
Attach a commit ID for webportal

### DIFF
--- a/src/webportal/build/build-pre.sh
+++ b/src/webportal/build/build-pre.sh
@@ -22,5 +22,10 @@ pushd $(dirname "$0") > /dev/null
 mkdir -p "../dependency"
 cp -arf "../../../docs" "../../../examples" "../dependency"
 cp -arf "../../../version" "../version"
+if [ "$ATTACH_COMMIT_ID" = true ]; then
+    echo `git rev-parse HEAD | cut -c1-6` > ../version/COMMIT.VERSION
+else
+    echo "" > ../version/COMMIT.VERSION
+fi
 
 popd > /dev/null

--- a/src/webportal/build/webportal.dockerfile
+++ b/src/webportal/build/webportal.dockerfile
@@ -27,6 +27,8 @@ COPY . .
 
 RUN yarn --no-git-tag-version --new-version version \
     "$(cat version/PAI.VERSION)"
+RUN npm install json -g
+RUN json -I -f package.json -e "this.commitVersion=\"`cat version/COMMIT.VERSION`\""
 RUN yarn install
 RUN npm run build
 

--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -29,6 +29,7 @@ const helpers = require('./helpers');
 
 const title = 'Platform for AI';
 const version = require('../package.json').version;
+const commitVersion = require('../package.json').commitVersion;
 const FABRIC_DIR = [
   path.resolve(__dirname, '../src/app/job/job-view/fabric'),
   path.resolve(__dirname, '../src/app/home'),
@@ -40,6 +41,7 @@ function generateHtml(opt) {
   return new HtmlWebpackPlugin(Object.assign({
     title: title,
     version: version,
+    commitVersion: commitVersion,
     template: './src/app/layout/layout.component.ejs',
     minify: {
       collapseWhitespace: true,

--- a/src/webportal/src/app/layout/layout.component.ejs
+++ b/src/webportal/src/app/layout/layout.component.ejs
@@ -105,9 +105,17 @@
             %>]" target="_blank">
               <i class="fa fa-comments"></i>
               <span>Feedback</span>
+              <% if (htmlWebpackPlugin.options.commitVersion) { %>
+              <span class="pull-right-container" style="margin-top: -16px">
+                <small class="label pull-right bg-blue"><%= htmlWebpackPlugin.options.version %></small>
+                <br>
+                <small class="label pull-right bg-blue">webportal@<%= htmlWebpackPlugin.options.commitVersion %></small>
+              </span>
+              <% } else { %>
               <span class="pull-right-container">
                 <small class="label pull-right bg-blue"><%= htmlWebpackPlugin.options.version %></small>
               </span>
+              <% } %>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
If build with the following environmental variable, a commit ID will be attached to webportal.
```bash
ATTACH_COMMIT_ID=true ./build/pai_build.py build -c ~/pai-config/ -s webportal
```

It looks like:
![image](https://user-images.githubusercontent.com/7499023/62950500-b9f85e80-be1a-11e9-8a7c-cfaf716daf6b.png)
