### PR TITLE
support aks env

### DIFF
--- a/src/job-exporter/deploy/job-exporter.yaml.template
+++ b/src/job-exporter/deploy/job-exporter.yaml.template
@@ -93,9 +93,15 @@ spec:
         - name: device-mount
           hostPath:
             path: /dev
+        {%- if cluster_cfg['rest-server']['launcher-type'] == "k8s" %}
+        - name: driver-path
+          hostPath:
+            path: /usr/local/nvidia
+        {%- else %}
         - name: driver-path
           hostPath:
             path: /var/drivers/nvidia/current
+        {%- endif %}
         - name: collector-mount
           hostPath:
             path: {{ cluster_cfg["cluster"]["common"]["data-path"] }}/prometheus


### PR DESCRIPTION
AKS doesn't export nvdia-smi to pod. We need to mount and set ENV manually.
Issue: https://github.com/Azure/AKS/issues/1271
This change will not break the on-premise env. Since in job-exporter, we append
the /var/drivers/nvidia/current to the `PATH` env. It should behind the `nvidia path`
set by nvida-plugin.