### PR TITLE
add k8s_node_gpu_allocatable remove k8s_node_gpu_reserved

### DIFF
--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -82,18 +82,17 @@ def gen_k8s_api_gauge():
     return GaugeMetricFamily("k8s_api_server_count", "count of k8s api server",
             labels=["error", "host_ip"])
 
+def gen_k8s_node_gpu_total():
+    return GaugeMetricFamily("k8s_node_gpu_total", "gpu capacity on k8s node",
+            labels=["host_ip"])
+
+def gen_k8s_node_gpu_allocatable():
+    return GaugeMetricFamily("k8s_node_gpu_allocatable",
+            "gpu allocatable on k8s node, this include used allocatable",
+            labels=["host_ip"])
+
 def gen_k8s_node_gpu_available():
     return GaugeMetricFamily("k8s_node_gpu_available", "gpu available on k8s node",
-            labels=["host_ip"])
-
-# reserved gpu means gpu not allocated to tasks and the node is being marked as
-# unschedulable.
-def gen_k8s_node_gpu_reserved():
-    return GaugeMetricFamily("k8s_node_gpu_reserved", "gpu reserved on k8s node",
-            labels=["host_ip"])
-
-def gen_k8s_node_gpu_total():
-    return GaugeMetricFamily("k8s_node_gpu_total", "gpu total on k8s node",
             labels=["host_ip"])
 
 service_response_histogram = Histogram("service_response_latency_seconds",
@@ -381,7 +380,7 @@ def collect_k8s_component(api_server_scheme, api_server_ip, api_server_port, ca_
 
 
 def parse_node_item(node, pai_node_gauge,
-        node_gpu_avail, node_gpu_total, node_gpu_reserved,
+        node_gpu_avail, node_gpu_total, node_gpu_allocatable,
         pods_info):
 
     ip = None
@@ -420,23 +419,10 @@ def parse_node_item(node, pai_node_gauge,
 
         # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/node-allocatable.md
         # [Allocatable] = [Node Capacity] - [Kube-Reserved] - [System-Reserved] - [Hard-Eviction-Threshold]
-        total_gpu = 0
-
-        allocatable = walk_json_field_safe(status, "allocatable")
-        if allocatable is not None:
-            gpu1 = int(walk_json_field_safe(allocatable, "alpha.kubernetes.io/nvidia-gpu") or "0")
-            gpu2 = int(walk_json_field_safe(allocatable, "nvidia.com/gpu") or "0")
-
-            total_gpu = max(gpu1, gpu2)
-            node_gpu_total.add_metric([ip], total_gpu)
-        else:
-            capacity = walk_json_field_safe(status, "capacity")
-            if capacity is not None:
-                gpu1 = int(walk_json_field_safe(capacity, "alpha.kubernetes.io/nvidia-gpu") or "0")
-                gpu2 = int(walk_json_field_safe(capacity, "nvidia.com/gpu") or "0")
-                total_gpu = max(gpu1. gpu2)
-
-                node_gpu_total.add_metric([ip], total_gpu)
+        gpu_capacity = int(walk_json_field_safe(status, "capacity", "nvidia.com/gpu") or 0)
+        gpu_allocatable = int(walk_json_field_safe(status, "allocatable", "nvidia.com/gpu") or 0)
+        node_gpu_total.add_metric([ip], gpu_capacity)
+        node_gpu_allocatable.add_metric([ip], gpu_allocatable)
 
         # Because k8s api's node api do not record how much resource left for
         # allocation, so we have to compute it ourselves.
@@ -446,14 +432,10 @@ def parse_node_item(node, pai_node_gauge,
             for pod in pods_info[ip]:
                 used_gpu += pod.gpu
 
-        # if a node is marked as unschedulable, the available gpu will be 0
-        # and reserved gpu will be `total - used`
-        if walk_json_field_safe(node, "spec", "unschedulable") != True:
-            node_gpu_avail.add_metric([ip], max(0, total_gpu - used_gpu))
-            node_gpu_reserved.add_metric([ip], 0)
+        if walk_json_field_safe(node, "spec", "unschedulable") != True and ready == "true":
+            node_gpu_avail.add_metric([ip], max(0, gpu_capacity - used_gpu))
         else:
             node_gpu_avail.add_metric([ip], 0)
-            node_gpu_reserved.add_metric([ip], max(0, total_gpu - used_gpu))
     else:
         logger.warning("unexpected structure of node %s: %s", ip, json.dumps(node))
 
@@ -469,7 +451,7 @@ def parse_node_item(node, pai_node_gauge,
 def process_nodes_status(nodes_object, pods_info):
     pai_node_gauge = gen_pai_node_gauge()
     node_gpu_avail = gen_k8s_node_gpu_available()
-    node_gpu_reserved = gen_k8s_node_gpu_reserved()
+    node_gpu_allocatable = gen_k8s_node_gpu_allocatable()
     node_gpu_total = gen_k8s_node_gpu_total()
 
     def _map_fn(item):
@@ -480,13 +462,13 @@ def process_nodes_status(nodes_object, pods_info):
                 pai_node_gauge,
                 node_gpu_avail,
                 node_gpu_total,
-                node_gpu_reserved,
+                node_gpu_allocatable,
                 pods_info)
 
     list(map(_map_fn, nodes_object["items"]))
 
     return [pai_node_gauge,
-            node_gpu_avail, node_gpu_total, node_gpu_reserved]
+            node_gpu_avail, node_gpu_total, node_gpu_allocatable]
 
 
 def process_vc_quota(vc_object):

--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -422,7 +422,6 @@ def parse_node_item(node, pai_node_gauge,
         gpu_capacity = int(walk_json_field_safe(status, "capacity", "nvidia.com/gpu") or 0)
         gpu_allocatable = int(walk_json_field_safe(status, "allocatable", "nvidia.com/gpu") or 0)
         node_gpu_total.add_metric([ip], gpu_capacity)
-        node_gpu_allocatable.add_metric([ip], gpu_allocatable)
 
         # Because k8s api's node api do not record how much resource left for
         # allocation, so we have to compute it ourselves.
@@ -434,8 +433,10 @@ def parse_node_item(node, pai_node_gauge,
 
         if walk_json_field_safe(node, "spec", "unschedulable") != True and ready == "true":
             node_gpu_avail.add_metric([ip], max(0, gpu_capacity - used_gpu))
+            node_gpu_allocatable.add_metric([ip], gpu_allocatable)
         else:
             node_gpu_avail.add_metric([ip], 0)
+            node_gpu_allocatable.add_metric([ip], 0)
     else:
         logger.warning("unexpected structure of node %s: %s", ip, json.dumps(node))
 

--- a/src/watchdog/src/watchdog.py
+++ b/src/watchdog/src/watchdog.py
@@ -432,7 +432,7 @@ def parse_node_item(node, pai_node_gauge,
                 used_gpu += pod.gpu
 
         if walk_json_field_safe(node, "spec", "unschedulable") != True and ready == "true":
-            node_gpu_avail.add_metric([ip], max(0, gpu_capacity - used_gpu))
+            node_gpu_avail.add_metric([ip], max(0, gpu_allocatable - used_gpu))
             node_gpu_allocatable.add_metric([ip], gpu_allocatable)
         else:
             node_gpu_avail.add_metric([ip], 0)

--- a/src/watchdog/test/data/dlws_nodes_list.json
+++ b/src/watchdog/test/data/dlws_nodes_list.json
@@ -79,7 +79,7 @@
       },
       "status": {
         "capacity": {
-          "alpha.kubernetes.io/nvidia-gpu": "4",
+          "nvidia.com/gpu": "4",
           "cpu": "16",
           "memory": "57709692Ki",
           "pods": "110"
@@ -88,7 +88,7 @@
           "cpu": "16",
           "memory": "57607292Ki",
           "pods": "110",
-          "alpha.kubernetes.io/nvidia-gpu": "4"
+          "nvidia.com/gpu": "4"
         },
         "conditions": [
           {

--- a/src/watchdog/test/data/dlws_nodes_list_with_unschedulable.json
+++ b/src/watchdog/test/data/dlws_nodes_list_with_unschedulable.json
@@ -80,7 +80,7 @@
       },
       "status": {
         "capacity": {
-          "alpha.kubernetes.io/nvidia-gpu": "4",
+          "nvidia.com/gpu": "4",
           "cpu": "16",
           "memory": "57709692Ki",
           "pods": "110"
@@ -89,7 +89,7 @@
           "cpu": "16",
           "memory": "57607292Ki",
           "pods": "110",
-          "alpha.kubernetes.io/nvidia-gpu": "4"
+          "nvidia.com/gpu": "4"
         },
         "conditions": [
           {

--- a/src/watchdog/test/test_watchdog.py
+++ b/src/watchdog/test/test_watchdog.py
@@ -132,9 +132,9 @@ class TestJobExporter(unittest.TestCase):
         self.assertEqual("k8s_node_gpu_total", gauges[2].name)
         self.assertEqual(1, len(gauges[2].samples))
         self.assertEqual(4, gauges[2].samples[0].value)
-        self.assertEqual("k8s_node_gpu_reserved", gauges[3].name)
+        self.assertEqual("k8s_node_gpu_allocatable", gauges[3].name)
         self.assertEqual(1, len(gauges[3].samples))
-        self.assertEqual(0, gauges[3].samples[0].value)
+        self.assertEqual(4, gauges[3].samples[0].value)
 
         for gauge in gauges:
             self.assertTrue(len(gauge.samples) > 0)
@@ -160,9 +160,9 @@ class TestJobExporter(unittest.TestCase):
         self.assertEqual("k8s_node_gpu_total", gauges[2].name)
         self.assertEqual(1, len(gauges[2].samples))
         self.assertEqual(4, gauges[2].samples[0].value)
-        self.assertEqual("k8s_node_gpu_reserved", gauges[3].name)
+        self.assertEqual("k8s_node_gpu_allocatable", gauges[3].name)
         self.assertEqual(1, len(gauges[3].samples))
-        self.assertEqual(2, gauges[3].samples[0].value)
+        self.assertEqual(4, gauges[3].samples[0].value)
 
         for gauge in gauges:
             self.assertTrue(len(gauge.samples) > 0)

--- a/src/watchdog/test/test_watchdog.py
+++ b/src/watchdog/test/test_watchdog.py
@@ -162,7 +162,7 @@ class TestJobExporter(unittest.TestCase):
         self.assertEqual(4, gauges[2].samples[0].value)
         self.assertEqual("k8s_node_gpu_allocatable", gauges[3].name)
         self.assertEqual(1, len(gauges[3].samples))
-        self.assertEqual(4, gauges[3].samples[0].value)
+        self.assertEqual(0, gauges[3].samples[0].value)
 
         for gauge in gauges:
             self.assertTrue(len(gauge.samples) > 0)


### PR DESCRIPTION
GPU Accounting Formula
 
Capacity = Allocatable + Unallocatable
Allocatable = Used in Allocatable + Available
 
Capacity: Total number of GPUs in the cluster, regardless of its usability.
Allocatable: Number of GPUs that are good for immediate allocation in the cluster.
Unallocatable: Number of GPUs that are bad, pending repair (e.g. GPUs having DBE).
Used in Allocatable: Number of GPUs in use by user jobs in the cluster.
Available: Number of GPUs available for usage in the cluster. This is the number users care about.

With above definition:

* `k8s_node_gpu_total` is collected from k8s node capacity, represents Capacity mentioned above. It will **not** be 0 when the node become unschedulable or not ready.
* `k8s_node_gpu_allocatable` is collected from k8s node allocatable, represents Allocatable above. It **will** be 0 when the node become unschedulable or not ready.
* `k8s_node_gpu_available` represents Available above, it **will** be 0 when the node become unschedulable or not ready. It is calculated by `allocatable - used` when node is ready and schedulable.

We also removed `k8s_node_gpu_reserved` since it only causes confusion.