### PR TITLE
The abnormal jobs in home page not show correctly

### DIFF
--- a/src/webportal/src/app/home/home/conn.js
+++ b/src/webportal/src/app/home/home/conn.js
@@ -90,7 +90,7 @@ export async function getAvailableGpuPerNode() {
 }
 
 export async function getLowGpuJobInfos() {
-  const prometheusQuery = `avg(avg_over_time(task_gpu_percent[10m]) < 10) by (job_name)`;
+  const prometheusQuery = `avg(avg_over_time(task_gpu_percent[10m])) by (job_name) < 10`;
   const res = await fetch(
     `${config.prometheusUri}/api/v1/query?query=${encodeURIComponent(
       prometheusQuery,


### PR DESCRIPTION
Currently, the abnormal job in home page will show the job
contains tasks which GPU usage is low. But we need show the job
which tasks average GPU usage is low. Fix this issue.