### PR TITLE
HiveD algorithm refactor

### DIFF
--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
@@ -48,7 +48,7 @@ type Cell interface {
 	GetUsedGpuNumAtPriority(CellPriority) int32
 	IncreaseUsedGpuNumAtPriority(CellPriority, int32)
 	GetUsedGpuNumSamePriority() int32
-	GetUsedGpuNumOtherPriority() int32
+	GetUsedGpuNumHigherPriority() int32
 	UpdateUsedGpuNumForPriority(CellPriority)
 	UpdateUsedGpuNumAllPriority(CellPriority)
 }
@@ -67,8 +67,8 @@ type GenericCell struct {
 	usedGpuNumAtPriority map[CellPriority]int32 // GPU number used by each priority
 	// GPU number used by the same priority as that of the pod to be scheduled in topologyAwareScheduler (for sorting cells)
 	usedGpuNumSamePriority int32
-	// GPU number used by the lower priorities than that of the pod to be scheduled in topologyAwareScheduler (for sorting cells)
-	usedGpuNumLowerPriority int32
+	// GPU number used by higher priorities than that of the pod to be scheduled in topologyAwareScheduler (for sorting cells)
+	usedGpuNumHigherPriority int32
 }
 
 func (c *GenericCell) GetChain() CellChain {
@@ -130,17 +130,17 @@ func (c *GenericCell) GetUsedGpuNumSamePriority() int32 {
 	return c.usedGpuNumSamePriority
 }
 
-func (c *GenericCell) GetUsedGpuNumOtherPriority() int32 {
-	return c.usedGpuNumLowerPriority
+func (c *GenericCell) GetUsedGpuNumHigherPriority() int32 {
+	return c.usedGpuNumHigherPriority
 }
 
 func (c *GenericCell) UpdateUsedGpuNumForPriority(p CellPriority) {
 	c.usedGpuNumSamePriority = c.usedGpuNumAtPriority[p]
-	c.usedGpuNumLowerPriority = 0
+	c.usedGpuNumHigherPriority = 0
 	c.freeGpuNumAtPriority = c.totalGpuNum
 	for priority, n := range c.usedGpuNumAtPriority {
-		if priority != p {
-			c.usedGpuNumLowerPriority += n
+		if priority > p {
+			c.usedGpuNumHigherPriority += n
 		}
 		if priority >= p {
 			c.freeGpuNumAtPriority -= n

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
@@ -63,7 +63,7 @@ type GenericCell struct {
 
 	totalGpuNum          int32                  // total GPU number of a cell
 	freeGpuNum           int32                  // free GPU number of a cell
-	freeGpuNumAtPriority int32                  // free GPU number at a certain priority (lower priority considered as free)
+	freeGpuNumAtPriority int32                  // free GPU number at the priority of the pod to be scheduled (lower priority considered as free)
 	usedGpuNumAtPriority map[CellPriority]int32 // GPU number used by each priority
 	// GPU number used by the same priority as that of the pod to be scheduled in topologyAwareScheduler (for sorting cells)
 	usedGpuNumSamePriority int32

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
@@ -51,6 +51,14 @@ type Cell interface {
 	UpdateUsedGpuNumAllPriority(CellPriority)
 }
 
+func CellEqual(c1 Cell, c2 Cell) bool {
+	if c1 == nil || c2 == nil {
+		return c1 == nil && c2 == nil
+	} else {
+		return c1.GetName() == c2.GetName()
+	}
+}
+
 type GenericCell struct {
 	chain              CellChain
 	level              CellLevel

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
@@ -25,7 +25,8 @@ package algorithm
 import (
 	"fmt"
 	"github.com/microsoft/hivedscheduler/pkg/api"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/microsoft/hivedscheduler/pkg/internal"
+	core "k8s.io/api/core/v1"
 )
 
 // A Cell represents a set of GPUs affinitized by their interconnection topology.
@@ -40,14 +41,32 @@ type Cell interface {
 	SetParent(Cell)
 	GetChildren() CellList
 	SetChildren(CellList)
+	AtOrHigherThanNode() bool
+
+	IncreaseFreeGpuNum(int32)
+	GetFreeGpuNumForPriority(CellPriority) int32
+	GetUsedGpuNumAtPriority(CellPriority) int32
+	IncreaseUsedGpuNumAtPriority(CellPriority, int32)
+	GetUsedGpuNumSamePriority() int32
+	GetUsedGpuNumOtherPriority() int32
+	SetUsedGpuNumForPriority(CellPriority)
+	SetUsedGpuNumAllPriority(CellPriority)
 }
 
 type GenericCell struct {
-	chain    CellChain
-	level    CellLevel
-	priority CellPriority // priority of a cell is max of those of its children and itself
-	parent   Cell         // pointer to its parent cell
-	children CellList     // pointer to its children cells
+	chain                  CellChain
+	level                  CellLevel
+	priority               CellPriority // priority of a cell is max of those of its children and itself
+	parent                 Cell         // pointer to its parent cell
+	children               CellList     // pointer to its children cells
+	atOrHigherThanNode     bool
+
+	totalGpuNum int32
+	freeGpuNum int32
+	freeGpuNumForPriority int32
+	usedGpuNumAtPriority   map[CellPriority]int32
+	usedGpuNumSamePriority int32
+	usedGpuNumOtherPriority int32
 }
 
 func (c *GenericCell) GetChain() CellChain {
@@ -82,28 +101,85 @@ func (c *GenericCell) SetChildren(children CellList) {
 	c.children = children
 }
 
+func (c *GenericCell) AtOrHigherThanNode() bool {
+	return c.atOrHigherThanNode
+}
+
+func (c *GenericCell) IncreaseFreeGpuNum(delta int32) {
+	c.freeGpuNum += delta
+}
+
+func (c *GenericCell) GetFreeGpuNumForPriority(p CellPriority) int32 {
+	return c.freeGpuNumForPriority
+}
+
+func (c *GenericCell) GetUsedGpuNumAtPriority(p CellPriority) int32 {
+	return c.usedGpuNumAtPriority[p]
+}
+
+func (c *GenericCell) IncreaseUsedGpuNumAtPriority(p CellPriority, delta int32) {
+	c.usedGpuNumAtPriority[p] += delta
+	if c.usedGpuNumAtPriority[p] == 0 {
+		delete(c.usedGpuNumAtPriority, p)
+	}
+}
+
+func (c *GenericCell) GetUsedGpuNumSamePriority() int32 {
+	return c.usedGpuNumSamePriority
+}
+
+func (c *GenericCell) GetUsedGpuNumOtherPriority() int32 {
+	return c.usedGpuNumOtherPriority
+}
+
+func (c *GenericCell) SetUsedGpuNumForPriority(p CellPriority) {
+	c.usedGpuNumSamePriority = c.usedGpuNumAtPriority[p]
+	c.usedGpuNumOtherPriority = 0
+	c.freeGpuNumForPriority = c.totalGpuNum
+	for priority, n := range c.usedGpuNumAtPriority {
+		if priority != p {
+			c.usedGpuNumOtherPriority += n
+		}
+		if priority >= p {
+			c.freeGpuNumForPriority -= n
+		}
+	}
+}
+
+func (c *GenericCell) SetUsedGpuNumAllPriority(p CellPriority) {
+	c.usedGpuNumSamePriority = c.totalGpuNum - c.freeGpuNum
+	c.freeGpuNumForPriority = c.totalGpuNum
+	for priority, n := range c.usedGpuNumAtPriority {
+		if priority >= p {
+			c.freeGpuNumForPriority -= n
+		}
+	}
+}
+
 // PhysicalCell defines a cell in the physical cluster.
 type PhysicalCell struct {
 	GenericCell
 	nodes       []string     // node names inside the cell
 	gpuIndices  []int32      // [-1] for cells at levels higher than node
-	pods        []types.UID  // pods running in this cell or its children
+	pods        []*core.Pod  // pods running in this cell or its children
 	virtualCell *VirtualCell // points to the bound virtual cell
+	tmpVirtualCell *VirtualCell // points to the temporarily bound virtual cell (before the binding is confirmed)
+	split bool
 	reserved    bool         // true when this is a reserved cell
-
-	// a ChainCellList with this cell as the top.
-	// used for pod placement inside a cell and cell allocation in a reserved one.
-	internalCellList ChainCellList
 }
 
-func NewPhysicalCell(c CellChain, l CellLevel) *PhysicalCell {
+func NewPhysicalCell(c CellChain, l CellLevel, g bool, n int32) *PhysicalCell {
 	return &PhysicalCell{
 		GenericCell: GenericCell{
-			chain:    c,
-			level:    l,
-			priority: freePriority,
+			chain:              c,
+			level:              l,
+			priority:           freePriority,
+			atOrHigherThanNode: g,
+			totalGpuNum:n,
+			freeGpuNum:n,
+			usedGpuNumAtPriority: map[CellPriority]int32{},
 		},
-		pods: []types.UID{},
+		pods: []*core.Pod{},
 	}
 }
 
@@ -124,14 +200,11 @@ func (c *PhysicalCell) SetPhysicalResources(nodes []string, gpuIndices []int32) 
 	c.gpuIndices = gpuIndices
 }
 
-func (c *PhysicalCell) AddPod(pod types.UID) {
+func (c *PhysicalCell) AddPod(pod *core.Pod) {
 	c.pods = append(c.pods, pod)
-	if c.parent != nil {
-		c.parent.(*PhysicalCell).AddPod(pod)
-	}
 }
 
-func (c *PhysicalCell) DeletePod(pod types.UID) {
+func (c *PhysicalCell) DeletePod(pod *core.Pod) {
 	idx := -1
 	for i, p := range c.pods {
 		if pod == p {
@@ -140,12 +213,9 @@ func (c *PhysicalCell) DeletePod(pod types.UID) {
 		}
 	}
 	if idx == -1 {
-		panic(fmt.Sprintf("Error when deleting pod %v: not exist in cell %v!", pod, c.GetName()))
+		panic(fmt.Sprintf("Error when deleting pod %v: not exist in cell %v!", internal.Key(pod), c.GetName()))
 	} else {
 		c.pods = append(c.pods[:idx], c.pods[idx+1:]...)
-	}
-	if c.parent != nil {
-		c.parent.(*PhysicalCell).DeletePod(pod)
 	}
 }
 
@@ -153,22 +223,8 @@ func (c *PhysicalCell) HasPod() bool {
 	return len(c.pods) != 0
 }
 
-func (c *PhysicalCell) InitPhysicalCellList() {
-	c.internalCellList = NewChainCellList(c.level)
-	c.internalCellList[c.level] = append(c.internalCellList[c.level], c)
-	for level := c.level - 1; level >= CellLevel(1); level-- {
-		for _, cc := range c.internalCellList[level+1] {
-			c.internalCellList[level] = append(c.internalCellList[level], cc.GetChildren()...)
-		}
-	}
-}
-
-func (c *PhysicalCell) GetPhysicalCellList() ChainCellList {
-	return c.internalCellList
-}
-
-func (c *PhysicalCell) ClearPhysicalCellList() {
-	c.internalCellList = nil
+func (c *PhysicalCell) GetPods() []*core.Pod {
+	return c.pods
 }
 
 func (c *PhysicalCell) GetVirtualCell() *VirtualCell {
@@ -177,6 +233,22 @@ func (c *PhysicalCell) GetVirtualCell() *VirtualCell {
 
 func (c *PhysicalCell) SetVirtualCell(vc *VirtualCell) {
 	c.virtualCell = vc
+}
+
+func (c *PhysicalCell) GetTmpVirtualCell() *VirtualCell {
+	return c.tmpVirtualCell
+}
+
+func (c *PhysicalCell) SetTmpVirtualCell(vc *VirtualCell) {
+	c.tmpVirtualCell = vc
+}
+
+func (c *PhysicalCell) IsSplit() bool {
+	return c.split
+}
+
+func (c *PhysicalCell) SetSplit(split bool) {
+	c.split = split
 }
 
 func (c *PhysicalCell) IsReserved() bool {
@@ -195,14 +267,25 @@ type VirtualCell struct {
 	indexInChain    int32                  // index of the cell in the ChainCellList it belongs to (assigned in initialization)
 	preAssignedCell *VirtualCell           // top level cell of this cell chain
 	physicalCell    *PhysicalCell          // points to the bound physical cell
+	tmpPhysicalCell *PhysicalCell // points to the temporarily bound physical cell (before the binding is confirmed)
 }
 
-func NewVirtualCell(vc api.VirtualClusterName, c CellChain, l CellLevel, i int32, pac *VirtualCell) *VirtualCell {
+func NewVirtualCell(vc api.VirtualClusterName,
+	c CellChain,
+	l CellLevel,
+	g bool,
+	n int32,
+	i int32,
+	pac *VirtualCell) *VirtualCell {
+
 	return &VirtualCell{
 		GenericCell: GenericCell{
-			chain:    c,
-			level:    l,
-			priority: freePriority,
+			chain:              c,
+			level:              l,
+			priority:           freePriority,
+			atOrHigherThanNode: g,
+			totalGpuNum:n,
+			usedGpuNumAtPriority: map[CellPriority]int32{},
 		},
 		vc:              vc,
 		indexInChain:    i,
@@ -244,4 +327,12 @@ func (c *VirtualCell) GetPhysicalCell() *PhysicalCell {
 
 func (c *VirtualCell) SetPhysicalCell(pc *PhysicalCell) {
 	c.physicalCell = pc
+}
+
+func (c *VirtualCell) GetTmpPhysicalCell() *PhysicalCell {
+	return c.tmpPhysicalCell
+}
+
+func (c *VirtualCell) SetTmpPhysicalCell(pc *PhysicalCell) {
+	c.tmpPhysicalCell = pc
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/config.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/config.go
@@ -391,6 +391,7 @@ func calculateGpuType(cellChainElements map[api.CellType]*cellChainElement, chai
 
 func ParseConfig(sConfig *api.Config) (
 	map[CellChain]ChainCellList, // chain:level:[]physicalCell
+	map[CellChain]map[CellLevel]int32, // chain:level:gpuNumber
 	map[string][]CellChain, // gpuType:[]chain
 	map[api.VirtualClusterName]map[CellChain]ChainCellList, // non reserved virtual cells, vc:chain:level:[]virtualCell
 	map[api.VirtualClusterName]map[api.ReservationId]ChainCellList, // reserved virtual cells, vc:reservationId:level:[]virtualCell
@@ -406,11 +407,12 @@ func ParseConfig(sConfig *api.Config) (
 	for k := range physicalCells {
 		cellChains = append(cellChains, k)
 	}
+	gpuNums := calculateGpuNumber(cellChainElements, cellChains)
 	gpuTypeToChain := calculateGpuType(cellChainElements, cellChains)
 
 	virtualSpecs := sConfig.VirtualClusters
 	virtualNonReservedCellList, virtualReservedCellList, reservedPhysicalCells := newVirtualCellConstructor(
 		cellChainElements, *virtualSpecs, rawReservedPhysicalCells).build()
 
-	return physicalCells, gpuTypeToChain, virtualNonReservedCellList, virtualReservedCellList, reservedPhysicalCells
+	return physicalCells, gpuNums, gpuTypeToChain, virtualNonReservedCellList, virtualReservedCellList, reservedPhysicalCells
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/constants.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/constants.go
@@ -26,12 +26,12 @@ import "math"
 
 const (
 	// internal cell priorities
-	regularPriority               = CellPriority(0)
-	opportunisticPriority         = CellPriority(-1)
-	freePriority                  = CellPriority(-2)
-	highestPriority               = CellPriority(1000)
+	regularPriority       = CellPriority(0)
+	opportunisticPriority = CellPriority(-1)
+	freePriority          = CellPriority(-2)
+	highestPriority       = CellPriority(1000)
 
 	// lowest and highest levels in a cell chain
-	lowestLevel = CellLevel(1)
+	lowestLevel  = CellLevel(1)
 	highestLevel = CellLevel(math.MaxInt32)
 )

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/constants.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/constants.go
@@ -22,16 +22,16 @@
 
 package algorithm
 
+import "math"
+
 const (
-	// internal cell priorities (not exposed to users)
+	// internal cell priorities
 	regularPriority               = CellPriority(0)
-	regularNonPreassignedPriority = CellPriority(-101)
-	opportunisticPriority         = CellPriority(-102)
-	freePriority                  = CellPriority(-103)
+	opportunisticPriority         = CellPriority(-1)
+	freePriority                  = CellPriority(-2)
 	highestPriority               = CellPriority(1000)
 
-	// lowest level in a cell chain
+	// lowest and highest levels in a cell chain
 	lowestLevel = CellLevel(1)
-	// used in setSelfAndParentPriority (meaning no limit on max level)
-	unlimitedLevel = CellLevel(0)
+	highestLevel = CellLevel(math.MaxInt32)
 )

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -878,11 +878,11 @@ func unbindCell(c *PhysicalCell) {
 // and its parent recursively.
 func updateUsedGpuNumAtPriority(c Cell, p CellPriority, increase bool) {
 	for c != nil {
+		delta := int32(-1)
 		if increase {
-			c.IncreaseUsedGpuNumAtPriority(p, 1)
-		} else {
-			c.IncreaseUsedGpuNumAtPriority(p, -1)
+			delta = 1
 		}
+		c.IncreaseUsedGpuNumAtPriority(p, delta)
 		c = c.GetParent()
 	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -415,8 +415,16 @@ func (h *HivedAlgorithm) scheduleRegularAffinityGroup(sr schedulingRequest) (map
 		return nil, nil
 	}
 	// map the vc placement to the physical cluster
+	gpuNums := make([]int32, len(sr.affinityGroup))
+	i := 0
+	for n := range sr.affinityGroup {
+		gpuNums[i] = n
+		i++
+	}
+	common.SortInt32(gpuNums)
 	physicalPlacement := map[int32][]CellList{}
-	for podGpuNum, podPlacements := range virtualPlacement {
+	for _, podGpuNum := range gpuNums {
+		podPlacements := virtualPlacement[podGpuNum]
 		physicalPlacement[podGpuNum] = make([]CellList, len(podPlacements))
 		for i, podGpus := range podPlacements {
 			physicalPlacement[podGpuNum][i] = make(CellList, len(podGpus))
@@ -765,6 +773,9 @@ func buddyAlloc(freeList ChainCellList, level CellLevel) *PhysicalCell {
 	}
 	if len(freeList[level]) == 0 {
 		return nil
+	}
+	for _, c := range freeList[level] {
+		fmt.Println(c.GetName())
 	}
 	return minOpportunisticCell(freeList[level])
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -29,16 +29,19 @@ import (
 	"github.com/microsoft/hivedscheduler/pkg/internal"
 	core "k8s.io/api/core/v1"
 	"k8s.io/klog"
+	"math"
 	"sync"
 )
 
 type HivedAlgorithm struct {
-	// intra-VC scheduler for each VC
+	// scheduler in each VC
 	vcSchedulers map[api.VirtualClusterName]intraVCScheduler
+	// scheduler for opportunistic pods
+	opportunisticSchedulers map[CellChain]*topologyAwareScheduler
 	// ChainCellLists of physical cells of each cell chain
 	fullCellList map[CellChain]ChainCellList
-	// map each cell type (chain + level) to the number of GPUs in such a cell
-	gpuNums map[CellChain]map[CellLevel]int32
+	// ChainCellLists of free physical cells of each cell chain (used in buddy alloc)
+	freeCellList map[CellChain]ChainCellList
 	// map each GPU type to all chains that contain this type
 	chains map[string][]CellChain
 	// all affinity groups that have been allocated cells
@@ -49,23 +52,26 @@ type HivedAlgorithm struct {
 	algorithmLock sync.RWMutex
 }
 
+// NewHivedAlgorithm initializes a HivedAlgorithm from the config file
 func NewHivedAlgorithm(sConfig *api.Config) *HivedAlgorithm {
-	pcl, gpuNums, gpuTypeToChain, nonReservedVcl, reservedVcl, reservedPc := ParseConfig(sConfig)
+	pcl, gpuTypeToChain, nonReservedVcl, reservedVcl, reservedPc := ParseConfig(sConfig)
 	h := &HivedAlgorithm{
 		vcSchedulers:            make(map[api.VirtualClusterName]intraVCScheduler),
+		opportunisticSchedulers: map[CellChain]*topologyAwareScheduler{},
 		fullCellList:            pcl,
-		gpuNums:                 gpuNums,
+		freeCellList:            make(map[CellChain]ChainCellList),
 		chains:                  gpuTypeToChain,
 		allocatedAffinityGroups: make(map[string]*AlgoAffinityGroup),
 		reservedCells:           reservedPc,
 	}
 	for vc := range nonReservedVcl {
-		h.vcSchedulers[vc] = &defaultIntraVCScheduler{
-			virtualNonReservedCellList: nonReservedVcl[vc],
-			virtualReservedCellList:    reservedVcl[vc],
-		}
+		h.vcSchedulers[vc] = newDefaultIntraVCScheduler(nonReservedVcl[vc], reservedVcl[vc])
+	}
+	for chain, ccl := range h.fullCellList {
+		h.opportunisticSchedulers[chain] = newTopologyAwareScheduler(ccl, false)
 	}
 	h.validateInitialAssignment()
+	h.initFreeCellList()
 	h.initReservations()
 	return h
 }
@@ -88,66 +94,34 @@ func (h *HivedAlgorithm) Schedule(pod *core.Pod, suggestedNodes []string) intern
 
 	klog.Infof("[%v]: Scheduling pod...", internal.Key(pod))
 	s := internal.ExtractPodSchedulingSpec(pod)
-
-	// Differences between group cells and pod cells:
-	// A group cell is allocated by the HiveD algorithm to an affinity group,
-	// and is the unit of HiveD's cell allocation.
-	// A pod cell is *only* for finding a GPU placement in a group cell for a specific pod.
-	// Pod placement operates on cells because this way we can use buddy alloc to avoid
-	// placing a pod cross multiple nodes.
-	// A pod cell is NOT for the cell allocation process!
-	if groupPhysical, groupVirtual := h.getOrRequestGroupCell(pod, s); groupPhysical != nil {
-		if podCell := h.requestPodCell(s, groupPhysical); podCell == nil {
-			return internal.PodScheduleResult{
-				PodPreemptInfo: &internal.PodPreemptInfo{},
-			}
-		} else {
-			nodes, gpuIndices := podCell.GetPhysicalPlacement()
-			if len(nodes) > 1 {
-				// TODO: request larger group cell (when scheduling the first pod),
-				//  or prove this is an impossibility
-				panic(fmt.Sprintf("pod placed across nodes: %v", podCell.GetName()))
-			}
-			selectedNode := nodes[0]
-			if !common.StringsContains(suggestedNodes, selectedNode) {
-				if !groupPhysical.HasPod() {
-					panic(fmt.Sprintf(
-						"[%v]: node %v picked by algorithm but not in K8S candidates", internal.Key(pod), selectedNode))
-				}
-			}
-			groupNodes, groupGpu := groupPhysical.GetPhysicalPlacement()
-			vcl, vci := int32(-1), int32(-1)
-			if groupVirtual != nil {
-				vcl = int32(groupVirtual.GetLevel())
-				vci = groupVirtual.GetIndex()
-			}
-			return internal.PodScheduleResult{
-				PodBindInfo: &api.PodBindInfo{
-					Node:         selectedNode,
-					GpuIsolation: gpuIndices[:s.GpuNumber],
-					CellChain:    string(groupPhysical.GetChain()),
-					PodCellLevel: int32(podCell.GetLevel()),
-					PodCellGpuPlacement: api.Range{
-						Start: gpuIndices[0],
-						End:   gpuIndices[len(gpuIndices)-1]},
-					GroupCellLevel: int32(groupPhysical.GetLevel()),
-					GroupCellNodes: groupNodes,
-					GroupCellGpuPlacement: api.Range{
-						Start: groupGpu[0],
-						End:   groupGpu[len(groupGpu)-1],
-					},
-					VirtualCellLevel: vcl,
-					VirtualCellIndex: vci,
-				},
-			}
+	var (
+		// gpu number -> a set of pods -> a set of GPUs of each pod
+		groupPhysicalPlacement map[int32][]CellList
+		groupVcPlacement       map[int32][]CellList
+		podIndex               int32
+		newGroup bool
+	)
+	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group == nil {
+		newGroup = true
+		klog.Infof("Scheduling new affinity group %v", s.AffinityGroup.Name)
+		groupPhysicalPlacement, groupVcPlacement = h.scheduleNewAffinityGroup(pod, s)
+		if groupPhysicalPlacement != nil {
+			podIndex = int32(len(groupPhysicalPlacement[s.GpuNumber])) - 1
 		}
 	} else {
-		return internal.PodScheduleResult{
-			PodWaitInfo: &internal.PodWaitInfo{
-				FailedNodeReasons: map[string]string{},
-			},
+		newGroup = false
+		if h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums[s.GpuNumber] <= 0 {
+			panic(internal.NewBadRequestError(fmt.Sprintf(
+				"Requesting more pods than the configured number for %v GPUs in affinity group %v",
+				s.GpuNumber, s.AffinityGroup.Name)))
 		}
+		klog.Infof("Pod from existing affinity group: %v", s.AffinityGroup.Name)
+		groupPhysicalPlacement = h.allocatedAffinityGroups[s.AffinityGroup.Name].physicalGpuPlacement
+		groupVcPlacement = h.allocatedAffinityGroups[s.AffinityGroup.Name].vcGpuPlacement
+		podIndex = h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums[s.GpuNumber] - 1
 	}
+	return generatePodScheduleResult(
+		groupPhysicalPlacement, groupVcPlacement, podIndex, suggestedNodes, pod, newGroup)
 }
 
 func (h *HivedAlgorithm) AddAllocatedPod(pod *core.Pod) {
@@ -159,58 +133,43 @@ func (h *HivedAlgorithm) AddAllocatedPod(pod *core.Pod) {
 	info := internal.ExtractPodBindInfo(pod)
 
 	chain := CellChain(info.CellChain)
-	podCell := h.findPhysicalCell(
-		chain,
-		CellLevel(info.PodCellLevel),
-		info.Node,
-		info.PodCellGpuPlacement.Start)
-	if podCell == nil {
-		panic(fmt.Sprintf(
-			"[%v]: pod cell not found when adding pod: chain %v, level %v, node %v, GPU range %v ~ %v",
-			internal.Key(pod), chain, info.PodCellLevel, info.Node,
-			info.PodCellGpuPlacement.Start, info.PodCellGpuPlacement.End))
-	}
-	podCell.AddPod(pod.UID)
-
-	firstPod := false
-	var groupCell *PhysicalCell
 	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group == nil {
-		firstPod = true
-		groupCell = h.findPhysicalCell(
-			chain,
-			CellLevel(info.GroupCellLevel),
-			info.GroupCellNodes[0],
-			info.GroupCellGpuPlacement.Start)
-		if groupCell == nil {
-			panic(fmt.Sprintf(
-				"[%v]: group cell of %v not found when adding pod: chain %v, level %v, node %v, GPU range %v ~ %v",
-				internal.Key(pod), s.AffinityGroup.Name, chain, info.GroupCellLevel, info.Node,
-				info.GroupCellGpuPlacement.Start, info.GroupCellGpuPlacement.End))
-		}
 		newGroup := newAlgoAffinityGroup(s.AffinityGroup)
-		newGroup.cell = groupCell
+		for _, gms := range info.GroupScheduleInfo {
+			newGroup.physicalGpuPlacement[gms.GpuNumber] = make([]CellList, len(gms.PodPlacements))
+			newGroup.vcGpuPlacement[gms.GpuNumber] = make([]CellList, len(gms.PodPlacements))
+			for i := int32(0); i < int32(len(gms.PodPlacements)); i++ {
+				newGroup.physicalGpuPlacement[gms.GpuNumber][i] = make(
+					CellList, len(gms.PodPlacements[i].PhysicalGpuIndices))
+				newGroup.vcGpuPlacement[gms.GpuNumber][i] = make(
+					CellList, len(gms.PodPlacements[i].PhysicalGpuIndices))
+				node := gms.PodPlacements[i].PhysicalNode
+				for j := int32(0); j < int32(len(gms.PodPlacements[i].PhysicalGpuIndices)); j++ {
+					physicalGpuIndex := gms.PodPlacements[i].PhysicalGpuIndices[j]
+					pGpu := h.findPhysicalGpu(chain, node, physicalGpuIndex)
+					if pGpu == nil {
+						panic(fmt.Sprintf("[%v]: physical GPU cell not found when adding pod: node %v, GPU index %v",
+							internal.Key(pod), node, physicalGpuIndex))
+					}
+					virtualCellIndex := gms.PodPlacements[i].VirtualGpuCellIndices[j]
+					vGpu := h.findVirtualGpu(
+						s.VirtualCluster, chain, s.ReservationId, virtualCellIndex)
+					if virtualCellIndex >= 0 && vGpu == nil {
+						panic(fmt.Sprintf("[%v]: virtual GPU cell not found when adding pod: virtual cell index %v",
+							internal.Key(pod), virtualCellIndex))
+					}
+					newGroup.physicalGpuPlacement[gms.GpuNumber][i][j] = pGpu
+					newGroup.vcGpuPlacement[gms.GpuNumber][i][j] = vGpu
+					h.confirmAllocatedGpu(pGpu, vGpu, CellPriority(s.Priority))
+				}
+			}
+		}
 		h.allocatedAffinityGroups[s.AffinityGroup.Name] = newGroup
 	}
-	h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums[s.GpuNumber]--
-
-	if firstPod {
-		klog.Infof("[%v]: first pod of group %v", internal.Key(pod), s.AffinityGroup.Name)
-		virtualCell := h.findVirtualCell(
-			s.VirtualCluster, chain, s.ReservationId, CellLevel(info.VirtualCellLevel), info.VirtualCellIndex)
-		if info.VirtualCellIndex >= 0 && virtualCell == nil {
-			var str string
-			if s.ReservationId != "" {
-				str = fmt.Sprintf("reservation %v", s.ReservationId)
-			} else {
-				str = fmt.Sprintf("chain %v", chain)
-			}
-			panic(fmt.Sprintf(
-				"[%v]: virtual cell of %v not found when adding pod: VC %v, %v, level %v, index %v",
-				internal.Key(pod), s.AffinityGroup.Name, s.VirtualCluster, str,
-				info.VirtualCellLevel, info.VirtualCellIndex))
-		}
-		confirmAllocatedCell(groupCell, virtualCell, CellPriority(s.Priority))
+	for _, gpuIndex := range info.GpuIsolation {
+		h.findPhysicalGpu(chain, info.Node, gpuIndex).AddPod(pod)
 	}
+	h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums[s.GpuNumber]--
 }
 
 func (h *HivedAlgorithm) DeleteAllocatedPod(pod *core.Pod) {
@@ -222,26 +181,32 @@ func (h *HivedAlgorithm) DeleteAllocatedPod(pod *core.Pod) {
 	info := internal.ExtractPodBindInfo(pod)
 
 	chain := CellChain(info.CellChain)
-	podCell := h.findPhysicalCell(
-		chain,
-		CellLevel(info.PodCellLevel),
-		info.Node,
-		info.PodCellGpuPlacement.Start)
-	if podCell == nil {
-		panic(fmt.Sprintf(
-			"[%v]: pod cell not exists when deleting pod: chain %v, level %v, node %v, GPU range %v ~ %v",
-			internal.Key(pod), chain, info.PodCellLevel, info.Node,
-			info.PodCellGpuPlacement.Start, info.PodCellGpuPlacement.End))
-	}
-	podCell.DeletePod(pod.UID)
-
 	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group == nil {
 		panic(fmt.Sprintf(
 			"[%v]: group %v not exists when deleting pod", internal.Key(pod), s.AffinityGroup.Name))
-	} else if !group.cell.HasPod() {
-		delete(h.allocatedAffinityGroups, s.AffinityGroup.Name)
-		group.cell.ClearPhysicalCellList()
-		confirmReleasedCell(group.cell)
+	} else {
+		h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums[s.GpuNumber]++
+		for _, gpuIndex := range info.GpuIsolation {
+			h.findPhysicalGpu(chain, info.Node, gpuIndex).DeletePod(pod)
+		}
+		allPodsDeleted := true
+		for gpuNum, unallocatedPodNum := range h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums {
+			if unallocatedPodNum != int32(
+				len(h.allocatedAffinityGroups[s.AffinityGroup.Name].physicalGpuPlacement[gpuNum])) {
+				allPodsDeleted = false
+				break
+			}
+		}
+		if allPodsDeleted {
+			for _, podPlacements := range h.allocatedAffinityGroups[s.AffinityGroup.Name].physicalGpuPlacement {
+				for _, podPlacement := range podPlacements {
+					for _, podGpu := range podPlacement {
+						h.confirmReleasedGpu(podGpu.(*PhysicalCell))
+					}
+				}
+			}
+			delete(h.allocatedAffinityGroups, s.AffinityGroup.Name)
+		}
 	}
 }
 
@@ -276,12 +241,20 @@ func (h *HivedAlgorithm) validateInitialAssignment() {
 	}
 }
 
+func (h *HivedAlgorithm) initFreeCellList() {
+	for chain, ccl := range h.fullCellList {
+		topLevel := CellLevel(len(ccl))
+		h.freeCellList[chain] = NewChainCellList(topLevel - 1)
+		h.freeCellList[chain][topLevel] = make(CellList, len(ccl[topLevel]))
+		copy(h.freeCellList[chain][topLevel], ccl[topLevel])
+	}
+}
+
 // initReservations creates bindings and sets priorities for the reserved cells.
 func (h *HivedAlgorithm) initReservations() {
 	for vc, vcReservation := range h.reservedCells {
 		for rid, physical := range vcReservation {
-			// set priority to hold the reserved cell in the physical cluster
-			setPriority(physical, regularPriority, unlimitedLevel)
+			h.removeCellFromFreeList(physical)
 			virtualList := h.vcSchedulers[vc].getReservedCellList()[rid]
 			virtual := virtualList[CellLevel(len(virtualList))][0].(*VirtualCell)
 			virtual.SetPhysicalCell(physical)
@@ -291,194 +264,265 @@ func (h *HivedAlgorithm) initReservations() {
 	}
 }
 
-// getOrRequestGroupCell gets the cell for a pod in an affinity group. If no cell has been
-// allocated to the group, then request a new one. Otherwise, return the allocated cell.
-func (h *HivedAlgorithm) getOrRequestGroupCell(
-	pod *core.Pod, s *api.PodSchedulingSpec) (*PhysicalCell, *VirtualCell) {
+func (h *HivedAlgorithm) scheduleNewAffinityGroup(
+	pod *core.Pod,
+	s *api.PodSchedulingSpec) (map[int32][]CellList, map[int32][]CellList) {
 
-	var groupPhysical *PhysicalCell
-	var groupVirtual *VirtualCell
+	var (
+		physicalPlacement map[int32][]CellList
+		vcPlacement       map[int32][]CellList
+		priority          CellPriority
+	)
+	if s.Priority < api.RegularPriority {
+		priority = opportunisticPriority
+	} else {
+		priority = CellPriority(s.Priority)
+	}
+	sr := schedulingRequest{
+		vc:            s.VirtualCluster,
+		reservationId: s.ReservationId,
+		priority:      priority,
+		podGpuNumbers:map[int32]int32{},
+	}
+	h.validateSchedulingRequest(sr, pod)
+	for _, m := range s.AffinityGroup.Members {
+		sr.podGpuNumbers[m.GpuNumber] = m.PodNumber
+	}
+	if sr.reservationId != "" {
+		klog.Infof("Use reservation %v", s.ReservationId)
+		sr.chain = h.reservedCells[sr.vc][sr.reservationId].GetChain()
+		physicalPlacement, vcPlacement = h.processSchedulingRequest(sr)
+	} else {
+		physicalPlacement, vcPlacement = h.scheduleAffinityGroupForGpuType(sr, s.GpuType, pod)
+	}
+	if physicalPlacement != nil {
+		klog.Infof("Succeed scheduling group %v", s.AffinityGroup.Name)
+	} else {
+		klog.Infof("Failed to schedule group %v", s.AffinityGroup.Name)
+	}
+	return physicalPlacement, vcPlacement
+}
 
-	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group == nil {
-		klog.Infof("Requesting new cell for group %v", s.AffinityGroup.Name)
-		var priority CellPriority
-		if s.Priority < api.RegularPriority {
-			priority = opportunisticPriority
+func (h *HivedAlgorithm) scheduleAffinityGroupForGpuType(
+	sr schedulingRequest,
+	gpuType string,
+	pod *core.Pod) (map[int32][]CellList, map[int32][]CellList) {
+
+	if gpuType != "" {
+		if chains := h.chains[gpuType]; chains == nil {
+			panic(internal.NewBadRequestError(fmt.Sprintf(
+				"[%v]: pod requesting an invalid GPU type: %v", internal.Key(pod), gpuType)))
 		} else {
-			priority = CellPriority(s.Priority)
-		}
-		cr := CellRequest{
-			VC:            s.VirtualCluster,
-			Priority:      priority,
-			ReservationId: s.ReservationId,
-		}
-		h.validateCellRequest(cr)
-
-		if cr.ReservationId != "" {
-			if cr.Priority < regularPriority {
-				panic(internal.NewBadRequestError(fmt.Sprintf(
-					"[%v]: opportunistic pod not supported to use reservation %v",
-					internal.Key(pod), cr.ReservationId)))
-			}
-			klog.Infof("Use reservation %v", s.ReservationId)
-			cr.Chain = h.reservedCells[cr.VC][cr.ReservationId].GetChain()
-			cr.Level = h.getLevelByGpuNum(getGroupCellSize(s.AffinityGroup), cr.Chain)
-			if cr.Level < lowestLevel || cr.Level > h.reservedCells[cr.VC][cr.ReservationId].GetLevel() {
-				panic(internal.NewBadRequestError(fmt.Sprintf(
-					"[%v]: pod requesting more GPUs in reservation %v",
-					internal.Key(pod), cr.ReservationId)))
-			}
-			groupPhysical, groupVirtual = h.requestGroupCell(cr)
-		} else if s.GpuType != "" {
-			if chains := h.chains[s.GpuType]; chains == nil {
-				panic(internal.NewBadRequestError(fmt.Sprintf(
-					"[%v]: pod requesting an invalid GPU type: %v", internal.Key(pod), s.GpuType)))
-			} else {
-				var vcHasType bool
-				groupPhysical, groupVirtual, vcHasType = h.requestGroupCellForGpuType(
-					cr, chains, getGroupCellSize(s.AffinityGroup))
-				if cr.Priority > opportunisticPriority && !vcHasType {
-					panic(internal.NewBadRequestError(fmt.Sprintf(
-						"[%v]: pod requesting GPU type %v which VC %v does not have",
-						internal.Key(pod), s.GpuType, s.VirtualCluster)))
+			vcHasType := false
+			for _, chain := range chains {
+				if h.vcSchedulers[sr.vc].getNonReservedCellList()[chain] != nil {
+					vcHasType = true
+				}
+				sr.chain = chain
+				if physicalPlacement, vcPlacement := h.processSchedulingRequest(sr); physicalPlacement != nil {
+					return physicalPlacement, vcPlacement
 				}
 			}
+			if sr.priority >= regularPriority && !vcHasType {
+				panic(internal.NewBadRequestError(fmt.Sprintf(
+					"[%v]: pod requesting GPU type %v which VC %v does not have",
+					internal.Key(pod), gpuType, sr.vc)))
+			}
+		}
+	} else {
+		for _, chains := range h.chains {
+			for _, chain := range chains {
+				sr.chain = chain
+				if physicalPlacement, vcPlacement := h.processSchedulingRequest(sr); physicalPlacement != nil {
+					return physicalPlacement, vcPlacement
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+// validateSchedulingRequest checks the existence of VC and reservation ID, and the legality of priority.
+func (h *HivedAlgorithm) validateSchedulingRequest(sr schedulingRequest, pod *core.Pod) {
+	var message string
+	if h.vcSchedulers[sr.vc] == nil {
+		message = fmt.Sprintf("VC %v does not exists!", sr.vc)
+	} else if sr.reservationId != "" {
+		if h.vcSchedulers[sr.vc].getReservedCellList()[sr.reservationId] == nil {
+			message = fmt.Sprintf("VC %v does not have reservation %v", sr.vc, sr.reservationId)
+		} else if sr.priority < regularPriority {
+			message = fmt.Sprintf("opportunistic pod not supported to use reservation %v", sr.reservationId)
+		}
+	} else if sr.priority > highestPriority {
+		message = fmt.Sprintf("priority %v exceeds highest priority", sr.priority)
+	}
+	if message != "" {
+		panic(internal.NewBadRequestError(fmt.Sprintf("[%v]: %v", internal.Key(pod), message)))
+	}
+}
+
+func (h *HivedAlgorithm) processSchedulingRequest(sr schedulingRequest) (map[int32][]CellList, map[int32][]CellList) {
+	if sr.priority >= regularPriority {
+		return h.scheduleGuaranteedPods(sr)
+	} else {
+		return h.scheduleOpportunisticPods(sr), nil
+	}
+}
+
+func (h *HivedAlgorithm) scheduleGuaranteedPods(sr schedulingRequest) (map[int32][]CellList, map[int32][]CellList) {
+	vcPlacement := h.vcSchedulers[sr.vc].schedule(sr)
+	if vcPlacement != nil {
+		physicalPlacement := map[int32][]CellList{}
+		for podGpuNum, podPlacements := range vcPlacement {
+			physicalPlacement[podGpuNum] = make([]CellList, len(podPlacements))
+			for i, podGpus := range podPlacements {
+				physicalPlacement[podGpuNum][i] = make(CellList, len(podGpus))
+				for j, gpu := range podGpus {
+					vGpu := gpu.(*VirtualCell)
+					pac := vGpu.GetPreAssignedCell()
+					preassignedPhysical := pac.GetPhysicalCell()
+					if preassignedPhysical == nil {
+						preassignedPhysical = pac.GetTmpPhysicalCell()
+					}
+					if preassignedPhysical == nil {
+						c := buddyAlloc(h.getTmpFreeCellList(sr.chain), pac.GetLevel())
+						if c == nil {
+							panic(fmt.Sprintf(
+								"Cannot find physical cell for a VC cell: %v", pac.GetName()))
+						} else {
+							preassignedPhysical = c
+							pac.SetTmpPhysicalCell(preassignedPhysical)
+							preassignedPhysical.SetTmpVirtualCell(pac)
+						}
+					}
+					physicalPlacement[podGpuNum][i][j] = mapNonPreassignedCellToPhysical(vGpu)
+				}
+			}
+		}
+		clearTmpBindings(vcPlacement)
+		return physicalPlacement, vcPlacement
+	}
+	return nil, nil
+}
+
+func (h *HivedAlgorithm) scheduleOpportunisticPods(sr schedulingRequest) map[int32][]CellList {
+	return h.opportunisticSchedulers[sr.chain].schedule(sr.podGpuNumbers, opportunisticPriority)
+}
+
+func (h *HivedAlgorithm) getTmpFreeCellList(chain CellChain) ChainCellList {
+	ccl := ChainCellList{}
+	for l := CellLevel(1); l <= CellLevel(len(h.freeCellList[chain])); l++ {
+		ccl[l] = make(CellList, len(h.freeCellList[chain][l]))
+		copy(ccl[l], h.freeCellList[chain][l])
+	}
+	return ccl
+}
+
+func (h *HivedAlgorithm) confirmAllocatedGpu(pc *PhysicalCell, vc *VirtualCell, p CellPriority) {
+	physicalPriority := p
+	if vc != nil {
+		preassignedNewlyBound := vc.GetPreAssignedCell().GetPhysicalCell() == nil
+		// create cell bindings
+		bindCells(pc, vc)
+		if preassignedNewlyBound {
+			// remove the allocated cell from the free list (possibly splitting cells)
+			h.removeCellFromFreeList(vc.GetPreAssignedCell().GetPhysicalCell())
+		}
+		vc.SetPriority(p)
+		updateUsedGpuNumAtPriority(vc, p, true)
+	} else {
+		physicalPriority = opportunisticPriority
+	}
+	pc.SetPriority(physicalPriority)
+	updateUsedGpuNumAtPriority(pc, physicalPriority, true)
+}
+
+func (h *HivedAlgorithm) confirmReleasedGpu(c *PhysicalCell) {
+	if vc := c.GetVirtualCell(); vc != nil {
+		preassignedPhysical := vc.GetPreAssignedCell().GetPhysicalCell()
+		// destroy cell bindings
+		unbindCells(c)
+		if vc.GetPreAssignedCell().GetPhysicalCell() == nil {
+			// add the released cell to the free list (possibly merging cells)
+			h.addCellToFreeList(preassignedPhysical)
+		}
+		updateUsedGpuNumAtPriority(vc, vc.GetPriority(), false)
+		vc.SetPriority(freePriority)
+	}
+	updateUsedGpuNumAtPriority(c, c.GetPriority(), false)
+	c.SetPriority(freePriority)
+}
+
+func (h *HivedAlgorithm) removeCellFromFreeList(c *PhysicalCell) {
+	chain := c.GetChain()
+	terminate := false
+	for {
+		l := c.GetLevel()
+		parent := c.GetParent()
+		if parent != nil {
+			pp := parent.(*PhysicalCell)
+			if pp.IsSplit() {
+				terminate = true
+			} else {
+				h.freeCellList[chain][l] = append(h.freeCellList[chain][l], pp.GetChildren()...)
+				pp.SetSplit(true)
+			}
 		} else {
-			for _, chains := range h.chains {
-				groupPhysical, groupVirtual, _ = h.requestGroupCellForGpuType(
-					cr, chains, getGroupCellSize(s.AffinityGroup))
-				if groupPhysical != nil {
+			terminate = true
+		}
+		h.freeCellList[chain].removeCell(c, l)
+		if terminate {
+			break
+		} else {
+			c = parent.(*PhysicalCell)
+		}
+	}
+}
+
+func (h *HivedAlgorithm) addCellToFreeList(c *PhysicalCell) {
+	chain := c.GetChain()
+	terminate := false
+	for {
+		l := c.GetLevel()
+		parent := c.GetParent()
+		if parent != nil {
+			allBuddyFree := true
+			for _, buddy := range parent.GetChildren() {
+				if buddy.(*PhysicalCell).GetVirtualCell() != nil {
+					allBuddyFree = false
 					break
 				}
 			}
-		}
-		if groupPhysical != nil {
-			klog.Infof("Allocated cell for group %v: %v", s.AffinityGroup.Name, groupPhysical.GetName())
-		} else {
-			klog.Infof("Cannot allocate cell for group %v", s.AffinityGroup.Name)
-		}
-	} else {
-		groupPhysical = group.cell
-		groupVirtual = groupPhysical.GetVirtualCell()
-	}
-	return groupPhysical, groupVirtual
-}
-
-// requestGroupCellForGpuType requests a group cell for a specific GPU type.
-func (h *HivedAlgorithm) requestGroupCellForGpuType(
-	cr CellRequest,
-	chains []CellChain,
-	gpuNum int32) (*PhysicalCell, *VirtualCell, bool) {
-
-	vcHasType := false
-	for _, chain := range chains {
-		if h.vcSchedulers[cr.VC].getNonReservedCellList()[chain] != nil {
-			vcHasType = true
-			cr.Chain = chain
-			if cr.Level = h.getLevelByGpuNum(gpuNum, chain); cr.Level >= lowestLevel {
-				if physicalCell, virtualCell := h.requestGroupCell(cr); physicalCell != nil {
-					return physicalCell, virtualCell, vcHasType
+			if !allBuddyFree {
+				terminate = true
+			} else {
+				for _, buddy := range parent.GetChildren() {
+					if buddy != c {
+						h.freeCellList[chain].removeCell(buddy, l)
+					}
 				}
+				parent.(*PhysicalCell).SetSplit(false)
 			}
-		}
-	}
-	return nil, nil, vcHasType
-}
-
-// validateCellRequest checks the existence of VC and reservation ID, and the legality of priority.
-// Cell chain and level has been guaranteed valid before requestGroupCell is called.
-func (h *HivedAlgorithm) validateCellRequest(cr CellRequest) {
-	var message string
-	if h.vcSchedulers[cr.VC] == nil {
-		message = fmt.Sprintf("VC %v does not exists!", cr.VC)
-	} else if cr.ReservationId != "" &&
-		h.vcSchedulers[cr.VC].getReservedCellList()[cr.ReservationId] == nil {
-		message = fmt.Sprintf("VC %v does not have reservation %v", cr.VC, cr.ReservationId)
-	} else if cr.Priority > highestPriority {
-		message = fmt.Sprintf("priority %v exceeds highest priority", cr.Priority)
-	}
-	if message != "" {
-		panic(internal.NewBadRequestError(message))
-	}
-}
-
-// requestGroupCell requests a new cell for an affinity group in the physical cluster.
-func (h *HivedAlgorithm) requestGroupCell(cr CellRequest) (*PhysicalCell, *VirtualCell) {
-	if cr.Priority >= regularPriority {
-		var vcCell *VirtualCell
-		vcCell = h.vcSchedulers[cr.VC].allocateCell(cr)
-		if vcCell != nil {
-			pac := vcCell.GetPreAssignedCell()
-
-			preassignedPhysical := pac.GetPhysicalCell()
-			// allocate physical cell for the preassigned cell
-			if preassignedPhysical == nil {
-				physicalCellView := getCellViewWithPriority(h.fullCellList[cr.Chain], regularPriority)
-				c := buddyAlloc(physicalCellView, pac.GetLevel())
-				if c == nil {
-					panic(fmt.Sprintf(
-						"Cannot find physical cell for a VC cell: %v", pac.GetName()))
-				} else {
-					preassignedPhysical = c.(*PhysicalCell)
-				}
-			}
-			return allocatePhysicalInsidePreassigned(preassignedPhysical, vcCell), vcCell
 		} else {
-			return nil, nil
+			terminate = true
 		}
-	} else {
-		physicalCellView := getCellViewWithPriority(h.fullCellList[cr.Chain], opportunisticPriority)
-		c := buddyAlloc(physicalCellView, cr.Level)
-		if c == nil {
-			klog.Infof(fmt.Sprintf(
-				"Insufficient resource for opportunistic cell request: chain %v, level %v", cr.Chain, cr.Level))
-			return nil, nil
+		if terminate {
+			h.freeCellList[chain][l] = append(h.freeCellList[chain][l], c)
+			break
 		} else {
-			return c.(*PhysicalCell), nil
+			c = parent.(*PhysicalCell)
 		}
 	}
 }
 
-// requestPodCell places a pod in an allocated group cell using buddy alloc.
-// TODO: collect preemption victims
-func (h *HivedAlgorithm) requestPodCell(s *api.PodSchedulingSpec, groupCell *PhysicalCell) *PhysicalCell {
-	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group != nil &&
-		group.unallocatedPodNums[s.GpuNumber] <= 0 {
-		panic(internal.NewBadRequestError(fmt.Sprintf(
-			"Requesting more pods than the configured number for %v GPUs in affinity group %v",
-			s.GpuNumber, s.AffinityGroup.Name)))
-	}
-	level := h.getLevelByGpuNum(getPodCellSize(s.GpuNumber), groupCell.GetChain())
-	if groupCell.internalCellList == nil {
-		groupCell.InitPhysicalCellList()
-	}
-	cellView := getCellViewForPodPlacement(groupCell.GetPhysicalCellList())
-	c := buddyAlloc(cellView, level)
-	if c == nil {
-		return nil
-	} else {
-		return c.(*PhysicalCell)
-	}
-}
-
-func (h *HivedAlgorithm) getLevelByGpuNum(gpuNum int32, chain CellChain) CellLevel {
-	for l := CellLevel(1); l <= CellLevel(len(h.gpuNums[chain])); l++ {
-		if h.gpuNums[chain][l] >= gpuNum {
-			return l
-		}
-	}
-	return unlimitedLevel
-}
-
-// findPhysicalCell finds a physical cell in the full list. This search is based on *one* node
+// findPhysicalGpu finds a physical GPU cell in the full list. This search is based on *one* node
 // and *one* GPU index, assuming there is no resource overlapping among cells at the same level.
-func (h *HivedAlgorithm) findPhysicalCell(
+func (h *HivedAlgorithm) findPhysicalGpu(
 	chain CellChain,
-	level CellLevel,
 	node string,
 	gpuIndex int32) *PhysicalCell {
 
-	for _, c := range h.fullCellList[chain][level] {
+	for _, c := range h.fullCellList[chain][1] {
 		success := false
 		cc := c.(*PhysicalCell)
 		nodes, gpuIndices := cc.GetPhysicalPlacement()
@@ -503,22 +547,21 @@ func (h *HivedAlgorithm) findPhysicalCell(
 	return nil
 }
 
-// findVirtualCell finds a virtual cell according to the index.
-func (h *HivedAlgorithm) findVirtualCell(
+// findVirtualGpu finds a virtual GPU cell according to the cell index.
+func (h *HivedAlgorithm) findVirtualGpu(
 	vc api.VirtualClusterName,
 	chain CellChain,
 	rid api.ReservationId,
-	level CellLevel,
 	index int32) *VirtualCell {
 
-	var searchList CellList
-	if rid == "" {
-		searchList = h.vcSchedulers[vc].getNonReservedCellList()[chain][level]
-	} else {
-		searchList = h.vcSchedulers[vc].getReservedCellList()[rid][level]
-	}
-
 	if index >= 0 {
+		var searchList CellList
+		if rid == "" {
+			searchList = h.vcSchedulers[vc].getNonReservedCellList()[chain][1]
+		} else {
+			searchList = h.vcSchedulers[vc].getReservedCellList()[rid][1]
+		}
+
 		for _, c := range searchList {
 			cc := c.(*VirtualCell)
 			if cc.GetIndex() == index {
@@ -529,164 +572,91 @@ func (h *HivedAlgorithm) findVirtualCell(
 	return nil
 }
 
-// confirmAllocatedCell confirms a cell allocation by creating cell bindings and setting priorities.
-func confirmAllocatedCell(physicalCell *PhysicalCell, virtualCell *VirtualCell, priority CellPriority) {
-	if virtualCell != nil {
-		// create cell bindings
-		pac := virtualCell.GetPreAssignedCell()
-		preassignedBound := pac.GetPhysicalCell() != nil
-		vc := virtualCell
-		pc := physicalCell
-		for vc.GetPhysicalCell() == nil {
-			vc.SetPhysicalCell(pc)
-			pc.SetVirtualCell(vc)
-			klog.Infof("Cells bound: %v and %v", vc.GetName(), pc.GetName())
-			if vc.GetParent() == nil {
-				break
-			}
-			vc = vc.GetParent().(*VirtualCell)
-			pc = pc.GetParent().(*PhysicalCell)
-		}
+func generatePodScheduleResult(
+	groupPhysicalPlacement map[int32][]CellList,
+	groupVcPlacement map[int32][]CellList,
+	podIndex int32,
+	suggestedNodes []string,
+	pod *core.Pod,
+	newGroup bool) internal.PodScheduleResult {
 
-		// set priority
-		setPriority(virtualCell, priority, unlimitedLevel)
-		// first hold the physical cell of the preassigned (set its priority to regularPriority)
-		if !preassignedBound {
-			setPriority(pac.GetPhysicalCell(), regularPriority, unlimitedLevel)
-		}
-		// set the priority of the physical cell to regularNonPreassignedPriority
-		// so that other cells inside the preassigned one can still be used by opportunistic pods
-		if virtualCell != pac {
-			setSelfAndParentPriority(physicalCell, regularNonPreassignedPriority, unlimitedLevel)
+	if groupPhysicalPlacement == nil {
+		return internal.PodScheduleResult{
+			PodWaitInfo: &internal.PodWaitInfo{
+				FailedNodeReasons: map[string]string{},
+			},
 		}
 	} else {
-		setPriority(physicalCell, opportunisticPriority, unlimitedLevel)
-	}
-}
-
-// confirmReleasedCell releases an allocated cell by destroying cell bindings and reset priorities.
-func confirmReleasedCell(c *PhysicalCell) {
-	var preassignedPhysical *PhysicalCell
-	if vc := c.GetVirtualCell(); vc != nil {
-		// destroy bindings
-		boundVirtual := vc
-		for !boundVirtual.GetPhysicalCell().IsReserved() {
-			boundPhysical := boundVirtual.GetPhysicalCell()
-			klog.Infof("Cells unbound: %v and %v", boundVirtual.GetName(), boundPhysical.GetName())
-			boundPhysical.SetVirtualCell(nil)
-			boundVirtual.SetPhysicalCell(nil)
-			if boundVirtual.GetParent() == nil {
-				break
-			} else {
-				unbindParent := true
-				for _, cc := range boundVirtual.GetParent().GetChildren() {
-					if child := cc.(*VirtualCell); child.GetPhysicalCell() != nil {
-						unbindParent = false
-						break
+		var (
+			selectedNode       string
+			selectedGpuIndices []int32
+			chain              string
+		)
+		preemptionVictims := common.NewSet()
+		gsi := make([]api.GroupMemberScheduleInfo, len(groupPhysicalPlacement))
+		groupMemberIndex := 0
+		for podGpuNum, podPhysicalPlacements := range groupPhysicalPlacement {
+			gms := api.GroupMemberScheduleInfo{
+				GpuNumber:     podGpuNum,
+				PodPlacements: make([]api.PodPlacementInfo, len(podPhysicalPlacements)),
+			}
+			for i := int32(0); i < int32(len(podPhysicalPlacements)); i++ {
+				gms.PodPlacements[i].PhysicalGpuIndices = make(
+					[]int32, len(podPhysicalPlacements[i]))
+				gms.PodPlacements[i].VirtualGpuCellIndices = make(
+					[]int32, len(podPhysicalPlacements[i]))
+				for j := 0; j < len(podPhysicalPlacements[i]); j++ {
+					pGpu := podPhysicalPlacements[i][j].(*PhysicalCell)
+					nodes, gpuIndices := pGpu.GetPhysicalPlacement()
+					gms.PodPlacements[i].PhysicalNode = nodes[0]
+					gms.PodPlacements[i].PhysicalGpuIndices[j] = gpuIndices[0]
+					if newGroup && pGpu.HasPod() {
+						preemptionVictims.Add(pGpu.GetPods()[0])
+					}
+					if groupVcPlacement != nil {
+						vGpu := groupVcPlacement[podGpuNum][i][j].(*VirtualCell)
+						gms.PodPlacements[i].VirtualGpuCellIndices[j] = vGpu.GetIndex()
+					} else {
+						gms.PodPlacements[i].VirtualGpuCellIndices[j] = -1
 					}
 				}
-				if !unbindParent {
-					break
+				if i == podIndex {
+					selectedNode = gms.PodPlacements[i].PhysicalNode
+					selectedGpuIndices = gms.PodPlacements[i].PhysicalGpuIndices
+					chain = string(podPhysicalPlacements[i][0].GetChain())
 				}
-				boundVirtual = boundVirtual.GetParent().(*VirtualCell)
 			}
+			gsi[groupMemberIndex] = gms
+			groupMemberIndex++
 		}
-		// reset priority
-		setSelfAndParentPriority(vc, freePriority, unlimitedLevel)
-		preassignedPhysical = vc.GetPreAssignedCell().GetPhysicalCell()
-	} else {
-		// check if the cell is inside a physical cell of a preassigned virtual cell
-		for cc := c; ; {
-			if boundVirtual := cc.GetVirtualCell(); boundVirtual != nil {
-				preassignedPhysical = boundVirtual.GetPreAssignedCell().GetPhysicalCell()
-				break
-			}
-			if cc.GetParent() != nil {
-				cc = cc.GetParent().(*PhysicalCell)
-			} else {
-				break
-			}
+		if !common.StringsContains(suggestedNodes, selectedNode) {
+			panic(fmt.Sprintf("[%v]: node %v picked by algorithm but not in K8S candidates",
+				internal.Key(pod), selectedNode))
 		}
-	}
-	// if preassignedPhysical is not released, should not change its priority
-	if preassignedPhysical != nil {
-		setSelfAndParentPriority(c, freePriority, preassignedPhysical.GetLevel())
-	} else {
-		setSelfAndParentPriority(c, freePriority, unlimitedLevel)
-	}
-}
-
-// allocatePhysicalInsidePreassigned allocates a physical cell to a virtual cell (possible split from a
-// preassigned one) according to the cell topology in the preassigned virtual cell.
-func allocatePhysicalInsidePreassigned(preassignedPhysical *PhysicalCell, vcCell *VirtualCell) *PhysicalCell {
-	// traverse the cell hierarchy to find the highest-level virtual cell
-	// that has not been bound to any physical cell
-	var boundCell *PhysicalCell
-	for c := vcCell; ; {
-		if c.GetPhysicalCell() != nil {
-			boundCell = c.GetPhysicalCell()
-			break
-		} else if c == vcCell.preAssignedCell {
-			break
+		if preemptionVictims.IsEmpty() {
+			klog.Infof("[%v]: scheduled to node %v, GPUs %v",
+				internal.Key(pod), selectedNode, selectedGpuIndices)
+			return internal.PodScheduleResult{
+				PodBindInfo: &api.PodBindInfo{
+					Node:              selectedNode,
+					GpuIsolation:      selectedGpuIndices,
+					CellChain:         chain,
+					GroupScheduleInfo: gsi,
+				},
+			}
 		} else {
-			c = c.GetParent().(*VirtualCell)
-		}
-	}
-	if boundCell == nil {
-		boundCell = preassignedPhysical
-	}
-
-	for boundCell.GetLevel() > vcCell.GetLevel() {
-		boundCell = selectCellFromBuddies(boundCell.GetChildren()).(*PhysicalCell)
-	}
-	if boundCell.GetPriority() > opportunisticPriority {
-		panic(fmt.Sprintf("Cannot find physical cell for %v", vcCell.GetName()))
-	}
-	return boundCell
-}
-
-// getCellViewWithPriority returns a free cell list of a chain given a priority.
-// A cell will be invisible if it is with a equal-or-higher priority, or all of its buddies and itself
-// are with lower priorities. In the latter case, all of the buddies are masked and effectively "merged".
-func getCellViewWithPriority(fullCellList ChainCellList, p CellPriority) ChainCellList {
-	top := CellLevel(len(fullCellList))
-	cellView := NewChainCellList(top)
-	for l := CellLevel(1); l <= top; l++ {
-		for _, c := range fullCellList[l] {
-			if c.GetPriority() < p &&
-				(c.GetParent() == nil || maxPriority(c.GetParent().GetChildren()) >= p) {
-				cellView[l] = append(cellView[l], c)
+			return internal.PodScheduleResult{
+				PodPreemptInfo: &internal.PodPreemptInfo{},
 			}
 		}
 	}
-	return cellView
-}
-
-// getCellViewForPodPlacement returns a free cell list inside a physical cell,
-// where a cell is free if it has no pod running (on itself or its children).
-// Similar to getCellViewWithPriority, buddy cells that are all free will be invisible ("merged").
-// This function is used for pod placement with buddy alloc.
-func getCellViewForPodPlacement(fullCellList ChainCellList) ChainCellList {
-	top := CellLevel(len(fullCellList))
-	cellView := NewChainCellList(top)
-	for l := CellLevel(1); l <= top; l++ {
-		for _, c := range fullCellList[l] {
-			cc := c.(*PhysicalCell)
-			if !cc.HasPod() {
-				if p := cc.GetParent(); p == nil || l == top || p.(*PhysicalCell).HasPod() {
-					cellView[l] = append(cellView[l], cc)
-				}
-			}
-		}
-	}
-	return cellView
 }
 
 // buddyAlloc allocates a free cell at a certain level from a cellView.
 // It splits a higher-level cell when there is no free cell at the current level.
 // Note that cellView is one-off: we will calculate it every time we call this function
 // (except recursive calls from it self). So we won't remove a returned cell from cellView.
-func buddyAlloc(cellView ChainCellList, level CellLevel) Cell {
+func buddyAlloc(cellView ChainCellList, level CellLevel) *PhysicalCell {
 	if len(cellView[level]) == 0 && level < CellLevel(len(cellView)) {
 		higherCell := buddyAlloc(cellView, level+1)
 		if higherCell != nil {
@@ -696,75 +666,107 @@ func buddyAlloc(cellView ChainCellList, level CellLevel) Cell {
 	if len(cellView[level]) == 0 {
 		return nil
 	}
-	return minPriorityCell(cellView[level])
+	return minOpportunisticCell(cellView[level])
 }
 
-func getGroupCellSize(a *api.AffinityGroup) int32 {
-	n := int32(0)
-	for _, m := range a.Members {
-		n += common.NextPowerOf2(m.GpuNumber) * m.PodNumber
-	}
-	return common.NextPowerOf2(n)
-}
-
-func getPodCellSize(n int32) int32 {
-	return common.NextPowerOf2(n)
-}
-
-func selectCellFromBuddies(cl []Cell) Cell {
-	return minPriorityCell(cl)
-}
-
-func maxPriority(cl CellList) CellPriority {
-	mp := freePriority
+func minOpportunisticCell(cl CellList) *PhysicalCell {
+	mo := int32(math.MaxInt32)
+	var moc *PhysicalCell
 	for _, c := range cl {
-		if c.GetPriority() > mp {
-			mp = c.GetPriority()
+		if pc := c.(*PhysicalCell); pc.GetVirtualCell() == nil && pc.GetTmpVirtualCell() == nil &&
+			pc.GetUsedGpuNumAtPriority(opportunisticPriority) < mo {
+			mo = pc.GetUsedGpuNumAtPriority(opportunisticPriority)
+			moc = pc
 		}
 	}
-	return mp
+	return moc
 }
 
-func minPriorityCell(cl CellList) Cell {
-	mp := highestPriority + 1
-	var mpc Cell
-	for _, c := range cl {
-		if c.GetPriority() < mp {
-			mp = c.GetPriority()
-			mpc = c
+// mapNonPreassignedCellToPhysical allocates a physical cell to a virtual cell (possibly split from a
+// preassigned one) according to the cell topology in the preassigned virtual cell.
+func mapNonPreassignedCellToPhysical(c *VirtualCell) *PhysicalCell {
+	if c.GetPhysicalCell() != nil {
+		return c.GetPhysicalCell()
+	} else if c.GetTmpPhysicalCell() != nil {
+		return c.GetTmpPhysicalCell()
+	} else {
+		parentPhysical := mapNonPreassignedCellToPhysical(c.GetParent().(*VirtualCell))
+		pc := minOpportunisticCell(parentPhysical.GetChildren())
+		if pc == nil || pc.GetPriority() > opportunisticPriority {
+			panic(fmt.Sprintf("Cannot find physical cell for %v", c.GetName()))
+		}
+		c.SetTmpPhysicalCell(pc)
+		pc.SetTmpVirtualCell(c)
+		return pc
+	}
+}
+
+func clearTmpBindings(vcPlacement map[int32][]CellList) {
+	for _, podPlacements := range vcPlacement {
+		for _, podGpus := range podPlacements {
+			for _, gpu := range podGpus {
+				for gpu != nil {
+					vGpu := gpu.(*VirtualCell)
+					if pGpu := vGpu.GetTmpPhysicalCell(); pGpu != nil {
+						pGpu.SetTmpVirtualCell(nil)
+						vGpu.SetTmpPhysicalCell(nil)
+						gpu = gpu.GetParent()
+					} else {
+						break
+					}
+				}
+			}
 		}
 	}
-	return mpc
 }
 
-func setPriority(c Cell, p CellPriority, maxLevel CellLevel) {
-	setSelfAndParentPriority(c, p, maxLevel)
-	setChildrenPriority(c, freePriority)
-}
-
-// setSelfAndParentPriority updates a cell's priority, and also that of its parent
-// to make sure parent's priority is not smaller than the max of those of children.
-// This operation will terminate after reaching a certain level (if specified).
-func setSelfAndParentPriority(c Cell, p CellPriority, maxLevel CellLevel) {
-	if maxLevel >= lowestLevel && c.GetLevel() >= maxLevel {
-		return
+func bindCells(pc *PhysicalCell, vc *VirtualCell) {
+	for vc.GetPhysicalCell() == nil {
+		vc.SetPhysicalCell(pc)
+		pc.SetVirtualCell(vc)
+		klog.Infof("Cells bound: %v and %v", vc.GetName(), pc.GetName())
+		if vc.GetParent() == nil {
+			break
+		}
+		vc = vc.GetParent().(*VirtualCell)
+		pc = pc.GetParent().(*PhysicalCell)
 	}
-	op := c.GetPriority()
-	c.SetPriority(p)
-	if parent := c.GetParent(); parent != nil {
-		if p > parent.GetPriority() {
-			setSelfAndParentPriority(parent, p, maxLevel)
-		} else if p < op {
-			setSelfAndParentPriority(parent, maxPriority(parent.GetChildren()), maxLevel)
+}
+
+func unbindCells(c *PhysicalCell) {
+	boundVirtual := c.GetVirtualCell()
+	for !boundVirtual.GetPhysicalCell().IsReserved() {
+		boundPhysical := boundVirtual.GetPhysicalCell()
+		klog.Infof("Cells unbound: %v and %v", boundVirtual.GetName(), boundPhysical.GetName())
+		boundPhysical.SetVirtualCell(nil)
+		boundVirtual.SetPhysicalCell(nil)
+		if boundVirtual.GetParent() == nil {
+			break
+		} else {
+			unbindParent := true
+			for _, cc := range boundVirtual.GetParent().GetChildren() {
+				if child := cc.(*VirtualCell); child.GetPhysicalCell() != nil {
+					unbindParent = false
+					break
+				}
+			}
+			if !unbindParent {
+				break
+			}
+			boundVirtual = boundVirtual.GetParent().(*VirtualCell)
 		}
 	}
 }
 
-// setChildrenPriority sets all children's priorities. Currently we always set to freePriority;
-// this is to enable allocation of child cells of a preassigned cell to opportunistic pods.
-func setChildrenPriority(c Cell, p CellPriority) {
-	for _, child := range c.GetChildren() {
-		child.SetPriority(p)
-		setChildrenPriority(child, p)
+func updateUsedGpuNumAtPriority(c Cell, p CellPriority, increase bool) {
+	for c != nil {
+		if increase {
+			c.IncreaseUsedGpuNumAtPriority(p, 1)
+			c.IncreaseFreeGpuNum(-1)
+		} else {
+			c.IncreaseUsedGpuNumAtPriority(p, -1)
+			c.IncreaseFreeGpuNum(1)
+		}
+		c = c.GetParent()
 	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -117,7 +117,7 @@ func (h *HivedAlgorithm) Schedule(pod *core.Pod, suggestedNodes []string) intern
 		}
 		klog.Infof("Pod from existing affinity group: %v", s.AffinityGroup.Name)
 		groupPhysicalPlacement = h.allocatedAffinityGroups[s.AffinityGroup.Name].physicalGpuPlacement
-		groupVcPlacement = h.allocatedAffinityGroups[s.AffinityGroup.Name].vcGpuPlacement
+		groupVcPlacement = h.allocatedAffinityGroups[s.AffinityGroup.Name].virtualGpuPlacement
 		podIndex = h.allocatedAffinityGroups[s.AffinityGroup.Name].unallocatedPodNums[s.GpuNumber] - 1
 	}
 	return generatePodScheduleResult(
@@ -139,11 +139,11 @@ func (h *HivedAlgorithm) AddAllocatedPod(pod *core.Pod) {
 		for _, gms := range info.AffinityGroupBindInfo {
 			gpuNumber := int32(len(gms.PodPlacements[0].PhysicalGpuIndices))
 			newGroup.physicalGpuPlacement[gpuNumber] = make([]CellList, len(gms.PodPlacements))
-			newGroup.vcGpuPlacement[gpuNumber] = make([]CellList, len(gms.PodPlacements))
+			newGroup.virtualGpuPlacement[gpuNumber] = make([]CellList, len(gms.PodPlacements))
 			for i := int32(0); i < int32(len(gms.PodPlacements)); i++ {
 				newGroup.physicalGpuPlacement[gpuNumber][i] = make(
 					CellList, len(gms.PodPlacements[i].PhysicalGpuIndices))
-				newGroup.vcGpuPlacement[gpuNumber][i] = make(
+				newGroup.virtualGpuPlacement[gpuNumber][i] = make(
 					CellList, len(gms.PodPlacements[i].PhysicalGpuIndices))
 				node := gms.PodPlacements[i].PhysicalNode
 				for j := int32(0); j < int32(len(gms.PodPlacements[i].PhysicalGpuIndices)); j++ {
@@ -161,7 +161,7 @@ func (h *HivedAlgorithm) AddAllocatedPod(pod *core.Pod) {
 							internal.Key(pod), virtualCellIndex))
 					}
 					newGroup.physicalGpuPlacement[gpuNumber][i][j] = pGpu
-					newGroup.vcGpuPlacement[gpuNumber][i][j] = vGpu
+					newGroup.virtualGpuPlacement[gpuNumber][i][j] = vGpu
 					h.confirmAllocatedGpu(pGpu, vGpu, CellPriority(s.Priority))
 				}
 			}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -560,7 +560,7 @@ func (h *HivedAlgorithm) addCellToFreeList(c *PhysicalCell) {
 				terminate = true
 			} else {
 				for _, buddy := range parent.GetChildren() {
-					if buddy != c {
+					if !CellEqual(buddy, c) {
 						h.freeCellList[chain].remove(buddy, l)
 					}
 				}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -604,7 +604,7 @@ func (h *HivedAlgorithm) findVirtualGpu(
 func generatePodScheduleResult(
 	groupPhysicalPlacement map[int32][]CellList,
 	groupVcPlacement map[int32][]CellList,
-	podIndex int32,
+	schedulePodIndex int32,
 	suggestedNodes []string,
 	pod *core.Pod,
 	newGroup bool) internal.PodScheduleResult {
@@ -650,7 +650,7 @@ func generatePodScheduleResult(
 						gms.PodPlacements[podIndex].VirtualCellIndices[gpuIndex] = -1
 					}
 				}
-				if podIndex == podIndex {
+				if podIndex == schedulePodIndex {
 					selectedNode = gms.PodPlacements[podIndex].PhysicalNode
 					selectedGpuIndices = gms.PodPlacements[podIndex].PhysicalGpuIndices
 					chain = string(podPhysicalPlacements[podIndex][0].GetChain())

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -148,36 +148,36 @@ var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, p
 	},
 }
 
-var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10 = &api.AffinityGroup{
+var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10 = &api.AffinityGroupSpec{
 	Name:    "group1",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 1}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
 	Name:    "group2",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 1}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
 	Name:    "group3",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 8}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 8}},
+}, &api.AffinityGroupSpec{
 	Name:    "group4",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 1}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
 	Name:    "group5",
-	Members: []api.AffinityGroupMember{{PodNumber: 2, GpuNumber: 1}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
 	Name:    "group6",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 1}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
 	Name:    "group7",
-	Members: []api.AffinityGroupMember{{PodNumber: 3, GpuNumber: 8}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 3, GpuNumber: 8}},
+}, &api.AffinityGroupSpec{
 	Name:    "group8",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 8}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 8}},
+}, &api.AffinityGroupSpec{
 	Name:    "group9",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 1}},
-}, &api.AffinityGroup{
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
 	Name:    "group10",
-	Members: []api.AffinityGroupMember{{PodNumber: 1, GpuNumber: 1}},
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
 }
 
 var pss = map[types.UID]api.PodSchedulingSpec{
@@ -316,7 +316,7 @@ func TestHivedAlgorithm(t *testing.T) {
 	for _, chains := range h.chains {
 		sortChains(chains)
 	}
-	printConfig(t, h)
+	//printConfig(t, h)
 
 	testCasesThatShouldSucceed(t, h)
 	testCasesThatShouldFail(t, h)

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -174,7 +174,7 @@ var group1, group2, group3, group4, group5, group6, group7, group8, group9, grou
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 8}},
 }, &api.AffinityGroupSpec{
 	Name:    "group9",
-	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 7}},
 }, &api.AffinityGroupSpec{
 	Name:    "group10",
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
@@ -235,7 +235,7 @@ var pss = map[types.UID]api.PodSchedulingSpec{
 		Priority:       1,
 		ReservationId:  "",
 		GpuType:        "",
-		GpuNumber:      1,
+		GpuNumber:      7,
 		AffinityGroup:  group9,
 	}, "pod9": { // use a GPU type that the VC does not have; should panic BadRequest
 		VirtualCluster: "VC2",
@@ -302,7 +302,7 @@ var expectedResult = map[*core.Pod]result{
 	pod4: {node: "0.0.5.0", gpuIsolation: []int32{0}},
 	pod5: {node: "0.0.3.0", gpuIsolation: []int32{1}},
 	pod6: {node: "0.0.3.0", gpuIsolation: []int32{0}},
-	pod8: {node: "1.0.0.2", gpuIsolation: []int32{0}},
+	pod8: {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
 }
 
 var allocatedPods []*core.Pod
@@ -316,14 +316,13 @@ func TestHivedAlgorithm(t *testing.T) {
 	for _, chains := range h.chains {
 		sortChains(chains)
 	}
-	//printConfig(t, h)
 
+	printConfig(t, h)
 	testCasesThatShouldSucceed(t, h)
 	testCasesThatShouldFail(t, h)
 	for i := len(allocatedPods) - 1; i >= 0; i-- {
 		h.DeleteAllocatedPod(allocatedPods[i])
 	}
-
 	testInvalidInitialAssignment(t, sConfig)
 }
 

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -351,9 +351,9 @@ var expectedBindInfos = map[*core.Pod]result{
 	pod9: {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4}},
 }
 
-var expectedPreemptInfos = map[*core.Pod][]string{
-	pod16: {"pod5", "pod6"},
-	pod17: {"pod5", "pod6"},
+var expectedPreemptInfos = map[*core.Pod]common.Set{
+	pod16: common.NewSet("pod5", "pod6"),
+	pod17: common.NewSet("pod5", "pod6"),
 }
 
 var allocatedPods []*core.Pod
@@ -443,10 +443,10 @@ func compareGpuIsolation(a []int32, b []int32) bool {
 	return false
 }
 
-func comparePods(a []*core.Pod, b []string) bool {
-	if len(a) == len(b) {
-		for i := 0; i < len(a); i++ {
-			if a[i].Name != b[i] {
+func comparePods(a []*core.Pod, b common.Set) bool {
+	if len(a) == len(b.Items()) {
+		for _, p := range a {
+			if !b.Contains(p.Name) {
 				return false
 			}
 		}
@@ -461,7 +461,7 @@ func compareSchedulingResult(t *testing.T, pod *core.Pod, psr internal.PodSchedu
 			t.Errorf("[%v]: wrong pod scheduling result: expected empty, but got %v:%v",
 				internal.Key(pod), psr.PodBindInfo.Node, psr.PodBindInfo.GpuIsolation)
 		}
-		if expectedPreemptInfos[pod] != nil && !comparePods(psr.PodPreemptInfo.VictimPods, expectedPreemptInfos[pod]) {
+		if !expectedPreemptInfos[pod].IsEmpty() && !comparePods(psr.PodPreemptInfo.VictimPods, expectedPreemptInfos[pod]) {
 			t.Errorf("[%v]: wrong preempt victims: expected %v, but got %v",
 				internal.Key(pod), expectedPreemptInfos[pod], psr.PodPreemptInfo.VictimPods)
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -48,7 +48,7 @@ func initNodes(h *HivedAlgorithm) {
 	}
 }
 
-var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, pod13, pod14 = &core.Pod{
+var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, pod13, pod14, pod15, pod16, pod17 = &core.Pod{
 	ObjectMeta: meta.ObjectMeta{
 		Name:        "pod1",
 		Namespace:   "test",
@@ -146,9 +146,30 @@ var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, p
 		UID:         "pod14",
 		Annotations: map[string]string{},
 	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod15",
+		Namespace:   "test",
+		UID:         "pod15",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod16",
+		Namespace:   "test",
+		UID:         "pod16",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod17",
+		Namespace:   "test",
+		UID:         "pod17",
+		Annotations: map[string]string{},
+	},
 }
 
-var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10 = &api.AffinityGroupSpec{
+var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10, group11 = &api.AffinityGroupSpec{
 	Name:    "group1",
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
 }, &api.AffinityGroupSpec{
@@ -162,7 +183,7 @@ var group1, group2, group3, group4, group5, group6, group7, group8, group9, grou
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
 }, &api.AffinityGroupSpec{
 	Name:    "group5",
-	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 1}},
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 16}},
 }, &api.AffinityGroupSpec{
 	Name:    "group6",
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
@@ -174,10 +195,13 @@ var group1, group2, group3, group4, group5, group6, group7, group8, group9, grou
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 8}},
 }, &api.AffinityGroupSpec{
 	Name:    "group9",
-	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 7}},
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 7}, {PodNumber: 1, GpuNumber: 5}},
 }, &api.AffinityGroupSpec{
 	Name:    "group10",
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
+}, &api.AffinityGroupSpec{
+	Name:    "group11",
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 16}},
 }
 
 var pss = map[types.UID]api.PodSchedulingSpec{
@@ -214,14 +238,14 @@ var pss = map[types.UID]api.PodSchedulingSpec{
 		Priority:       1,
 		ReservationId:  "VC1-YQW-DGX2",
 		GpuType:        "DGX2-V100",
-		GpuNumber:      1,
+		GpuNumber:      16,
 		AffinityGroup:  group5,
 	}, "pod6": { // use reservation
 		VirtualCluster: "VC1",
 		Priority:       1,
 		ReservationId:  "VC1-YQW-DGX2",
 		GpuType:        "DGX2-V100",
-		GpuNumber:      1,
+		GpuNumber:      16,
 		AffinityGroup:  group5,
 	}, "pod7": { // out of quota; should return PodWaitInfo
 		VirtualCluster: "VC2",
@@ -230,64 +254,85 @@ var pss = map[types.UID]api.PodSchedulingSpec{
 		GpuType:        "DGX1-P100",
 		GpuNumber:      8,
 		AffinityGroup:  group7,
-	}, "pod8": { // any GPU type
+	}, "pod8": { // any GPU type; heterogeneous affinity group
 		VirtualCluster: "VC2",
 		Priority:       1,
 		ReservationId:  "",
 		GpuType:        "",
 		GpuNumber:      7,
 		AffinityGroup:  group9,
-	}, "pod9": { // use a GPU type that the VC does not have; should panic BadRequest
+	}, "pod9": { // any GPU type; heterogeneous affinity group
+		VirtualCluster: "VC2",
+		Priority:       1,
+		ReservationId:  "",
+		GpuType:        "",
+		GpuNumber:      5,
+		AffinityGroup:  group9,
+	}, "pod10": { // use a GPU type that the VC does not have; should panic BadRequest
 		VirtualCluster: "VC2",
 		Priority:       1,
 		ReservationId:  "",
 		GpuType:        "DGX2-V100",
 		GpuNumber:      1,
 		AffinityGroup:  group6,
-	}, "pod10": { // invalid affinity group configuration
-		VirtualCluster: "VC2",
-		Priority:       1,
-		ReservationId:  "",
-		GpuType:        "DGX1-P100",
-		GpuNumber:      8,
-		AffinityGroup:  group8,
 	}, "pod11": { // invalid affinity group configuration
 		VirtualCluster: "VC2",
 		Priority:       1,
 		ReservationId:  "",
 		GpuType:        "DGX1-P100",
-		GpuNumber:      8,
+		GpuNumber:      2,
 		AffinityGroup:  group8,
-	}, "pod12": { // invalid VC
+	}, "pod12": { // invalid affinity group configuration
+		VirtualCluster: "VC2",
+		Priority:       1,
+		ReservationId:  "",
+		GpuType:        "DGX1-P100",
+		GpuNumber:      2,
+		AffinityGroup:  group8,
+	}, "pod13": { // invalid VC
 		VirtualCluster: "surprise!",
 		Priority:       1,
 		ReservationId:  "",
 		GpuType:        "DGX1-P100",
 		GpuNumber:      1,
 		AffinityGroup:  group10,
-	}, "pod13": { // invalid reservation
+	}, "pod14": { // invalid reservation
 		VirtualCluster: "VC2",
 		Priority:       1,
 		ReservationId:  "surprise!",
 		GpuType:        "DGX1-P100",
 		GpuNumber:      1,
 		AffinityGroup:  group10,
-	}, "pod14": { // invalid priority
+	}, "pod15": { // invalid priority
 		VirtualCluster: "VC2",
 		Priority:       1001,
 		ReservationId:  "",
 		GpuType:        "DGX1-P100",
 		GpuNumber:      1,
 		AffinityGroup:  group10,
+	}, "pod16": { // trigger preemption
+		VirtualCluster: "VC1",
+		Priority:       2,
+		ReservationId:  "VC1-YQW-DGX2",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group11,
+	}, "pod17": { // trigger preemption
+		VirtualCluster: "VC1",
+		Priority:       2,
+		ReservationId:  "VC1-YQW-DGX2",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group11,
 	},
 }
 
 var casesThatShouldSucceed = []*core.Pod{
-	pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8,
+	pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod16, pod17,
 }
 
 var casesThatShouldFail = [][]*core.Pod{
-	{pod9}, {pod10, pod11}, {pod12}, {pod13}, {pod14},
+	{pod10}, {pod11, pod12}, {pod13}, {pod14}, {pod15},
 }
 
 type result struct {
@@ -295,14 +340,20 @@ type result struct {
 	gpuIsolation []int32
 }
 
-var expectedResult = map[*core.Pod]result{
+var expectedBindInfos = map[*core.Pod]result{
 	pod1: {node: "0.0.1.0", gpuIsolation: []int32{0}},
 	pod2: {node: "0.0.1.0", gpuIsolation: []int32{1}},
 	pod3: {node: "0.0.1.0", gpuIsolation: []int32{8, 9, 10, 11, 12, 13, 14, 15}},
 	pod4: {node: "0.0.5.0", gpuIsolation: []int32{0}},
-	pod5: {node: "0.0.3.0", gpuIsolation: []int32{1}},
-	pod6: {node: "0.0.3.0", gpuIsolation: []int32{0}},
-	pod8: {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
+	pod5: {node: "0.0.3.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod6: {node: "0.0.3.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod8: {node: "1.0.0.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
+	pod9: {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4}},
+}
+
+var expectedPreemptInfos = map[*core.Pod][]string{
+	pod16: {"pod5", "pod6"},
+	pod17: {"pod5", "pod6"},
 }
 
 var allocatedPods []*core.Pod
@@ -392,16 +443,31 @@ func compareGpuIsolation(a []int32, b []int32) bool {
 	return false
 }
 
+func comparePods(a []*core.Pod, b []string) bool {
+	if len(a) == len(b) {
+		for i := 0; i < len(a); i++ {
+			if a[i].Name != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 func compareSchedulingResult(t *testing.T, pod *core.Pod, psr internal.PodScheduleResult) {
-	expected := expectedResult[pod]
-	if expected.node == "" {
+	if expected := expectedBindInfos[pod]; expected.node == "" {
 		if psr.PodBindInfo != nil {
 			t.Errorf("[%v]: wrong pod scheduling result: expected empty, but got %v:%v",
 				internal.Key(pod), psr.PodBindInfo.Node, psr.PodBindInfo.GpuIsolation)
 		}
+		if expectedPreemptInfos[pod] != nil && !comparePods(psr.PodPreemptInfo.VictimPods, expectedPreemptInfos[pod]) {
+			t.Errorf("[%v]: wrong preempt victims: expected %v, but got %v",
+				internal.Key(pod), expectedPreemptInfos[pod], psr.PodPreemptInfo.VictimPods)
+		}
 	} else if psr.PodBindInfo.Node != expected.node ||
 		!compareGpuIsolation(psr.PodBindInfo.GpuIsolation, expected.gpuIsolation) {
-		t.Errorf("[%v]: wrong pod scheduling result: expected %v:%v, but got %v:%v",
+		t.Errorf("[%v]: wrong pod bind info: expected %v:%v, but got %v:%v",
 			internal.Key(pod), expected.node, expected.gpuIsolation, psr.PodBindInfo.Node, psr.PodBindInfo.GpuIsolation)
 	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -28,24 +28,22 @@ import (
 	"k8s.io/klog"
 )
 
-// intraVCScheduler is an interface for allocating cells inside a VC.
-// It stores two maps of ChainCellList, one for reserved cells, the other
-// for non-reserved ones. It should be able to return a virtual cell
-// on receiving a cell request.
+// intraVCScheduler is an interface for scheduling pods inside a VC.
+// It stores two maps of ChainCellList, one for reserved cells, the other for non-reserved ones.
+// It should be able to return a set of GPU placements in the VC for a scheduling request.
 type intraVCScheduler interface {
 	getNonReservedCellList() map[CellChain]ChainCellList
 	getReservedCellList() map[api.ReservationId]ChainCellList
 
-	// Scheduling a series of pods inside a VC. We use topologyAwareScheduler by default
-	// (see defaultIntraVCScheduler).
+	// Scheduling a series of pods inside a VC. We use topologyAwareScheduler by default.
 	schedule(schedulingRequest) map[int32][]CellList
 }
 
 type defaultIntraVCScheduler struct {
 	virtualNonReservedCellList map[CellChain]ChainCellList
 	virtualReservedCellList    map[api.ReservationId]ChainCellList
-	schedulersNonReserved                  map[CellChain]*topologyAwareScheduler
-	schedulersReserved map[api.ReservationId]*topologyAwareScheduler
+	schedulersNonReserved      map[CellChain]*topologyAwareScheduler
+	schedulersReserved         map[api.ReservationId]*topologyAwareScheduler
 }
 
 func newDefaultIntraVCScheduler(

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -42,8 +42,11 @@ type intraVCScheduler interface {
 type defaultIntraVCScheduler struct {
 	virtualNonReservedCellList map[CellChain]ChainCellList
 	virtualReservedCellList    map[api.ReservationId]ChainCellList
-	nonReservedSchedulers      map[CellChain]*topologyAwareScheduler
-	reservedSchedulers         map[api.ReservationId]*topologyAwareScheduler
+	// currently we create a topologyAwareScheduler for each cluster view (each chain, each reservation).
+	// we plan to support multiple cluster views in one scheduler, and to support schedule pods
+	// across different cluster views.
+	nonReservedSchedulers map[CellChain]*topologyAwareScheduler
+	reservedSchedulers    map[api.ReservationId]*topologyAwareScheduler
 }
 
 func newDefaultIntraVCScheduler(
@@ -85,7 +88,7 @@ func (s *defaultIntraVCScheduler) schedule(sr schedulingRequest) map[int32][]Cel
 	if scheduler != nil {
 		result = scheduler.Schedule(sr.affinityGroup, sr.priority)
 	}
-	if scheduler == nil || result == nil {
+	if result == nil {
 		var str string
 		if sr.reservationId != "" {
 			str = fmt.Sprintf("reservation %v", sr.reservationId)

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -51,15 +51,16 @@ type defaultIntraVCScheduler struct {
 
 func newDefaultIntraVCScheduler(
 	nonReservedVcl map[CellChain]ChainCellList,
-	reservedVcl map[api.ReservationId]ChainCellList) *defaultIntraVCScheduler {
+	reservedVcl map[api.ReservationId]ChainCellList,
+	gpuNums map[CellChain]map[CellLevel]int32) *defaultIntraVCScheduler {
 
 	snr := map[CellChain]*topologyAwareScheduler{}
 	sr := map[api.ReservationId]*topologyAwareScheduler{}
 	for chain, ccl := range nonReservedVcl {
-		snr[chain] = NewTopologyAwareScheduler(ccl, true)
+		snr[chain] = NewTopologyAwareScheduler(ccl, gpuNums[chain], true)
 	}
 	for rid, ccl := range reservedVcl {
-		sr[rid] = NewTopologyAwareScheduler(ccl, true)
+		sr[rid] = NewTopologyAwareScheduler(ccl, gpuNums[ccl[CellLevel(1)][0].GetChain()], true)
 	}
 	return &defaultIntraVCScheduler{
 		virtualNonReservedCellList: nonReservedVcl,

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -36,14 +36,36 @@ type intraVCScheduler interface {
 	getNonReservedCellList() map[CellChain]ChainCellList
 	getReservedCellList() map[api.ReservationId]ChainCellList
 
-	// Cell allocation inside a VC. We use buddy alloc for default
+	// Scheduling a series of pods inside a VC. We use topologyAwareScheduler by default
 	// (see defaultIntraVCScheduler).
-	allocateCell(CellRequest) *VirtualCell
+	schedule(schedulingRequest) map[int32][]CellList
 }
 
 type defaultIntraVCScheduler struct {
 	virtualNonReservedCellList map[CellChain]ChainCellList
 	virtualReservedCellList    map[api.ReservationId]ChainCellList
+	schedulersNonReserved                  map[CellChain]*topologyAwareScheduler
+	schedulersReserved map[api.ReservationId]*topologyAwareScheduler
+}
+
+func newDefaultIntraVCScheduler(
+	nonReservedVcl map[CellChain]ChainCellList,
+	reservedVcl map[api.ReservationId]ChainCellList) *defaultIntraVCScheduler {
+
+	snr := map[CellChain]*topologyAwareScheduler{}
+	sr := map[api.ReservationId]*topologyAwareScheduler{}
+	for chain, ccl := range nonReservedVcl {
+		snr[chain] = newTopologyAwareScheduler(ccl, true)
+	}
+	for rid, ccl := range reservedVcl {
+		sr[rid] = newTopologyAwareScheduler(ccl, true)
+	}
+	return &defaultIntraVCScheduler{
+		virtualNonReservedCellList: nonReservedVcl,
+		virtualReservedCellList:    reservedVcl,
+		schedulersNonReserved:      snr,
+		schedulersReserved:         sr,
+	}
 }
 
 func (s *defaultIntraVCScheduler) getNonReservedCellList() map[CellChain]ChainCellList {
@@ -54,27 +76,27 @@ func (s *defaultIntraVCScheduler) getReservedCellList() map[api.ReservationId]Ch
 	return s.virtualReservedCellList
 }
 
-func (s *defaultIntraVCScheduler) allocateCell(cr CellRequest) *VirtualCell {
-	var fullCellList ChainCellList
-	if cr.ReservationId != "" {
-		fullCellList = s.virtualReservedCellList[cr.ReservationId]
+func (s *defaultIntraVCScheduler) schedule(sr schedulingRequest) map[int32][]CellList {
+	var scheduler *topologyAwareScheduler
+	if sr.reservationId != "" {
+		scheduler = s.schedulersReserved[sr.reservationId]
 	} else {
-		fullCellList = s.virtualNonReservedCellList[cr.Chain]
+		scheduler = s.schedulersNonReserved[sr.chain]
 	}
-
-	vcCellView := getCellViewWithPriority(fullCellList, cr.Priority)
-	c := buddyAlloc(vcCellView, cr.Level)
-	if c != nil {
-		return c.(*VirtualCell) // downgrade pod running on c
-	} else {
+	var result map[int32][]CellList
+	if scheduler != nil {
+		result = scheduler.schedule(sr.podGpuNumbers, sr.priority)
+	}
+	if scheduler == nil || result == nil {
 		var str string
-		if cr.ReservationId != "" {
-			str = fmt.Sprintf("reservation %v", cr.ReservationId)
+		if sr.reservationId != "" {
+			str = fmt.Sprintf("reservation %v", sr.reservationId)
 		} else {
-			str = fmt.Sprintf("chain %v", cr.Chain)
+			str = fmt.Sprintf("chain %v", sr.chain)
 		}
-		klog.Infof("Insufficient quota in VC %v for cell request: %v, level %v, priority %v",
-			cr.VC, str, cr.Level, cr.Priority)
-		return nil
+		klog.Infof("Insufficient quota in VC %v for scheduling request: %v, GPU numbers %v, priority %v",
+			sr.vc, str, sr.podGpuNumbers, sr.priority)
 	}
+	klog.Infof("%v", result)
+	return result
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -84,11 +84,11 @@ func (s *defaultIntraVCScheduler) schedule(sr schedulingRequest) map[int32][]Cel
 	} else {
 		scheduler = s.nonReservedSchedulers[sr.chain]
 	}
-	var result map[int32][]CellList
+	var placement map[int32][]CellList
 	if scheduler != nil {
-		result = scheduler.Schedule(sr.affinityGroup, sr.priority)
+		placement = scheduler.Schedule(sr.affinityGroup, sr.priority)
 	}
-	if result == nil {
+	if placement == nil {
 		var str string
 		if sr.reservationId != "" {
 			str = fmt.Sprintf("reservation %v", sr.reservationId)
@@ -98,5 +98,5 @@ func (s *defaultIntraVCScheduler) schedule(sr schedulingRequest) map[int32][]Cel
 		klog.Infof("Insufficient quota in VC %v for scheduling request: %v, GPU numbers %v, priority %v",
 			sr.vc, str, sr.affinityGroup, sr.priority)
 	}
-	return result
+	return placement
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -1,0 +1,292 @@
+// MIT License
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE
+
+package algorithm
+
+import (
+	"fmt"
+	"github.com/microsoft/hivedscheduler/pkg/common"
+	"sort"
+)
+
+type topologyAwareScheduler struct {
+	clusterView              CellList
+	podGpuNumbers            []int32
+	currentSolutionIndices   []int32
+	currentLCA               CellList
+	lowestLCASolution        CellList
+	lowestLCASolutionIndices []int32
+	lowestLCALevel           CellLevel
+	crossPriorityPack        bool
+}
+
+func newTopologyAwareScheduler(ccl ChainCellList, crossPriorityPack bool) *topologyAwareScheduler {
+	var l CellLevel
+	for l = CellLevel(1); l <= CellLevel(len(ccl)); l++ {
+		if ccl[l][0].AtOrHigherThanNode() {
+			break
+		}
+	}
+	clusterView := make(CellList, len(ccl[l]))
+	copy(clusterView, ccl[l])
+	cellSets := common.NewSet()
+	for ; l > CellLevel(1); l-- {
+		for _, c := range ccl[l-1] {
+			if r := findRootCell(c); r.GetLevel() < l {
+				cellSets.Add(r)
+			}
+		}
+	}
+	for item := range cellSets.Items() {
+		c := item.(Cell)
+		clusterView = append(clusterView, c)
+	}
+	return &topologyAwareScheduler{
+		clusterView:clusterView,
+		crossPriorityPack: crossPriorityPack}
+}
+
+func findRootCell(c Cell) Cell {
+	for c.GetParent() != nil {
+		c = c.GetParent()
+	}
+	return c
+}
+
+func (t *topologyAwareScheduler) schedule(
+	podGpuNumbers map[int32]int32,
+	p CellPriority) map[int32][]CellList {
+
+	t.podGpuNumbers = []int32{}
+	for gpuNum, podNum := range podGpuNumbers {
+		for i := int32(0); i < podNum; i++ {
+			t.podGpuNumbers = append(t.podGpuNumbers, gpuNum)
+		}
+	}
+	sortGpuNumbers(t.podGpuNumbers)
+	priority := opportunisticPriority
+	t.updateClusterView(priority)
+	success := t.findNodesForPods(priority)
+	if !success && p > opportunisticPriority {
+		priority = p
+		t.updateClusterView(priority)
+		success = t.findNodesForPods(priority)
+	}
+	if success {
+		selectedNodes := make(CellList, len(t.podGpuNumbers))
+		for i := 0; i < len(t.currentSolutionIndices); i++ {
+			selectedNodes[i] = t.clusterView[t.currentSolutionIndices[i]]
+		}
+		nodeGpus := map[Cell]CellList{}
+		podPlacements := map[int32][]CellList{}
+		for podIndex := 0; podIndex < len(t.podGpuNumbers); podIndex++ {
+			gpuNumber := t.podGpuNumbers[podIndex]
+			node := selectedNodes[podIndex]
+			nodeGpus[node] = t.findGpusInNode(node, gpuNumber, priority, nodeGpus[node])
+			if podPlacements[gpuNumber] == nil {
+				podPlacements[gpuNumber] = []CellList{}
+			}
+			podPlacements[gpuNumber] = append(podPlacements[gpuNumber], t.lowestLCASolution)
+		}
+		return podPlacements
+	}
+	return nil
+}
+
+func (t *topologyAwareScheduler) findNodesForPods(p CellPriority) bool {
+	sort.Sort(t.clusterView)
+	t.currentSolutionIndices = make([]int32, len(t.podGpuNumbers))
+	podIndex := 0
+	pickedGpuNum := int32(0)
+	var node Cell
+	for nodeIndex := 0; nodeIndex < len(t.clusterView); {
+		node = t.clusterView[nodeIndex]
+		if node.GetFreeGpuNumForPriority(p) - pickedGpuNum >= t.podGpuNumbers[podIndex] {
+			t.currentSolutionIndices[podIndex] = int32(nodeIndex)
+			pickedGpuNum += t.podGpuNumbers[podIndex]
+			podIndex++
+			if podIndex == len(t.podGpuNumbers) {
+				return true
+			}
+		} else {
+			pickedGpuNum = 0
+			nodeIndex++
+		}
+	}
+	return false
+}
+
+func (t *topologyAwareScheduler) findGpusInNode(
+	node Cell,
+	gpuNumber int32,
+	p CellPriority,
+	availableGpus CellList) CellList {
+
+	t.currentSolutionIndices = make([]int32, gpuNumber)
+	t.currentLCA = make(CellList, gpuNumber)
+	t.lowestLCASolution = make(CellList, gpuNumber)
+	t.lowestLCASolutionIndices = make([]int32, gpuNumber)
+	t.lowestLCALevel = highestLevel
+
+	if availableGpus == nil {
+		availableGpus = CellList{}
+		preemptibleGpus := CellList{}
+		availableGpus, preemptibleGpus = getGpusFromNode(node, p, availableGpus, preemptibleGpus)
+		availableGpus = append(availableGpus, preemptibleGpus...)
+	}
+	availableGpuIndex := int32(0)
+	searchGpuIndex := int32(0)
+	var gpu Cell
+	for {
+		for availableGpuIndex < int32(len(availableGpus)) {
+			gpu = availableGpus[availableGpuIndex]
+			t.currentSolutionIndices[searchGpuIndex] = availableGpuIndex
+			if searchGpuIndex == 0 {
+				t.currentLCA[searchGpuIndex] = gpu
+			} else {
+				t.currentLCA[searchGpuIndex] = findLCA(gpu, t.currentLCA[searchGpuIndex-1])
+				if (t.currentLCA[searchGpuIndex] == nil && t.lowestLCALevel < highestLevel) ||
+					(t.currentLCA[searchGpuIndex].GetLevel() > t.lowestLCALevel) {
+					availableGpuIndex++
+					continue
+				}
+			}
+			if searchGpuIndex == gpuNumber-1 {
+				if t.checkCurrentGpus(availableGpus) {
+					availableGpus = t.removePickedGpus(availableGpus)
+					return availableGpus
+				}
+			} else {
+				searchGpuIndex++
+			}
+			availableGpuIndex++
+		}
+		searchGpuIndex--
+		if searchGpuIndex < 0 {
+			if t.lowestLCALevel == highestLevel {
+				panic(fmt.Sprintf("failed to allocate %v GPUs in picked node %v", gpuNumber, node.GetName()))
+			}
+			availableGpus = t.removePickedGpus(availableGpus)
+			return availableGpus
+		}
+		availableGpuIndex = t.currentSolutionIndices[searchGpuIndex] + 1
+	}
+}
+
+func (t *topologyAwareScheduler) checkCurrentGpus(gpus CellList) bool {
+	currentLCALevel := t.currentLCA[len(t.currentLCA)-1].GetLevel()
+	if currentLCALevel < t.lowestLCALevel {
+		copy(t.lowestLCASolutionIndices, t.currentSolutionIndices)
+		for i := 0; i < len(t.currentSolutionIndices); i++ {
+			t.lowestLCASolution[i] = gpus[t.currentSolutionIndices[i]]
+		}
+		t.lowestLCALevel = currentLCALevel
+		if t.lowestLCALevel == t.lowestLCASolution[0].GetLevel() + 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *topologyAwareScheduler) removePickedGpus(gpus CellList) CellList {
+	for i, index := range t.lowestLCASolutionIndices {
+		offset := int32(i)
+		if i < len(t.lowestLCASolutionIndices)-1 {
+			nextIndex := t.lowestLCASolutionIndices[i+1]
+			copy(gpus[index-offset:nextIndex-offset-1], gpus[index+1:nextIndex])
+		} else {
+			copy(gpus[index-offset:], gpus[index+1:])
+		}
+	}
+	return gpus[:len(gpus)-len(t.currentSolutionIndices)]
+}
+
+func sortGpuNumbers(n []int32) {
+	tmp := make([]int, len(n))
+	for i := 0; i < len(n); i++ {
+		tmp[i] = int(n[i])
+	}
+	sort.Ints(tmp)
+	for i := 0; i < len(tmp); i++ {
+		n[i] = int32(tmp[i])
+	}
+}
+
+func findLCA(lower Cell, higher Cell) Cell {
+	for lower.GetLevel() < higher.GetLevel() {
+		if lower.GetParent() == nil {
+			return nil
+		}
+		lower = lower.GetParent()
+	}
+	if lower == higher {
+		return lower
+	}
+	for lower.GetParent() != higher.GetParent() {
+		if lower.GetParent() == nil || higher.GetParent() == nil {
+			return nil
+		}
+		lower = lower.GetParent()
+		higher = higher.GetParent()
+	}
+	return lower.GetParent()
+}
+
+func (t *topologyAwareScheduler) updateClusterView(p CellPriority) {
+	for _, c := range t.clusterView {
+		if t.crossPriorityPack {
+			c.SetUsedGpuNumAllPriority(p)
+		} else {
+			c.SetUsedGpuNumForPriority(p)
+		}
+	}
+}
+
+func (t *topologyAwareScheduler) getNodeViewFromCells(ccl ChainCellList, p CellPriority) CellList {
+	var l CellLevel
+	for l = CellLevel(1); l <= CellLevel(len(ccl)); l++ {
+		if ccl[l][0].AtOrHigherThanNode() {
+			break
+		}
+	}
+	for _, c := range ccl[l] {
+		if t.crossPriorityPack {
+			c.SetUsedGpuNumAllPriority(p)
+		} else {
+			c.SetUsedGpuNumForPriority(p)
+		}
+	}
+	return ccl[l]
+}
+
+func getGpusFromNode(c Cell, p CellPriority, freeGpus CellList, preemptibleGpus CellList) (CellList, CellList) {
+	if c.GetLevel() > 1 {
+		for _, cc := range c.GetChildren() {
+			freeGpus, preemptibleGpus = getGpusFromNode(cc, p, freeGpus, preemptibleGpus)
+		}
+	} else if c.GetPriority() == freePriority {
+		freeGpus = append(freeGpus, c)
+	} else if c.GetPriority() < p {
+		preemptibleGpus = append(preemptibleGpus, c)
+	}
+	return freeGpus, preemptibleGpus
+}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -24,12 +24,13 @@ package algorithm
 
 import (
 	"fmt"
+	"github.com/microsoft/hivedscheduler/pkg/common"
 	"sort"
 )
 
 // topologyAwareScheduler can schedule a set of pods on a cluster view.
-// It tries to place pods to nodes with fewer free GPUs (i.e., packing), while trying to avoid preemptions.
-// Inside each node, it tries to allocate GPUs with better affinity.
+// It first tries to place pods to nodes with fewer free GPUs (i.e., packing), while trying to avoid preemptions.
+// Then inside each node, it tries to allocate GPUs with better affinity.
 type topologyAwareScheduler struct {
 	// a list of node level cells (top level cells that are lower than node level will be treated as nodes)
 	clusterView CellList
@@ -69,7 +70,7 @@ func (t *topologyAwareScheduler) Schedule(
 			sortedPodGpuNumbers = append(sortedPodGpuNumbers, gpuNum)
 		}
 	}
-	sortGpuNumbers(sortedPodGpuNumbers)
+	common.SortInt32(sortedPodGpuNumbers)
 
 	// disable preemption first (reduce preemption)
 	priority := opportunisticPriority
@@ -243,17 +244,6 @@ func removePickedGpus(gpus CellList, indices []int32) CellList {
 		}
 	}
 	return gpus[:len(gpus)-len(indices)]
-}
-
-func sortGpuNumbers(n []int32) {
-	tmp := make([]int, len(n))
-	for i := 0; i < len(n); i++ {
-		tmp[i] = int(n[i])
-	}
-	sort.Ints(tmp)
-	for i := 0; i < len(tmp); i++ {
-		n[i] = int32(tmp[i])
-	}
 }
 
 // findLCA finds the lowest common ancestor of two cells (nil if they have no LCA).

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -254,10 +254,10 @@ func findLCA(lower Cell, higher Cell) Cell {
 		}
 		lower = lower.GetParent()
 	}
-	if lower == higher {
+	if lower.GetName() == higher.GetName() {
 		return lower
 	}
-	for lower.GetParent() != higher.GetParent() {
+	for lower.GetParent().GetName() != higher.GetParent().GetName() {
 		if lower.GetParent() == nil || higher.GetParent() == nil {
 			return nil
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -254,10 +254,10 @@ func findLCA(lower Cell, higher Cell) Cell {
 		}
 		lower = lower.GetParent()
 	}
-	if lower.GetName() == higher.GetName() {
+	if CellEqual(lower, higher) {
 		return lower
 	}
-	for lower.GetParent().GetName() != higher.GetParent().GetName() {
+	for !CellEqual(lower, higher) {
 		if lower.GetParent() == nil || higher.GetParent() == nil {
 			return nil
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -283,12 +283,12 @@ func (t *topologyAwareScheduler) updateClusterView(p CellPriority) {
 		if t.crossPriorityPack {
 			// if crossPriorityPack is enabled, set c.usedGpuNumSamePriority as the total number of used GPUs
 			// in the cell, so that a pod will be packed to the node with the most used GPUs
-			c.SetUsedGpuNumAllPriority(p)
+			c.UpdateUsedGpuNumAllPriority(p)
 		} else {
 			// otherwise set c.usedGpuNumSamePriority as the number of GPUs used by the same priority, and
 			// c.usedGpuNumLowerPriority as that of the lower priorities, so that a pod will be packed to the node
 			// with the most GPUs used by the same priority, and the fewest GPUs used by the lower priorities.
-			c.SetUsedGpuNumForPriority(p)
+			c.UpdateUsedGpuNumForPriority(p)
 		}
 	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -64,7 +64,7 @@ func (t *topologyAwareScheduler) Schedule(
 	p CellPriority) map[int32][]CellList {
 
 	// GPU numbers of the pods to schedule
-	sortedPodGpuNumbers := []int32{}
+	var sortedPodGpuNumbers []int32
 	for gpuNum, podNum := range podGpuNumbers {
 		for i := int32(0); i < podNum; i++ {
 			sortedPodGpuNumbers = append(sortedPodGpuNumbers, gpuNum)
@@ -110,7 +110,7 @@ func (t *topologyAwareScheduler) Schedule(
 func findNodesForPods(clusterView CellList, n []int32, p CellPriority) []int32 {
 	// sort the nodes according to gpu numbers in each node.
 	// this is achieved through the Less method defined in type CellList.
-	sort.Sort(clusterView)
+	sort.Stable(clusterView)
 	currentNodeIndices := make([]int32, len(n)) // indices of the currently picked nodes
 	podIndex := 0
 	pickedGpuNum := int32(0)

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -276,7 +276,7 @@ func (t *topologyAwareScheduler) updateClusterView(p CellPriority) {
 			c.UpdateUsedGpuNumAllPriority(p)
 		} else {
 			// otherwise set c.usedGpuNumSamePriority as the number of GPUs used by the same priority, and
-			// c.usedGpuNumLowerPriority as that of the lower priorities, so that a pod will be packed to the node
+			// c.usedGpuNumHigherPriority as that of the higher priorities, so that a pod will be packed to the node
 			// with the most GPUs used by the same priority, and the fewest GPUs used by the lower priorities.
 			c.UpdateUsedGpuNumForPriority(p)
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -77,28 +77,6 @@ func (cl CellList) remove(c Cell) CellList {
 	return cl[:length-1]
 }
 
-// Methods for sorting cells in a CellList.
-// Note that this sorting logic is used only by topologyAwareScheduler.
-func (cl CellList) Len() int {
-	return len(cl)
-}
-
-func (cl CellList) Less(i int, j int) bool {
-	if cl[i].GetUsedGpuNumSamePriority() > cl[j].GetUsedGpuNumSamePriority() {
-		return true
-	} else if cl[i].GetUsedGpuNumSamePriority() < cl[j].GetUsedGpuNumSamePriority() {
-		return false
-	} else if cl[i].GetUsedGpuNumHigherPriority() < cl[j].GetUsedGpuNumHigherPriority() {
-		return true
-	} else {
-		return false
-	}
-}
-
-func (cl CellList) Swap(i int, j int) {
-	cl[i], cl[j] = cl[j], cl[i]
-}
-
 // ChainCellList maps each level in a chain to a CellList.
 type ChainCellList map[CellLevel]CellList
 

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -126,7 +126,7 @@ type AlgoAffinityGroup struct {
 	cell                 *PhysicalCell
 	unallocatedPodNums   map[int32]int32      // GpuNum -> PodNum
 	physicalGpuPlacement map[int32][]CellList // GpuNum -> a list of pods -> a list of physical GPUs of each pod
-	vcGpuPlacement       map[int32][]CellList // GpuNum -> a list of pods -> a list of virtual GPUs of each pod
+	virtualGpuPlacement  map[int32][]CellList // GpuNum -> a list of pods -> a list of virtual GPUs of each pod
 }
 
 func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
@@ -137,6 +137,6 @@ func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
 	return &AlgoAffinityGroup{
 		unallocatedPodNums:   numPods,
 		physicalGpuPlacement: map[int32][]CellList{},
-		vcGpuPlacement:       map[int32][]CellList{},
+		virtualGpuPlacement:  map[int32][]CellList{},
 	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -61,10 +61,8 @@ func (cl CellList) String() string {
 
 func (cl CellList) remove(c Cell) CellList {
 	index := -1
-	// note that the cell is removed by reference. if you create a clone of the cell,
-	// the cloned one cannot be removed the CellList.
 	for i, cc := range cl {
-		if cc == c {
+		if cc.GetName() == c.GetName() {
 			index = i
 			break
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -60,6 +60,8 @@ func (cl CellList) String() string {
 
 func (cl CellList) remove(c Cell) CellList {
 	index := -1
+	// note that the cell is removed by reference. if you create a clone of the cell,
+	// the cloned one cannot be removed the CellList.
 	for i, cc := range cl {
 		if cc == c {
 			index = i
@@ -87,7 +89,7 @@ func (cl CellList) Less(i int, j int) bool {
 		return true
 	} else if cl[i].GetUsedGpuNumSamePriority() < cl[j].GetUsedGpuNumSamePriority() {
 		return false
-	} else if cl[i].GetUsedGpuNumOtherPriority() < cl[j].GetUsedGpuNumOtherPriority() {
+	} else if cl[i].GetUsedGpuNumHigherPriority() < cl[j].GetUsedGpuNumHigherPriority() {
 		return true
 	} else {
 		return false
@@ -122,6 +124,7 @@ func (ccl ChainCellList) remove(c Cell, l CellLevel) {
 	klog.Infof("Cell removed from cell list: %v", c.GetName())
 }
 
+// AlgoAffinityGroup is the algorithm-internal representation of an affinity group.
 type AlgoAffinityGroup struct {
 	cell                 *PhysicalCell
 	unallocatedPodNums   map[int32]int32      // GpuNum -> PodNum

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -43,14 +43,6 @@ type schedulingRequest struct {
 	priority      CellPriority
 }
 
-type CellRequest struct {
-	VC            api.VirtualClusterName
-	ReservationId api.ReservationId
-	Chain         CellChain
-	Level         CellLevel
-	Priority      CellPriority
-}
-
 // CellList is a list of cells at a certain level of a chain.
 type CellList []Cell
 
@@ -130,9 +122,9 @@ func (ccl ChainCellList) removeCell(c Cell, l CellLevel) {
 
 type AlgoAffinityGroup struct {
 	cell                 *PhysicalCell
-	unallocatedPodNums   map[int32]int32 // GpuNum -> PodNum
-	physicalGpuPlacement map[int32][]CellList
-	vcGpuPlacement       map[int32][]CellList
+	unallocatedPodNums   map[int32]int32      // GpuNum -> PodNum
+	physicalGpuPlacement map[int32][]CellList // GpuNum -> a list of pods -> a list of GPUs of each pod
+	vcGpuPlacement       map[int32][]CellList // same as above
 }
 
 func newAlgoAffinityGroup(g *api.AffinityGroup) *AlgoAffinityGroup {
@@ -141,8 +133,8 @@ func newAlgoAffinityGroup(g *api.AffinityGroup) *AlgoAffinityGroup {
 		numPods[m.GpuNumber] += m.PodNumber
 	}
 	return &AlgoAffinityGroup{
-		unallocatedPodNums: numPods,
+		unallocatedPodNums:   numPods,
 		physicalGpuPlacement: map[int32][]CellList{},
-		vcGpuPlacement: map[int32][]CellList{},
+		vcGpuPlacement:       map[int32][]CellList{},
 	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -62,7 +62,7 @@ func (cl CellList) String() string {
 func (cl CellList) remove(c Cell) CellList {
 	index := -1
 	for i, cc := range cl {
-		if cc.GetName() == c.GetName() {
+		if CellEqual(cc, c) {
 			index = i
 			break
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
@@ -96,15 +96,20 @@ type PodBindInfo struct {
 	// The node to bind
 	Node string `yaml:"node"`
 	// The GPUs to bind
-	GpuIsolation          []int32  `yaml:"gpuIsolation"`
-	CellChain             string   `yaml:"cellChain"`
-	PodCellLevel          int32    `yaml:"podCellLevel"`
-	PodCellGpuPlacement   Range    `yaml:"podCellGpuRange"`
-	GroupCellLevel        int32    `yaml:"groupCellLevel"`
-	GroupCellNodes        []string `yaml:"groupCellNodes"`
-	GroupCellGpuPlacement Range    `yaml:"groupCellGpuRange"`
-	VirtualCellLevel      int32    `yaml:"virtualCellLevel"`
-	VirtualCellIndex      int32    `yaml:"virtualCellIndex"`
+	GpuIsolation      []int32                   `yaml:"gpuIsolation"`
+	CellChain         string                    `yaml:"cellChain"`
+	GroupScheduleInfo []GroupMemberScheduleInfo `yaml:"groupScheduleInfo"`
+}
+
+type GroupMemberScheduleInfo struct {
+	GpuNumber int32                  `yaml:"gpuNumber"`
+	PodPlacements []PodPlacementInfo `yaml:"podPlacements"`
+}
+
+type PodPlacementInfo struct {
+	PhysicalNode          string  `yaml:"physicalNodes"`
+	PhysicalGpuIndices    []int32 `yaml:"physicalGpuIndices"`
+	VirtualGpuCellIndices []int32 `yaml:"virtualGpuCellIndices"`
 }
 
 type Range struct {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
@@ -102,7 +102,7 @@ type PodBindInfo struct {
 }
 
 type GroupMemberScheduleInfo struct {
-	GpuNumber int32                  `yaml:"gpuNumber"`
+	GpuNumber     int32              `yaml:"gpuNumber"`
 	PodPlacements []PodPlacementInfo `yaml:"podPlacements"`
 }
 

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
@@ -78,15 +78,15 @@ type PodSchedulingSpec struct {
 	ReservationId  ReservationId      `yaml:"reservationId"`
 	GpuType        string             `yaml:"gpuType"`
 	GpuNumber      int32              `yaml:"gpuNumber"`
-	AffinityGroup  *AffinityGroup     `yaml:"affinityGroup"`
+	AffinityGroup  *AffinityGroupSpec `yaml:"affinityGroup"`
 }
 
-type AffinityGroup struct {
-	Name    string                `yaml:"name"`
-	Members []AffinityGroupMember `yaml:"members"`
+type AffinityGroupSpec struct {
+	Name    string                    `yaml:"name"`
+	Members []AffinityGroupMemberSpec `yaml:"members"`
 }
 
-type AffinityGroupMember struct {
+type AffinityGroupMemberSpec struct {
 	PodNumber int32 `yaml:"podNumber"`
 	GpuNumber int32 `yaml:"gpuNumber"`
 }
@@ -96,25 +96,19 @@ type PodBindInfo struct {
 	// The node to bind
 	Node string `yaml:"node"`
 	// The GPUs to bind
-	GpuIsolation      []int32                   `yaml:"gpuIsolation"`
-	CellChain         string                    `yaml:"cellChain"`
-	GroupScheduleInfo []GroupMemberScheduleInfo `yaml:"groupScheduleInfo"`
+	GpuIsolation          []int32                       `yaml:"gpuIsolation"`
+	CellChain             string                        `yaml:"cellChain"`
+	AffinityGroupBindInfo []AffinityGroupMemberBindInfo `yaml:"affinityGroupBindInfo"`
 }
 
-type GroupMemberScheduleInfo struct {
-	GpuNumber     int32              `yaml:"gpuNumber"`
+type AffinityGroupMemberBindInfo struct {
 	PodPlacements []PodPlacementInfo `yaml:"podPlacements"`
 }
 
 type PodPlacementInfo struct {
-	PhysicalNode          string  `yaml:"physicalNodes"`
-	PhysicalGpuIndices    []int32 `yaml:"physicalGpuIndices"`
-	VirtualGpuCellIndices []int32 `yaml:"virtualGpuCellIndices"`
-}
-
-type Range struct {
-	Start int32 // included
-	End   int32 // included
+	PhysicalNode       string  `yaml:"physicalNode"`
+	PhysicalGpuIndices []int32 `yaml:"physicalGpuIndices"`
+	VirtualCellIndices []int32 `yaml:"virtualCellIndices"`
 }
 
 type WebServerPaths struct {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/types.go
@@ -41,6 +41,10 @@ func NewSet(items ...T) Set {
 	return s
 }
 
+func (s Set) Items() map[T]Empty {
+	return s.items
+}
+
 func (s Set) Contains(item T) bool {
 	_, exists := s.items[item]
 	return exists
@@ -54,6 +58,10 @@ func (s Set) Add(item T) Set {
 func (s Set) Delete(item T) Set {
 	delete(s.items, item)
 	return s
+}
+
+func (s Set) IsEmpty() bool {
+	return len(s.items) == 0
 }
 
 type ImmutableSet struct {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/types.go
@@ -60,6 +60,10 @@ func (s Set) IsEmpty() bool {
 	return len(s.items) == 0
 }
 
+func (s Set) Items() map[T]Empty {
+	return s.items
+}
+
 type ImmutableSet struct {
 	set Set
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/types.go
@@ -41,10 +41,6 @@ func NewSet(items ...T) Set {
 	return s
 }
 
-func (s Set) Items() map[T]Empty {
-	return s.items
-}
-
 func (s Set) Contains(item T) bool {
 	_, exists := s.items[item]
 	return exists

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/utils.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/common/utils.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -231,18 +232,6 @@ func StringsContains(s []string, e string) bool {
 	return false
 }
 
-func NextPowerOf2(i int32) int32 {
-	u := uint32(i)
-	u--
-	u |= u >> 1
-	u |= u >> 2
-	u |= u >> 4
-	u |= u >> 8
-	u |= u >> 16
-	u++
-	return int32(u)
-}
-
 func Int32ToString(i int32) string {
 	s := strconv.FormatInt(int64(i), 10)
 	return s
@@ -254,4 +243,15 @@ func StringToInt32(s string) int32 {
 		panic(fmt.Sprintf("invalid literal for int32: %v", err))
 	}
 	return int32(i)
+}
+
+func SortInt32(n []int32) {
+	tmp := make([]int, len(n))
+	for i := 0; i < len(n); i++ {
+		tmp[i] = int(n[i])
+	}
+	sort.Ints(tmp)
+	for i := 0; i < len(tmp); i++ {
+		n[i] = int32(tmp[i])
+	}
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
@@ -173,7 +173,9 @@ type PodPreemptInfo struct {
 	// Need to ensure the newly added victim Pods are eventually added to here,
 	// otherwise, the preemption will never complete.
 	// It can be empty, such as current preemptor Pod is waiting for the victim Pods
-	// of other preemptor Pods to be preempted.
+	// of other preemptor Pods in the same group to be preempted.
+	// It can contain victim Pods across multiple nodes, such as a victim group may
+	// contain Pods across multiple nodes.
 	VictimPods []*core.Pod
 }
 

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
@@ -167,8 +167,7 @@ type PodWaitInfo struct {
 
 // No need to use it recover scheduler preempting resource
 type PodPreemptInfo struct {
-	// Including all victim Pods in the victim cell, although the default scheduler
-	// will only preempt victims on one node.
+	// Only need to include the victim Pods for the current preemptor Pod.
 	// Need to ensure the newly deleted victim Pods are eventually removed from here,
 	// otherwise, the default scheduler refuse to execute any preemption.
 	// Need to ensure the newly added victim Pods are eventually added to here,

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
@@ -172,6 +172,8 @@ type PodPreemptInfo struct {
 	// otherwise, the default scheduler refuse to execute any preemption.
 	// Need to ensure the newly added victim Pods are eventually added to here,
 	// otherwise, the preemption will never complete.
+	// It can be empty, such as current preemptor Pod is waiting for the victim Pods
+	// of other preemptor Pods to be preempted.
 	VictimPods []*core.Pod
 }
 

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/utils.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/utils.go
@@ -214,9 +214,9 @@ func ExtractPodSchedulingSpec(pod *core.Pod) *si.PodSchedulingSpec {
 
 	// Defaulting
 	if podSchedulingSpec.AffinityGroup == nil {
-		podSchedulingSpec.AffinityGroup = &si.AffinityGroup{
+		podSchedulingSpec.AffinityGroup = &si.AffinityGroupSpec{
 			Name: Key(pod),
-			Members: []si.AffinityGroupMember{{
+			Members: []si.AffinityGroupMemberSpec{{
 				PodNumber: 1,
 				GpuNumber: podSchedulingSpec.GpuNumber},
 			},


### PR DESCRIPTION
- In-VC scheduling no longer relies on cells (and buddy alloc).
- Wrote a topology-aware scheduling algorithm, which is used for in-VC scheduling and opportunistic pod scheduling.
- Cell priority mechanism simplified: only keeps a free cell list for the physical cluster for regular pod scheduling, and a full cell list for opportunistic pod scheduling. They are decoupled now.