### PR TITLE
[Rest Server] Enable fancy retry policy for elastic tasks

### DIFF
--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -267,7 +267,7 @@ const generateTaskRole = (taskRole, labels, config) => {
   }
   // enable gang scheduling or not
   let gangAllocation = 'true';
-  let retryPolicy = {
+  const retryPolicy = {
     fancyRetryPolicy: false,
     maxRetryCount: 0,
   };

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -266,15 +266,20 @@ const generateTaskRole = (taskRole, labels, config) => {
     shmMB = config.taskRoles[taskRole].extraContainerOptions.shmMB || 512;
   }
   // enable gang scheduling or not
-  const gangAllocation = ('extras' in config && config.extras.gangAllocation === false) ? 'false' : 'true';
+  let gangAllocation = 'true';
+  let retryPolicy = {
+    fancyRetryPolicy: false,
+    maxRetryCount: 0,
+  };
+  if ('extras' in config && config.extras.gangAllocation === false) {
+    gangAllocation = 'false';
+    retryPolicy.fancyRetryPolicy = true;
+  }
   const frameworkTaskRole = {
     name: convertName(taskRole),
     taskNumber: config.taskRoles[taskRole].instances || 1,
     task: {
-      retryPolicy: {
-        fancyRetryPolicy: false,
-        maxRetryCount: 0,
-      },
+      retryPolicy,
       podGracefulDeletionTimeoutSec: launcherConfig.podGracefulDeletionTimeoutSec,
       pod: {
         metadata: {


### PR DESCRIPTION
Enable fancy retry policy for elastic tasks,
task will retry for transient failure, e.g. node deallocation.