### PR TITLE
[Deployment] Add gateway uri in configuration

### DIFF
--- a/deployment/clusterObjectModel/cluster_object_model.py
+++ b/deployment/clusterObjectModel/cluster_object_model.py
@@ -121,8 +121,12 @@ class cluster_object_model:
         self.layout = file_handler.load_yaml_config("{0}/layout.yaml".format(self.configuration_path))
         overwrite_service_configuration = file_handler.load_yaml_config("{0}/services-configuration.yaml".format(self.configuration_path))
         self.overwrite_service_configuration, updated = forward_compatibility.service_configuration_convert(overwrite_service_configuration)
+
         cluster_type = self.overwrite_service_configuration["cluster"]["common"]["cluster-type"]
-        
+        if ("gateway-uri" not in self.overwrite_service_configuration["cluster"]["common"]):
+            self.overwrite_service_configuration["cluster"]["common"]["gateway-uri"] = \
+                "http://{}".format([host["hostip"] for host in self.layout["machine-list"] if host.get("pai-master") == "true"][0])
+
         parser_dict = dict()
         parser_dict["layout"] = pai_com_layout.Layout(self.layout)
 

--- a/examples/cluster-configuration/services-configuration.yaml
+++ b/examples/cluster-configuration/services-configuration.yaml
@@ -22,6 +22,9 @@
 #    cluster-id: pai
 #    cluster-type: yarn
 #
+#    # Gateway address, used to visit the cluster from public network
+#    gateway-uri: "https://pai.domain.com"
+#
 #    # HDFS, zookeeper data path on your cluster machine.
 #    data-path: "/datastorage"
 #


### PR DESCRIPTION
In some network environments, pylon may not have a public address and the cluster can only be visited through a gateway #3635.