### PR TITLE
Fix hadoop image name check

### DIFF
--- a/src/hadoop-ai/build/build-pre.sh
+++ b/src/hadoop-ai/build/build-pre.sh
@@ -22,7 +22,7 @@ pushd $(dirname "$0") > /dev/null
 hadoopBinaryDir="/hadoop-binary"
 
 # When changing the patch id, please update it.
-patchId="12940533-12933562-docker_executor-12944563-fix1-20190627"
+patchId="12940533-12933562-docker_executor-12944563-fix1-20190819"
 
 hadoopBinaryPath="${hadoopBinaryDir}/hadoop-2.9.0.tar.gz"
 cacheVersion="${hadoopBinaryDir}/${patchId}-done"

--- a/src/hadoop-ai/build/docker-executor.patch
+++ b/src/hadoop-ai/build/docker-executor.patch
@@ -26,7 +26,7 @@ index a044cb6..819c496 100644
    //containername
    public static final String DOCKER_IMAGE_PATTERN =
 -    "^(([\\w\\.-]+)(:\\d+)*\\/)?[\\w\\.:-]+$";
-+          "^(([a-zA-Z0-9.-]+)(:\d+)?/)?([a-z0-9_./-]+)(:[\w.-]+)?$";
++          "^(([a-zA-Z0-9.-]+)(:\\d+)?/)?([a-z0-9_./-]+)(:[\\w.-]+)?$";
 
    private final FileContext lfs;
    private final Pattern dockerImagePattern;

--- a/src/hadoop-ai/build/docker-executor.patch
+++ b/src/hadoop-ai/build/docker-executor.patch
@@ -5,7 +5,7 @@ index 96f6c57..1b89e90 100644
 @@ -1544,6 +1544,14 @@ public static boolean isAclEnabled(Configuration conf) {
    public static final String NM_DOCKER_CONTAINER_EXECUTOR_IMAGE_NAME =
      NM_PREFIX + "docker-container-executor.image-name";
- 
+
 +  /** The Docker run option(For DockerContainerExecutor).*/
 +  public static final String NM_DOCKER_CONTAINER_EXECUTOR_EXEC_OPTION =
 +          NM_PREFIX + "docker-container-executor.exec-option";
@@ -26,8 +26,8 @@ index a044cb6..819c496 100644
    //containername
    public static final String DOCKER_IMAGE_PATTERN =
 -    "^(([\\w\\.-]+)(:\\d+)*\\/)?[\\w\\.:-]+$";
-+          "^(([\\w\\.-]+)(:\\d+)*\\/)?([\\w\\.-]+\\/)?[\\w\\.:-]+$";
- 
++          "^(([a-zA-Z0-9.-]+)(:\d+)?/)?([a-z0-9_./-]+)(:[\w.-]+)?$";
+
    private final FileContext lfs;
    private final Pattern dockerImagePattern;
 @@ -127,7 +127,12 @@ public void init() throws IOException {
@@ -45,7 +45,7 @@ index a044cb6..819c496 100644
          "Invalid docker exec path: " + dockerExecutor);
      }
 @@ -181,8 +186,11 @@ public int launchContainer(ContainerStartContext ctx) throws IOException {
- 
+
      //Variables for the launch environment can be injected from the command-line
      //while submitting the application
 -    String containerImageName = container.getLaunchContext().getEnvironment()


### PR DESCRIPTION
Fix #3202 

Use the latest hadoop regex, reference https://github.com/apache/hadoop/blob/29465bf169a7e348a4f32265083450faf66d5631/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-nodemanager/src/main/java/org/apache/hadoop/yarn/server/nodemanager/containermanager/linux/runtime/DockerLinuxContainerRuntime.java#L205

Test:
```
Old pattern: ^(([\w\.-]+)(:\d+)*\/)?([\w\.-]+\/)?[\w\.:-]+$
[OK] Old pattern pass test string: registry.somecompany.com:9999/containername:0.1
[OK] Old pattern pass test string: containername:0.1
[OK] Old pattern pass test string: containername
[Fail] Old pattern fail test string: harbor.bglab.com/library/openpai/hadoop-run:v0.12.0

New pattern: ^(([a-zA-Z0-9.-]+)(:\d+)?/)?([a-z0-9_./-]+)(:[\w.-]+)?$
[OK] New pattern pass test string: registry.somecompany.com:9999/containername:0.1
[OK] New pattern pass test string: containername:0.1
[OK] New pattern pass test string: containername
[OK] New pattern pass test string: harbor.bglab.com/library/openpai/hadoop-run:v0.12.0
```