### PR TITLE
Fix version change in webportal

### DIFF
--- a/src/webportal/build/build-pre.sh
+++ b/src/webportal/build/build-pre.sh
@@ -21,7 +21,8 @@ pushd $(dirname "$0") > /dev/null
 
 mkdir -p "../dependency"
 cp -arf "../../../docs" "../../../examples" "../dependency"
-cp -arf "../../../version" "../version"
+mkdir -p "../version"
+cp -arf ../../../version/* "../version/"
 if [ "$ATTACH_COMMIT_ID" = true ]; then
     echo `git rev-parse HEAD | cut -c1-6` > ../version/COMMIT.VERSION
 else


### PR DESCRIPTION
Currently we use `cp -arf "../../../version" "../version"` to copy the PAI version to `src/webportal/` , here is a small problem:

- If it is the first time to run `cp -arf "../../../version" "../version"` , a `version` folder will be created under `src/webportal`
- If you run the  `cp -arf "../../../version" "../version"` again,  it will copy the `version` folder under `src/webportal/version/`. Thus the folder structure becomes `src/webportal/version/version`, which is not desired.

To reproduce:
- build and deploy the cluster
- change the PAI.VERSION to make a new version
- build and deploy the cluster, but the version will not change in webportal



