### PR TITLE
fix grafana can not be accessed behind the gateway

### DIFF
--- a/src/grafana/deploy/grafana-configuration/prom-datasource.json.template
+++ b/src/grafana/deploy/grafana-configuration/prom-datasource.json.template
@@ -2,7 +2,7 @@
   "name":"PM",
   "type":"prometheus",
   "url":"{{ cluster_cfg['prometheus']['url'] }}/prometheus",
-  "access":"direct",
+  "access":"proxy",
   "basicAuth":false,
   "isDefault":true
 }

--- a/src/pylon/deploy/pylon-config/location.conf.template
+++ b/src/pylon/deploy/pylon-config/location.conf.template
@@ -233,13 +233,10 @@ location ~ ^/grafana(.*)$$ {
   sub_filter_once off;
   sub_filter
     '<base href="/" />'
-    '<base href="$scheme://$http_host/grafana/" />';
-  sub_filter
-    '{{PROMETHEUS_URI}}/prometheus'
-    '$scheme://$http_host/prometheus';
+    '<base href="/grafana/" />';
   sub_filter
     '{{GRAFANA_URI}}'
-    '$scheme://$http_host/grafana';
+    '/grafana';
   sub_filter
     '"url":"/'
     '"url":"./';


### PR DESCRIPTION
Before this change, grafana access Prometheus from the front-end. And it doesn't work in the env with the gateway. Change it to though back-end proxy.
The request flow is changed from "Grafana->Gateway->Pylon->Prometheus" to  "Grafana->->Prometheus"