### PR TITLE
[Rest Server] Add node selector for user jobs in k8s

### DIFF
--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -412,9 +412,9 @@ const generateTaskRole = (taskRole, labels, config) => {
                   {
                     matchExpressions: [
                       {
-                        key: "pai-worker",
-                        operator: "In",
-                        values: ["true"],
+                        key: 'pai-worker',
+                        operator: 'In',
+                        values: ['true'],
                       },
                     ],
                   },

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -405,6 +405,23 @@ const generateTaskRole = (taskRole, labels, config) => {
               },
             },
           ],
+          affinity: {
+            nodeAffinity: {
+              requiredDuringSchedulingIgnoredDuringExecution: {
+                nodeSelectorTerms: [
+                  {
+                    matchExpressions: [
+                      {
+                        key: "pai-worker",
+                        operator: "In",
+                        values: ["true"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
           imagePullSecrets: [
             {
               name: launcherConfig.runtimeImagePullSecrets,


### PR DESCRIPTION
Add node selector for user jobs in k8s,
only run user pods on pai-worker nodes.