### PR TITLE
Increase container log max size and keep single log file

### DIFF
--- a/deployment/k8sPaiLibrary/template/docker-daemon.json.template
+++ b/deployment/k8sPaiLibrary/template/docker-daemon.json.template
@@ -1,8 +1,8 @@
 {
   "log-driver": "json-file",
   "log-opts": {
-    "max-size": "100m",
-    "max-file": "10"
+    "max-size": "2g",
+    "max-file": "1"
   },
   "data-root": "{{ hostcofig["docker-data"] }}",
   "runtimes": {


### PR DESCRIPTION
Because K8S does not recognize multiple rotated files yet