### PR TITLE
Remove drivers service in k8s cluster deployment

### DIFF
--- a/src/drivers/deploy/service.yaml
+++ b/src/drivers/deploy/service.yaml
@@ -17,7 +17,6 @@
 
 cluster-type:
   - yarn
-  - k8s
 
 prerequisite:
   - cluster-configuration


### PR DESCRIPTION
Remove drivers serivce in k8s cluster deployment, users should install nvidia drivers on the host by themselves.

With nvidia device plugin, [job-exporter](https://github.com/Microsoft/pai/blob/master/src/job-exporter/deploy/job-exporter.yaml.template#L71-L72) and user jobs will work w/o drivers service in k8s cluster.