### PR TITLE
[Webportal] Fix webpack conflict

### DIFF
--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -75,6 +75,7 @@ const config = (env, argv) => ({
   output: {
     path: helpers.root('dist'),
     filename: 'scripts/[name].bundle.js',
+    jsonpFunction: 'webportalWebpackJsonp',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.json'],


### PR DESCRIPTION
Resolve webpack chunks runtime conflicts between webportal and plugins,
use another `jsonpFunction` name for webportal.

Issue left in #3244.

Reference: https://webpack.js.org/configuration/output/#outputjsonpfunction