### PR TITLE
[Web Portal] Seperate 'waiting' and 'running' states on task role's statistics

### DIFF
--- a/src/webportal/src/app/job/job-view/fabric/job-detail.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail.jsx
@@ -172,7 +172,7 @@ class JobDetail extends React.Component {
             : taskConfig.instances;
           dummyTaskInfo = {
             taskStatuses: Array.from({ length: instances }, (v, idx) => ({
-              taskState: 'Waiting',
+              taskState: 'WAITING',
             })),
           };
         }

--- a/src/webportal/src/app/job/job-view/fabric/job-detail/components/task-role.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/components/task-role.jsx
@@ -55,6 +55,7 @@ export default class TaskRole extends React.Component {
     const { taskInfo } = this.props;
     const count = {
       running: 0,
+      waiting: 0,
       succeeded: 0,
       failed: 0,
       unknown: 0,
@@ -63,8 +64,10 @@ export default class TaskRole extends React.Component {
       for (const item of taskInfo.taskStatuses) {
         switch (item.taskState) {
           case 'RUNNING':
-          case 'WAITING':
             count.running += 1;
+            break;
+          case 'WAITING':
+            count.waiting += 1;
             break;
           case 'SUCCEEDED':
             count.succeeded += 1;


### PR DESCRIPTION
![图片](https://user-images.githubusercontent.com/8802144/66737882-b7a89400-ee9f-11e9-9ca5-cd039e765e66.png)
