### PR TITLE
PaiJobsZombie do not have minor_number

### DIFF
--- a/src/tools/reports.py
+++ b/src/tools/reports.py
@@ -191,7 +191,6 @@ class Alert(object):
             "NvidiaMemoryLeak": lambda a: a["minor_number"],
             "GpuUsedByExternalProcess": lambda a: a["minor_number"],
             "GpuUsedByZombieContainer": lambda a: a["minor_number"],
-            "PaiJobsZombie": lambda a: a["minor_number"],
             "k8sApiServerNotOk": lambda a: a["error"],
             "k8sDockerDaemonNotOk": lambda a: a["error"],
             "NodeFilesystemUsage": lambda a: a["device"],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/665253/64500640-9842a800-d2f0-11e9-9604-29e5c36adebf.png)

PaiJobsZombie alert do not have minor_number label, use default instance label.

`ALERTS{alertname="PaiJobsZombie",alertstate="firing",instance="172.23.233.62:9102",job="pai_serivce_exporter",pai_service_name="job-exporter",scraped_from="job-exporter-bmhml",type="residual_job"}`