### PR TITLE
[Deployment] Remove deprecated flag for kubelet

### DIFF
--- a/deployment/k8sPaiLibrary/template/kubelet.sh.template
+++ b/deployment/k8sPaiLibrary/template/kubelet.sh.template
@@ -52,7 +52,6 @@ docker run \
     /hyperkube kubelet --fail-swap-on=false --address={{ hostcofig['hostip'] }} \
   --register-node=true \
   --kubeconfig=/etc/kubernetes/config \
-  --require-kubeconfig \
   --hostname-override={{ hostcofig['nodename'] }} \
   --cluster-dns={{ cluster_cfg['kubernetes']['cluster-dns'] }} \
   --cluster-domain=cluster.local  \


### PR DESCRIPTION
Remove deprecated `--require-kubeconfig` flag for kubelet.