### PR TITLE
HiveD Reconfiguration

### DIFF
--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
@@ -290,10 +290,10 @@ func (c *VirtualCell) SetPhysicalCell(pc *PhysicalCell) {
 	c.physicalCell = pc
 }
 
-func (c *VirtualCell) GetPreBoundVirtualCell() *PhysicalCell {
+func (c *VirtualCell) GetPreBoundPhysicalCell() *PhysicalCell {
 	return c.preBoundPhysicalCell
 }
 
-func (c *VirtualCell) SetPreBoundVirtualCell(pc *PhysicalCell) {
+func (c *VirtualCell) SetPreBoundPhysicalCell(pc *PhysicalCell) {
 	c.preBoundPhysicalCell = pc
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/cell.go
@@ -25,6 +25,7 @@ package algorithm
 import (
 	"fmt"
 	"github.com/microsoft/hivedscheduler/pkg/api"
+	"k8s.io/klog"
 )
 
 // A Cell represents a set of GPUs affinitized by their interconnection topology.
@@ -161,16 +162,15 @@ func (c *PhysicalCell) SetPhysicalResources(nodes []string, gpuIndices []int32) 
 
 func (c *PhysicalCell) AddAffinityGroup(g *AlgoAffinityGroup) {
 	if c.affinityGroup != nil {
-		panic(fmt.Sprintf("Error when adding affinity group %v to cell %v: cell already has group %v",
-			g.name, c.GetName(), c.affinityGroup.name))
+		klog.Errorf("Error when adding affinity group %v to cell %v: cell already has group %v",
+			g.name, c.GetName(), c.affinityGroup.name)
 	}
 	c.affinityGroup = g
 }
 
 func (c *PhysicalCell) DeleteAffinityGroup(g *AlgoAffinityGroup) {
 	if c.affinityGroup == nil || c.affinityGroup.name != g.name {
-		panic(fmt.Sprintf("Error when deleting affinity group %v from cell %v: not exists!",
-			g.name, c.GetName()))
+		klog.Errorf("Error when deleting affinity group %v from cell %v: not found", g.name, c.GetName())
 	}
 	c.affinityGroup = nil
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -127,61 +127,75 @@ func (h *HivedAlgorithm) AddAllocatedPod(pod *core.Pod) {
 	h.algorithmLock.Lock()
 	defer h.algorithmLock.Unlock()
 
-	klog.Infof("[%v]: adding allocated pod...", internal.Key(pod))
 	s := internal.ExtractPodSchedulingSpec(pod)
 	info := internal.ExtractPodBindInfo(pod)
+	klog.Infof("[%v]: adding allocated pod (node %v, GPUs %v)...", internal.Key(pod), info.Node, info.GpuIsolation)
 
 	chain := CellChain(info.CellChain)
 	hasVirtualPlacement := true
+	downgrade := false
 	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group == nil {
 		newGroup := newAlgoAffinityGroup(s.AffinityGroup)
 		for _, gms := range info.AffinityGroupBindInfo {
 			gpuNumber := int32(len(gms.PodPlacements[0].PhysicalGpuIndices))
-			newGroup.physicalGpuPlacement[gpuNumber] = make([]CellList, len(gms.PodPlacements))
-			if hasVirtualPlacement {
-				newGroup.virtualGpuPlacement[gpuNumber] = make([]CellList, len(gms.PodPlacements))
-			}
 			for podIndex := int32(0); podIndex < int32(len(gms.PodPlacements)); podIndex++ {
-				newGroup.physicalGpuPlacement[gpuNumber][podIndex] = make(
-					CellList, len(gms.PodPlacements[podIndex].PhysicalGpuIndices))
-				if hasVirtualPlacement {
-					newGroup.virtualGpuPlacement[gpuNumber][podIndex] = make(
-						CellList, len(gms.PodPlacements[podIndex].PhysicalGpuIndices))
-				}
 				node := gms.PodPlacements[podIndex].PhysicalNode
 				for gpuIndex := int32(0); gpuIndex < int32(
 					len(gms.PodPlacements[podIndex].PhysicalGpuIndices)); gpuIndex++ {
 					physicalGpuIndex := gms.PodPlacements[podIndex].PhysicalGpuIndices[gpuIndex]
-					pGpu := h.findPhysicalGpu(chain, node, physicalGpuIndex)
-					if pGpu == nil {
-						panic(fmt.Sprintf("[%v]: physical GPU cell not found when adding pod: node %v, GPU index %v",
-							internal.Key(pod), node, physicalGpuIndex))
-					}
-					newGroup.physicalGpuPlacement[gpuNumber][podIndex][gpuIndex] = pGpu
-
-					var vGpu *VirtualCell
-					if hasVirtualPlacement {
-						virtualCellIndex := gms.PodPlacements[podIndex].VirtualCellIndices[gpuIndex]
-						if virtualCellIndex >= 0 {
-							vGpu = h.findVirtualGpu(s.VirtualCluster, chain, s.ReservationId, virtualCellIndex)
-							if vGpu == nil {
-								panic(fmt.Sprintf("[%v]: virtual GPU cell not found when adding pod: virtual cell index %v",
-									internal.Key(pod), virtualCellIndex))
+					if pGpu := h.findPhysicalGpu(chain, node, physicalGpuIndex); pGpu == nil {
+						klog.Infof(
+							"[%v]: cannot find GPU %v on node %v due to reconfiguration: deleted from the spec",
+							internal.Key(pod), physicalGpuIndex, node)
+					} else {
+						newGroup.physicalGpuPlacement[gpuNumber][podIndex][gpuIndex] = pGpu
+						var vGpu *VirtualCell
+						if hasVirtualPlacement && !downgrade {
+							preassignedLevel := CellLevel(gms.PodPlacements[podIndex].PreassignedCellLevels[gpuIndex])
+							if preassignedLevel >= 0 {
+								var message string
+								if vcs := h.vcSchedulers[s.VirtualCluster]; vcs == nil {
+									message = fmt.Sprintf("VC %v has been deleted", s.VirtualCluster)
+								} else {
+									var vccl ChainCellList
+									var str string
+									if s.ReservationId != "" {
+										vccl = vcs.getReservedCellList()[s.ReservationId]
+										str = string(s.ReservationId)
+									} else {
+										vccl = vcs.getNonReservedCellList()[CellChain(info.CellChain)]
+										str = info.CellChain
+									}
+									if vccl == nil {
+										message = fmt.Sprintf("VC %v no longer has cells for %v", s.VirtualCluster, str)
+									} else {
+										vGpu, message = mapNonPreassignedCellToVirtual(pGpu, vccl, preassignedLevel)
+									}
+								}
+								if vGpu == nil {
+									klog.Infof(
+										"[%v]: cannot find virtual cell due to reconfiguration: %v",
+										internal.Key(pod), message)
+									downgrade = true
+								} else {
+									newGroup.virtualGpuPlacement[gpuNumber][podIndex][gpuIndex] = vGpu
+								}
+							} else {
+								newGroup.virtualGpuPlacement = nil
+								hasVirtualPlacement = false
 							}
-							newGroup.virtualGpuPlacement[gpuNumber][podIndex][gpuIndex] = vGpu
-						} else {
-							newGroup.virtualGpuPlacement = nil
-							hasVirtualPlacement = false
 						}
+						h.confirmAllocatedGpu(pGpu, vGpu, CellPriority(s.Priority), newGroup)
 					}
-					h.confirmAllocatedGpu(pGpu, vGpu, CellPriority(s.Priority), newGroup)
 				}
 			}
+		}
+		if downgrade {
+			h.downgradeAffinityGroup(newGroup)
 		}
 		h.allocatedAffinityGroups[s.AffinityGroup.Name] = newGroup
 		klog.Infof("New affinity group created: %v", s.AffinityGroup.Name)
 	}
-	klog.Infof("[%v]: added to node %v, GPUs %v", internal.Key(pod), info.Node, info.GpuIsolation)
 	h.allocatedAffinityGroups[s.AffinityGroup.Name].allocatedPods[s.GpuNumber] = append(
 		h.allocatedAffinityGroups[s.AffinityGroup.Name].allocatedPods[s.GpuNumber], pod)
 }
@@ -190,8 +204,9 @@ func (h *HivedAlgorithm) DeleteAllocatedPod(pod *core.Pod) {
 	h.algorithmLock.Lock()
 	defer h.algorithmLock.Unlock()
 
-	klog.Infof("[%v]: deleting allocated pod...", internal.Key(pod))
 	s := internal.ExtractPodSchedulingSpec(pod)
+	info := internal.ExtractPodBindInfo(pod)
+	klog.Infof("[%v]: deleting allocated pod (node %v, GPUs %v)...", internal.Key(pod), info.Node, info.GpuIsolation)
 
 	if group := h.allocatedAffinityGroups[s.AffinityGroup.Name]; group == nil {
 		panic(fmt.Sprintf(
@@ -224,7 +239,9 @@ func (h *HivedAlgorithm) DeleteAllocatedPod(pod *core.Pod) {
 			for _, podPlacements := range group.physicalGpuPlacement {
 				for _, podPlacement := range podPlacements {
 					for _, gpu := range podPlacement {
-						h.confirmReleasedGpu(gpu.(*PhysicalCell), group)
+						if gpu != nil {
+							h.confirmReleasedGpu(gpu.(*PhysicalCell), group)
+						}
 					}
 				}
 			}
@@ -248,18 +265,22 @@ func (h *HivedAlgorithm) validateInitialAssignment() {
 		}
 	}
 	for chain, chainQuota := range totalQuota {
-		ccl := h.fullCellList[chain]
-		top := CellLevel(len(ccl))
-		available := int32(len(ccl[top]))
-		for l := top; l >= lowestLevel; l-- {
-			left := available - chainQuota[l]
-			if left < 0 {
-				panic(fmt.Sprintf(
-					"Insufficient physical cells at chain %v level %v: %v needed, %v available",
-					chain, l, chainQuota[l], available))
-			}
-			if l > lowestLevel {
-				available = left * int32(len(ccl[l][0].GetChildren()))
+		if ccl := h.fullCellList[chain]; ccl == nil {
+			panic(fmt.Sprintf(
+				"Chain %v not exists in physical cluster", chain))
+		} else {
+			top := CellLevel(len(ccl))
+			available := int32(len(ccl[top]))
+			for l := top; l >= lowestLevel; l-- {
+				left := available - chainQuota[l]
+				if left < 0 {
+					panic(fmt.Sprintf(
+						"Insufficient physical cells at chain %v level %v: %v needed, %v available",
+						chain, l, chainQuota[l], available))
+				}
+				if l > lowestLevel {
+					available = left * int32(len(ccl[l][0].GetChildren()))
+				}
 			}
 		}
 	}
@@ -324,7 +345,7 @@ func (h *HivedAlgorithm) scheduleNewAffinityGroup(
 		physicalPlacement, virtualPlacement = h.scheduleAffinityGroupForGpuType(sr, s.GpuType, pod)
 	}
 	if physicalPlacement != nil {
-		klog.Infof("Succeeded scheduling group %v", s.AffinityGroup.Name)
+		klog.Infof("Succeeded in scheduling group %v", s.AffinityGroup.Name)
 	} else {
 		klog.Infof("Failed to schedule group %v", s.AffinityGroup.Name)
 	}
@@ -430,7 +451,7 @@ func (h *HivedAlgorithm) scheduleRegularAffinityGroup(sr schedulingRequest) (map
 				// check if the preassigned cell has been (temporarily) bound to a physical cell
 				preassignedPhysical := pac.GetPhysicalCell()
 				if preassignedPhysical == nil {
-					preassignedPhysical = pac.GetPreBoundVirtualCell()
+					preassignedPhysical = pac.GetPreBoundPhysicalCell()
 				}
 				if preassignedPhysical == nil {
 					// allocate a new physical cell to the preassigned cell. input a copy of the free cell list
@@ -443,7 +464,7 @@ func (h *HivedAlgorithm) scheduleRegularAffinityGroup(sr schedulingRequest) (map
 						preassignedPhysical = c
 						// create binding (which is temporary and will be cleared after the scheduling,
 						// same reason as above)
-						pac.SetPreBoundVirtualCell(preassignedPhysical)
+						pac.SetPreBoundPhysicalCell(preassignedPhysical)
 						preassignedPhysical.SetPreBoundVirtualCell(pac)
 					}
 				}
@@ -451,7 +472,7 @@ func (h *HivedAlgorithm) scheduleRegularAffinityGroup(sr schedulingRequest) (map
 			}
 		}
 	}
-	clearTmpBindings(virtualPlacement)
+	clearPreBindings(virtualPlacement)
 	return physicalPlacement, virtualPlacement
 }
 
@@ -512,6 +533,23 @@ func (h *HivedAlgorithm) confirmReleasedGpu(pGpu *PhysicalCell, g *AlgoAffinityG
 	updateUsedGpuNumAtPriority(pGpu, pGpu.GetPriority(), false)
 	pGpu.SetPriority(freePriority)
 	pGpu.DeleteAffinityGroup(g)
+}
+
+func (h *HivedAlgorithm) downgradeAffinityGroup(g *AlgoAffinityGroup) {
+	for _, podVirtualPlacements := range g.virtualGpuPlacement {
+		for _, podVirtualPlacement := range podVirtualPlacements {
+			for _, gpu := range podVirtualPlacement {
+				if gpu != nil {
+					vGpu := gpu.(*VirtualCell)
+					pGpu := vGpu.GetPhysicalCell()
+					h.confirmReleasedGpu(pGpu, g)
+					h.confirmAllocatedGpu(pGpu, nil, opportunisticPriority, g)
+				}
+			}
+		}
+	}
+	g.virtualGpuPlacement = nil
+	klog.Infof("Affinity group %v downgraded to opportunistic", g.name)
 }
 
 // removeCellFromFreeList removes a cell from the free cell list and splits its parent recursively if needed.
@@ -578,9 +616,30 @@ func (h *HivedAlgorithm) addCellToFreeList(c *PhysicalCell) {
 	}
 }
 
-// findPhysicalGpu finds a physical GPU cell in the full list. This search is based on *one* node
-// and *one* GPU index, assuming there is no resource overlapping among cells at the same level.
+// findPhysicalGpu finds a physical GPU cell in the full list. If the GPU is not found in the chain specified
+// in the PodBindInfo (due to reconfiguration), we will try to search in the other chains.
 func (h *HivedAlgorithm) findPhysicalGpu(
+	chain CellChain,
+	node string,
+	gpuIndex int32) *PhysicalCell {
+
+	if g := h.findPhysicalGpuInChain(chain, node, gpuIndex); g == nil {
+		for c := range h.fullCellList {
+			if c != chain {
+				if g = h.findPhysicalGpuInChain(c, node, gpuIndex); g != nil {
+					return g
+				}
+			}
+		}
+		return nil
+	} else {
+		return g
+	}
+}
+
+// findPhysicalGpuInChain finds a physical GPU cell in the full list of a given chain. This search is based on
+// *one* node and *one* GPU index, assuming there is no resource overlapping among cells at the same level.
+func (h *HivedAlgorithm) findPhysicalGpuInChain(
 	chain CellChain,
 	node string,
 	gpuIndex int32) *PhysicalCell {
@@ -610,31 +669,6 @@ func (h *HivedAlgorithm) findPhysicalGpu(
 	return nil
 }
 
-// findVirtualGpu finds a virtual GPU cell according to the cell index.
-func (h *HivedAlgorithm) findVirtualGpu(
-	vc api.VirtualClusterName,
-	chain CellChain,
-	rid api.ReservationId,
-	index int32) *VirtualCell {
-
-	if index >= 0 {
-		var searchList CellList
-		if rid == "" {
-			searchList = h.vcSchedulers[vc].getNonReservedCellList()[chain][1]
-		} else {
-			searchList = h.vcSchedulers[vc].getReservedCellList()[rid][1]
-		}
-
-		for _, c := range searchList {
-			cc := c.(*VirtualCell)
-			if cc.GetIndex() == index {
-				return cc
-			}
-		}
-	}
-	return nil
-}
-
 // generatePodScheduleResult writes the scheduling result into a PodScheduleResult.
 func generatePodScheduleResult(
 	groupPhysicalPlacement map[int32][]CellList,
@@ -645,71 +679,70 @@ func generatePodScheduleResult(
 	suggestedNodes []string,
 	pod *core.Pod) internal.PodScheduleResult {
 
-	if groupPhysicalPlacement == nil {
+	affinityGroupBindInfo, selectedNode, selectedGpuIndices := generateAffinityGroupBindInfo(
+		groupPhysicalPlacement, groupVirtualPlacement, currentGpuNum, currentPodIndex)
+	if affinityGroupBindInfo == nil {
 		return internal.PodScheduleResult{
 			PodWaitInfo: &internal.PodWaitInfo{
 				FailedNodeReasons: map[string]string{},
 			},
 		}
+	}
+	chain := string(groupPhysicalPlacement[currentGpuNum][currentPodIndex][0].GetChain())
+	if !common.StringsContains(suggestedNodes, selectedNode) {
+		panic(fmt.Sprintf("[%v]: node %v picked by algorithm but not in K8S candidates",
+			internal.Key(pod), selectedNode))
+	}
+	// collect preemption victims
+	needPreemption := false
+	preemptionVictims := common.NewSet()
+	if newGroup {
+		// if any of the GPUs allocated for the whole group is still used by a pod,
+		// we will wait for the preemption, as the group is gang-scheduled.
+		for gpuNum := range groupPhysicalPlacement {
+			for podIndex := range groupPhysicalPlacement[gpuNum] {
+				for _, gpu := range groupPhysicalPlacement[gpuNum][podIndex] {
+					pGpu := gpu.(*PhysicalCell)
+					if pGpu.HasAffinityGroup() {
+						needPreemption = true
+						break
+					}
+				}
+			}
+		}
+		for _, gpu := range groupPhysicalPlacement[currentGpuNum][currentPodIndex] {
+			pGpu := gpu.(*PhysicalCell)
+			if pGpu.HasAffinityGroup() {
+				// for any victim pod, gang-preempt all the other pods from the same affinity group
+				for _, victims := range pGpu.GetAffinityGroups()[0].allocatedPods {
+					for _, victimPod := range victims {
+						preemptionVictims.Add(victimPod)
+					}
+				}
+			}
+		}
+	}
+	if needPreemption {
+		var victimPods []*core.Pod
+		var victimNames []string
+		for v := range preemptionVictims.Items() {
+			victimPods = append(victimPods, v.(*core.Pod))
+			victimNames = append(victimNames, internal.Key(v.(*core.Pod)))
+		}
+		klog.Infof("[%v]: need to preempt pods %v", internal.Key(pod), victimNames)
+		return internal.PodScheduleResult{
+			PodPreemptInfo: &internal.PodPreemptInfo{VictimPods: victimPods},
+		}
 	} else {
-		affinityGroupBindInfo, selectedNode, selectedGpuIndices := generateAffinityGroupBindInfo(
-			groupPhysicalPlacement, groupVirtualPlacement, currentGpuNum, currentPodIndex)
-		chain := string(groupPhysicalPlacement[currentGpuNum][currentPodIndex][0].GetChain())
-		if !common.StringsContains(suggestedNodes, selectedNode) {
-			panic(fmt.Sprintf("[%v]: node %v picked by algorithm but not in K8S candidates",
-				internal.Key(pod), selectedNode))
-		}
-		// collect preemption victims
-		needPreemption := false
-		preemptionVictims := common.NewSet()
-		if newGroup {
-			// if any of the GPUs allocated for the whole group is still used by a pod,
-			// we will wait for the preemption, as the group is gang-scheduled.
-			for gpuNum := range groupPhysicalPlacement {
-				for podIndex := range groupPhysicalPlacement[gpuNum] {
-					for _, gpu := range groupPhysicalPlacement[gpuNum][podIndex] {
-						pGpu := gpu.(*PhysicalCell)
-						if pGpu.HasAffinityGroup() {
-							needPreemption = true
-							break
-						}
-					}
-				}
-			}
-			for _, gpu := range groupPhysicalPlacement[currentGpuNum][currentPodIndex] {
-				pGpu := gpu.(*PhysicalCell)
-				if pGpu.HasAffinityGroup() {
-					// for any victim pod, gang-preempt all the other pods from the same affinity group
-					for _, victims := range pGpu.GetAffinityGroups()[0].allocatedPods {
-						for _, victimPod := range victims {
-							preemptionVictims.Add(victimPod)
-						}
-					}
-				}
-			}
-		}
-		if needPreemption {
-			var victimPods []*core.Pod
-			var victimNames []string
-			for v := range preemptionVictims.Items() {
-				victimPods = append(victimPods, v.(*core.Pod))
-				victimNames = append(victimNames, internal.Key(v.(*core.Pod)))
-			}
-			klog.Infof("[%v]: need to preempt pods %v", internal.Key(pod), victimNames)
-			return internal.PodScheduleResult{
-				PodPreemptInfo: &internal.PodPreemptInfo{VictimPods: victimPods},
-			}
-		} else {
-			klog.Infof("[%v]: scheduled to node %v, GPUs %v",
-				internal.Key(pod), selectedNode, selectedGpuIndices)
-			return internal.PodScheduleResult{
-				PodBindInfo: &api.PodBindInfo{
-					Node:                  selectedNode,
-					GpuIsolation:          selectedGpuIndices,
-					CellChain:             chain,
-					AffinityGroupBindInfo: affinityGroupBindInfo,
-				},
-			}
+		klog.Infof("[%v]: scheduled to node %v, GPUs %v",
+			internal.Key(pod), selectedNode, selectedGpuIndices)
+		return internal.PodScheduleResult{
+			PodBindInfo: &api.PodBindInfo{
+				Node:                  selectedNode,
+				GpuIsolation:          selectedGpuIndices,
+				CellChain:             chain,
+				AffinityGroupBindInfo: affinityGroupBindInfo,
+			},
 		}
 	}
 }
@@ -723,6 +756,9 @@ func generateAffinityGroupBindInfo(
 	currentGpuNum int32,
 	currentPodIndex int32) ([]api.AffinityGroupMemberBindInfo, string, []int32) {
 
+	if groupPhysicalPlacement == nil {
+		return nil, "", nil
+	}
 	affinityGroupBindInfo := make([]api.AffinityGroupMemberBindInfo, len(groupPhysicalPlacement))
 	var selectedNode string
 	var selectedGpuIndices []int32
@@ -734,11 +770,16 @@ func generateAffinityGroupBindInfo(
 		for podIndex := int32(0); podIndex < int32(len(podPhysicalPlacements)); podIndex++ {
 			mbi.PodPlacements[podIndex].PhysicalGpuIndices = make(
 				[]int32, len(podPhysicalPlacements[podIndex]))
-			mbi.PodPlacements[podIndex].VirtualCellIndices = make(
+			mbi.PodPlacements[podIndex].PreassignedCellLevels = make(
 				[]int32, len(podPhysicalPlacements[podIndex]))
 			for gpuIndex := 0; gpuIndex < len(podPhysicalPlacements[podIndex]); gpuIndex++ {
-				pGpu := podPhysicalPlacements[podIndex][gpuIndex].(*PhysicalCell)
-				nodes, gpuIndices := pGpu.GetPhysicalPlacement()
+				pGpu := podPhysicalPlacements[podIndex][gpuIndex]
+				if pGpu == nil {
+					// the address has been deleted due to reconfiguration
+					// (the affinity group was scheduled before the reconfiguration)
+					return nil, "", nil
+				}
+				nodes, gpuIndices := pGpu.(*PhysicalCell).GetPhysicalPlacement()
 				// here each cell (i.e., pGpu) is only one GPU, hence we takes the first element
 				// in its "nodes" and "gpuIndices" as the node and GPU address
 				if mbi.PodPlacements[podIndex].PhysicalNode == "" {
@@ -747,9 +788,10 @@ func generateAffinityGroupBindInfo(
 				mbi.PodPlacements[podIndex].PhysicalGpuIndices[gpuIndex] = gpuIndices[0]
 				if groupVirtualPlacement != nil {
 					vGpu := groupVirtualPlacement[podGpuNum][podIndex][gpuIndex].(*VirtualCell)
-					mbi.PodPlacements[podIndex].VirtualCellIndices[gpuIndex] = vGpu.GetIndex()
+					mbi.PodPlacements[podIndex].PreassignedCellLevels[gpuIndex] = int32(
+						vGpu.GetPreAssignedCell().GetLevel())
 				} else {
-					mbi.PodPlacements[podIndex].VirtualCellIndices[gpuIndex] = -1
+					mbi.PodPlacements[podIndex].PreassignedCellLevels[gpuIndex] = -1
 				}
 			}
 		}
@@ -777,11 +819,11 @@ func buddyAlloc(freeList ChainCellList, level CellLevel) *PhysicalCell {
 	if len(freeList[level]) == 0 {
 		return nil
 	}
-	return minOpportunisticCell(freeList[level])
+	return fewestOpporPhysicalCell(freeList[level])
 }
 
-// minOpportunisticCell selects a cell with the minimum number of opportunistic pods from a cell list.
-func minOpportunisticCell(cl CellList) *PhysicalCell {
+// fewestOpporPhysicalCell selects a physical cell with the minimum number of opportunistic pods from a cell list.
+func fewestOpporPhysicalCell(cl CellList) *PhysicalCell {
 	mo := int32(math.MaxInt32)
 	var moc *PhysicalCell
 	for _, c := range cl {
@@ -800,30 +842,67 @@ func minOpportunisticCell(cl CellList) *PhysicalCell {
 func mapNonPreassignedCellToPhysical(c *VirtualCell) *PhysicalCell {
 	if c.GetPhysicalCell() != nil {
 		return c.GetPhysicalCell()
-	} else if c.GetPreBoundVirtualCell() != nil {
-		return c.GetPreBoundVirtualCell()
+	} else if c.GetPreBoundPhysicalCell() != nil {
+		return c.GetPreBoundPhysicalCell()
 	} else {
 		parentPhysical := mapNonPreassignedCellToPhysical(c.GetParent().(*VirtualCell))
-		pc := minOpportunisticCell(parentPhysical.GetChildren())
+		pc := fewestOpporPhysicalCell(parentPhysical.GetChildren())
 		if pc == nil || pc.GetPriority() > opportunisticPriority {
 			panic(fmt.Sprintf("Cannot find physical cell for %v", c.GetName()))
 		}
-		c.SetPreBoundVirtualCell(pc)
+		c.SetPreBoundPhysicalCell(pc)
 		pc.SetPreBoundVirtualCell(c)
 		return pc
 	}
 }
 
-// clearTmpBindings clears the temporary bindings created during scheduling.
-func clearTmpBindings(virtualPlacement map[int32][]CellList) {
+// mapNonPreassignedCellToVirtual maps a physical cell (possibly allocated to a non-preassigned virtual cell)
+// to the corresponding virtual cell. This can be viewed as a inverse operation of mapNonPreassignedCellToPhysical,
+// used for finding the virtual cell when adding an allocated pod.
+func mapNonPreassignedCellToVirtual(c *PhysicalCell, ccl ChainCellList, preassignedLevel CellLevel) (*VirtualCell, string) {
+	if c.GetVirtualCell() != nil {
+		return c.GetVirtualCell(), ""
+	} else if c.GetLevel() == preassignedLevel {
+		if preassignedVirtual := unboundVirtualCell(ccl[preassignedLevel]); preassignedVirtual == nil {
+			return nil, fmt.Sprintf("insufficient quota in the VC at the preassigned level (%v)", preassignedLevel)
+		} else {
+			return preassignedVirtual, ""
+		}
+	} else if c.GetParent() == nil {
+		return nil, fmt.Sprintf(
+			"physical and virtual cell hierarchies not match (cannot reach the preassigned level %v in physical)",
+			preassignedLevel)
+	} else {
+		parentVirtual, message := mapNonPreassignedCellToVirtual(c.GetParent().(*PhysicalCell), ccl, preassignedLevel)
+		if parentVirtual == nil {
+			return nil, message
+		} else {
+			return unboundVirtualCell(parentVirtual.GetChildren()), ""
+		}
+	}
+}
+
+// unboundVirtualCell returns a virtual cell that has not been bound to a physical cell from a cell list.
+func unboundVirtualCell(cl CellList) *VirtualCell {
+	for _, c := range cl {
+		vc := c.(*VirtualCell)
+		if vc.GetPhysicalCell() == nil {
+			return vc
+		}
+	}
+	return nil
+}
+
+// clearPreBindings clears the temporary bindings created during scheduling.
+func clearPreBindings(virtualPlacement map[int32][]CellList) {
 	for _, podPlacements := range virtualPlacement {
 		for _, podGpus := range podPlacements {
 			for _, gpu := range podGpus {
 				for gpu != nil {
 					vGpu := gpu.(*VirtualCell)
-					if pGpu := vGpu.GetPreBoundVirtualCell(); pGpu != nil {
+					if pGpu := vGpu.GetPreBoundPhysicalCell(); pGpu != nil {
 						pGpu.SetPreBoundVirtualCell(nil)
-						vGpu.SetPreBoundVirtualCell(nil)
+						vGpu.SetPreBoundPhysicalCell(nil)
 						gpu = gpu.GetParent()
 					} else {
 						break

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -803,7 +803,7 @@ func generateAffinityGroupBindInfo(
 			for gpuIndex := 0; gpuIndex < len(podPhysicalPlacements[podIndex]); gpuIndex++ {
 				pGpu := podPhysicalPlacements[podIndex][gpuIndex]
 				if pGpu == nil {
-					klog.Infof("Resources previously allocated has been invalid due to reconfiguration; pod should wait")
+					klog.Warningf("Resources previously allocated has been invalid; pod should wait")
 					return nil, "", nil
 				}
 				nodes, gpuIndices := pGpu.(*PhysicalCell).GetPhysicalPlacement()

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -23,6 +23,7 @@
 package algorithm
 
 import (
+	"fmt"
 	"github.com/microsoft/hivedscheduler/pkg/api"
 	"github.com/microsoft/hivedscheduler/pkg/common"
 	"github.com/microsoft/hivedscheduler/pkg/internal"
@@ -34,8 +35,21 @@ import (
 	"testing"
 )
 
+var allPods = map[string]*core.Pod{}
+
 func init() {
 	common.InitAll()
+	for i := 1; i <= 23; i++ {
+		podName := fmt.Sprintf("pod%v", i)
+		allPods[podName] = &core.Pod{
+			ObjectMeta: meta.ObjectMeta{
+				Name:        podName,
+				Namespace:   "test",
+				UID:         types.UID(podName),
+				Annotations: map[string]string{},
+			},
+		}
+	}
 }
 
 var allNodes []string
@@ -46,169 +60,6 @@ func initNodes(h *HivedAlgorithm) {
 			allNodes = append(allNodes, c.(*PhysicalCell).nodes...)
 		}
 	}
-}
-
-var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, pod13, pod14, pod15, pod16, pod17, pod18, pod19, pod20, pod21, pod22, pod23 = &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod1",
-		Namespace:   "test",
-		UID:         "pod1",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod2",
-		Namespace:   "test",
-		UID:         "pod2",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod3",
-		Namespace:   "test",
-		UID:         "pod3",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod4",
-		Namespace:   "test",
-		UID:         "pod4",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod5",
-		Namespace:   "test",
-		UID:         "pod5",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod6",
-		Namespace:   "test",
-		UID:         "pod6",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod7",
-		Namespace:   "test",
-		UID:         "pod7",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod8",
-		Namespace:   "test",
-		UID:         "pod8",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod9",
-		Namespace:   "test",
-		UID:         "pod9",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod10",
-		Namespace:   "test",
-		UID:         "pod10",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod11",
-		Namespace:   "test",
-		UID:         "pod11",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod12",
-		Namespace:   "test",
-		UID:         "pod12",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod13",
-		Namespace:   "test",
-		UID:         "pod13",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod14",
-		Namespace:   "test",
-		UID:         "pod14",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod15",
-		Namespace:   "test",
-		UID:         "pod15",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod16",
-		Namespace:   "test",
-		UID:         "pod16",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod17",
-		Namespace:   "test",
-		UID:         "pod17",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod18",
-		Namespace:   "test",
-		UID:         "pod18",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod19",
-		Namespace:   "test",
-		UID:         "pod19",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod20",
-		Namespace:   "test",
-		UID:         "pod20",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod21",
-		Namespace:   "test",
-		UID:         "pod21",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod22",
-		Namespace:   "test",
-		UID:         "pod22",
-		Annotations: map[string]string{},
-	},
-}, &core.Pod{
-	ObjectMeta: meta.ObjectMeta{
-		Name:        "pod23",
-		Namespace:   "test",
-		UID:         "pod23",
-		Annotations: map[string]string{},
-	},
 }
 
 var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10, group11, group12, group13, group14 = &api.AffinityGroupSpec{
@@ -420,12 +271,16 @@ var pss = map[types.UID]api.PodSchedulingSpec{
 	},
 }
 
-var casesThatShouldSucceed = []*core.Pod{
-	pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod16, pod17, pod18, pod19, pod20, pod21, pod22, pod23,
+var casesThatShouldSucceed = []string{
+	"pod1", "pod2", "pod3", "pod4", "pod5", "pod6", "pod7", "pod8", "pod9", "pod16", "pod17", "pod18", "pod19", "pod20", "pod21", "pod22", "pod23",
 }
 
-var casesThatShouldFail = [][]*core.Pod{
-	{pod10}, {pod11, pod12}, {pod13}, {pod14}, {pod15},
+var casesThatShouldFail = [][]string{
+	{"pod10"}, {"pod11", "pod12"}, {"pod13"}, {"pod14"}, {"pod15"},
+}
+
+var casesThatShouldDowngrade = []string{
+	"pod8", "pod9", "pod20", "pod21",
 }
 
 type result struct {
@@ -433,26 +288,26 @@ type result struct {
 	gpuIsolation []int32
 }
 
-var expectedBindInfos = map[*core.Pod]result{
-	pod1:  {node: "0.0.1.0", gpuIsolation: []int32{0}},
-	pod2:  {node: "0.0.1.0", gpuIsolation: []int32{1}},
-	pod3:  {node: "0.0.1.0", gpuIsolation: []int32{8, 9, 10, 11, 12, 13, 14, 15}},
-	pod4:  {node: "0.0.5.0", gpuIsolation: []int32{0}},
-	pod5:  {node: "0.0.3.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod6:  {node: "0.0.3.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod8:  {node: "1.0.0.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
-	pod9:  {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4}},
-	pod18: {node: "0.0.3.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod19: {node: "0.0.3.3", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod20: {node: "0.0.4.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod21: {node: "0.0.4.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod22: {node: "0.0.4.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod23: {node: "0.0.4.3", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+var expectedBindInfos = map[string]result{
+	"pod1":  {node: "0.0.1.0", gpuIsolation: []int32{0}},
+	"pod2":  {node: "0.0.1.0", gpuIsolation: []int32{1}},
+	"pod3":  {node: "0.0.1.0", gpuIsolation: []int32{8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod4":  {node: "0.0.5.0", gpuIsolation: []int32{0}},
+	"pod5":  {node: "0.0.3.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod6":  {node: "0.0.3.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod8":  {node: "1.0.0.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
+	"pod9":  {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4}},
+	"pod18": {node: "0.0.3.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod19": {node: "0.0.3.3", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod20": {node: "0.0.4.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod21": {node: "0.0.4.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod22": {node: "0.0.4.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	"pod23": {node: "0.0.4.3", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
 }
 
-var expectedPreemptInfos = map[*core.Pod]common.Set{
-	pod16: common.NewSet("pod5", "pod6"),
-	pod17: common.NewSet("pod5", "pod6"),
+var expectedPreemptInfos = map[string]common.Set{
+	"pod16": common.NewSet("pod5", "pod6"),
+	"pod17": common.NewSet("pod5", "pod6"),
 }
 
 var allocatedPods []*core.Pod
@@ -515,7 +370,8 @@ func testNormalOperations(t *testing.T, h *HivedAlgorithm) {
 func testCasesThatShouldSucceed(t *testing.T, h *HivedAlgorithm) {
 	allocatedPods = []*core.Pod{}
 	var psr internal.PodScheduleResult
-	for _, pod := range casesThatShouldSucceed {
+	for _, podName := range casesThatShouldSucceed {
+		pod := allPods[podName]
 		pod.Annotations[api.AnnotationKeyPodSchedulingSpec] = common.ToYaml(pss[pod.UID])
 		psr = h.Schedule(pod, allNodes)
 		compareSchedulingResult(t, pod, psr)
@@ -527,7 +383,7 @@ func testCasesThatShouldSucceed(t *testing.T, h *HivedAlgorithm) {
 	}
 }
 
-func testOneCaseThatShouldFail(t *testing.T, h *HivedAlgorithm, pods []*core.Pod) {
+func testOneCaseThatShouldFail(t *testing.T, h *HivedAlgorithm, podNames []string) {
 	defer func() {
 		if r := recover(); r != nil {
 			if err, ok := r.(*api.WebServerError); ok && err.Code == http.StatusBadRequest {
@@ -540,7 +396,8 @@ func testOneCaseThatShouldFail(t *testing.T, h *HivedAlgorithm, pods []*core.Pod
 		}
 	}()
 	var psr internal.PodScheduleResult
-	for _, pod := range pods {
+	for _, podName := range podNames {
+		pod := allPods[podName]
 		pod.Annotations[api.AnnotationKeyPodSchedulingSpec] = common.ToYaml(pss[pod.UID])
 		psr = h.Schedule(pod, allNodes)
 		allocatedPod := internal.NewBindingPod(pod, psr.PodBindInfo)
@@ -590,6 +447,13 @@ func testReconfiguration(t *testing.T, sConfig *api.Config) {
 	for _, pod := range allocatedPods {
 		h.AddAllocatedPod(pod)
 	}
+	for _, podName := range casesThatShouldDowngrade {
+		pod := allPods[podName]
+		g := h.allocatedAffinityGroups[pss[pod.UID].AffinityGroup.Name]
+		if g.virtualGpuPlacement != nil {
+			t.Errorf("Group %v is expected to be downgraded, but not", g.name)
+		}
+	}
 	testDeleteAllocatedPods(t, h)
 }
 
@@ -617,7 +481,7 @@ func compareGpuIsolation(a []int32, b []int32) bool {
 	return false
 }
 
-func comparePods(a []*core.Pod, b common.Set) bool {
+func containsPods(a []*core.Pod, b common.Set) bool {
 	for _, p := range a {
 		if !b.Contains(p.Name) {
 			return false
@@ -627,14 +491,14 @@ func comparePods(a []*core.Pod, b common.Set) bool {
 }
 
 func compareSchedulingResult(t *testing.T, pod *core.Pod, psr internal.PodScheduleResult) {
-	if expected, ok := expectedBindInfos[pod]; !ok {
+	if expected, ok := expectedBindInfos[pod.Name]; !ok {
 		if psr.PodBindInfo != nil {
 			t.Errorf("[%v]: wrong pod scheduling result: expected empty, but got %v:%v",
 				internal.Key(pod), psr.PodBindInfo.Node, psr.PodBindInfo.GpuIsolation)
 		}
-		if !expectedPreemptInfos[pod].IsEmpty() && !comparePods(psr.PodPreemptInfo.VictimPods, expectedPreemptInfos[pod]) {
+		if !expectedPreemptInfos[pod.Name].IsEmpty() && !containsPods(psr.PodPreemptInfo.VictimPods, expectedPreemptInfos[pod.Name]) {
 			t.Errorf("[%v]: wrong preempt victims: expected %v, but got %v",
-				internal.Key(pod), expectedPreemptInfos[pod], psr.PodPreemptInfo.VictimPods)
+				internal.Key(pod), expectedPreemptInfos[pod.Name], psr.PodPreemptInfo.VictimPods)
 		}
 	} else if psr.PodBindInfo.Node != expected.node ||
 		!compareGpuIsolation(psr.PodBindInfo.GpuIsolation, expected.gpuIsolation) {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -618,15 +618,12 @@ func compareGpuIsolation(a []int32, b []int32) bool {
 }
 
 func comparePods(a []*core.Pod, b common.Set) bool {
-	if len(a) == len(b.Items()) {
-		for _, p := range a {
-			if !b.Contains(p.Name) {
-				return false
-			}
+	for _, p := range a {
+		if !b.Contains(p.Name) {
+			return false
 		}
-		return true
 	}
-	return false
+	return true
 }
 
 func compareSchedulingResult(t *testing.T, pod *core.Pod, psr internal.PodScheduleResult) {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -434,7 +434,8 @@ func testReconfiguration(t *testing.T, sConfig *api.Config) {
 	(*sConfig.PhysicalCluster).PhysicalCells[5].CellChildren[0].CellChildren[0].CellAddress = "0.0.3.100"
 	// case: insufficient VC quota
 	(*sConfig.VirtualClusters)["VC2"].VirtualCells[0].CellNumber = 1
-	// case: inconsistent physical and virtual cell hierarchies
+	// case: physical cells are split to smaller ones in the spec so that
+	// they cannot be bound to the virtual cells previously allocated
 	originalCell := (*sConfig.PhysicalCluster).PhysicalCells[6]
 	(*sConfig.PhysicalCluster).PhysicalCells[6] = originalCell.CellChildren[0].CellChildren[0]
 	(*sConfig.PhysicalCluster).PhysicalCells = append((*sConfig.PhysicalCluster).PhysicalCells, originalCell.CellChildren[0].CellChildren[1])

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -48,7 +48,7 @@ func initNodes(h *HivedAlgorithm) {
 	}
 }
 
-var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, pod13, pod14, pod15, pod16, pod17 = &core.Pod{
+var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, pod13, pod14, pod15, pod16, pod17, pod18, pod19, pod20, pod21, pod22, pod23 = &core.Pod{
 	ObjectMeta: meta.ObjectMeta{
 		Name:        "pod1",
 		Namespace:   "test",
@@ -167,9 +167,51 @@ var pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod10, pod11, pod12, p
 		UID:         "pod17",
 		Annotations: map[string]string{},
 	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod18",
+		Namespace:   "test",
+		UID:         "pod18",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod19",
+		Namespace:   "test",
+		UID:         "pod19",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod20",
+		Namespace:   "test",
+		UID:         "pod20",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod21",
+		Namespace:   "test",
+		UID:         "pod21",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod22",
+		Namespace:   "test",
+		UID:         "pod22",
+		Annotations: map[string]string{},
+	},
+}, &core.Pod{
+	ObjectMeta: meta.ObjectMeta{
+		Name:        "pod23",
+		Namespace:   "test",
+		UID:         "pod23",
+		Annotations: map[string]string{},
+	},
 }
 
-var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10, group11 = &api.AffinityGroupSpec{
+var group1, group2, group3, group4, group5, group6, group7, group8, group9, group10, group11, group12, group13, group14 = &api.AffinityGroupSpec{
 	Name:    "group1",
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
 }, &api.AffinityGroupSpec{
@@ -201,6 +243,15 @@ var group1, group2, group3, group4, group5, group6, group7, group8, group9, grou
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 1, GpuNumber: 1}},
 }, &api.AffinityGroupSpec{
 	Name:    "group11",
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 16}},
+}, &api.AffinityGroupSpec{
+	Name:    "group12",
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 16}},
+}, &api.AffinityGroupSpec{
+	Name:    "group13",
+	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 16}},
+}, &api.AffinityGroupSpec{
+	Name:    "group14",
 	Members: []api.AffinityGroupMemberSpec{{PodNumber: 2, GpuNumber: 16}},
 }
 
@@ -324,11 +375,53 @@ var pss = map[types.UID]api.PodSchedulingSpec{
 		GpuType:        "DGX2-V100",
 		GpuNumber:      16,
 		AffinityGroup:  group11,
+	}, "pod18": { // used for test splitting physical cell hierarchies in reconfiguration
+		VirtualCluster: "VC1",
+		Priority:       1,
+		ReservationId:  "",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group12,
+	}, "pod19": { // used for test splitting physical cell hierarchies in reconfiguration
+		VirtualCluster: "VC1",
+		Priority:       1,
+		ReservationId:  "",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group12,
+	}, "pod20": { // guaranteed pod in splitting physical cell hierarchies
+		VirtualCluster: "VC1",
+		Priority:       1,
+		ReservationId:  "",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group13,
+	}, "pod21": { // guaranteed pod in splitting physical cell hierarchies
+		VirtualCluster: "VC1",
+		Priority:       1,
+		ReservationId:  "",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group13,
+	}, "pod22": { // opportunistic pod in splitting physical cell hierarchies
+		VirtualCluster: "VC1",
+		Priority:       -1,
+		ReservationId:  "",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group14,
+	}, "pod23": { // opportunistic pod in splitting physical cell hierarchies
+		VirtualCluster: "VC1",
+		Priority:       -1,
+		ReservationId:  "",
+		GpuType:        "DGX2-V100",
+		GpuNumber:      16,
+		AffinityGroup:  group14,
 	},
 }
 
 var casesThatShouldSucceed = []*core.Pod{
-	pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod16, pod17,
+	pod1, pod2, pod3, pod4, pod5, pod6, pod7, pod8, pod9, pod16, pod17, pod18, pod19, pod20, pod21, pod22, pod23,
 }
 
 var casesThatShouldFail = [][]*core.Pod{
@@ -341,14 +434,20 @@ type result struct {
 }
 
 var expectedBindInfos = map[*core.Pod]result{
-	pod1: {node: "0.0.1.0", gpuIsolation: []int32{0}},
-	pod2: {node: "0.0.1.0", gpuIsolation: []int32{1}},
-	pod3: {node: "0.0.1.0", gpuIsolation: []int32{8, 9, 10, 11, 12, 13, 14, 15}},
-	pod4: {node: "0.0.5.0", gpuIsolation: []int32{0}},
-	pod5: {node: "0.0.3.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod6: {node: "0.0.3.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
-	pod8: {node: "1.0.0.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
-	pod9: {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4}},
+	pod1:  {node: "0.0.1.0", gpuIsolation: []int32{0}},
+	pod2:  {node: "0.0.1.0", gpuIsolation: []int32{1}},
+	pod3:  {node: "0.0.1.0", gpuIsolation: []int32{8, 9, 10, 11, 12, 13, 14, 15}},
+	pod4:  {node: "0.0.5.0", gpuIsolation: []int32{0}},
+	pod5:  {node: "0.0.3.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod6:  {node: "0.0.3.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod8:  {node: "1.0.0.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6}},
+	pod9:  {node: "1.0.0.2", gpuIsolation: []int32{0, 1, 2, 3, 4}},
+	pod18: {node: "0.0.3.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod19: {node: "0.0.3.3", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod20: {node: "0.0.4.0", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod21: {node: "0.0.4.1", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod22: {node: "0.0.4.2", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
+	pod23: {node: "0.0.4.3", gpuIsolation: []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}},
 }
 
 var expectedPreemptInfos = map[*core.Pod]common.Set{
@@ -369,9 +468,8 @@ func TestHivedAlgorithm(t *testing.T) {
 	}
 
 	printConfig(t, h)
-	testCasesThatShouldSucceed(t, h)
-	testCasesThatShouldFail(t, h)
-	testDeleteAllocatedPods(t, h)
+	testNormalOperations(t, h)
+	testReconfiguration(t, sConfig)
 	testInvalidInitialAssignment(t, sConfig)
 }
 
@@ -408,7 +506,14 @@ func printConfig(t *testing.T, h *HivedAlgorithm) {
 	}
 }
 
+func testNormalOperations(t *testing.T, h *HivedAlgorithm) {
+	testCasesThatShouldSucceed(t, h)
+	testCasesThatShouldFail(t, h)
+	testDeleteAllocatedPods(t, h)
+}
+
 func testCasesThatShouldSucceed(t *testing.T, h *HivedAlgorithm) {
+	allocatedPods = []*core.Pod{}
 	var psr internal.PodScheduleResult
 	for _, pod := range casesThatShouldSucceed {
 		pod.Annotations[api.AnnotationKeyPodSchedulingSpec] = common.ToYaml(pss[pod.UID])
@@ -459,6 +564,33 @@ func testDeleteAllocatedPods(t *testing.T, h *HivedAlgorithm) {
 			t.Errorf("Group %v is expected to be deleted in scheduler, but not", g.name)
 		}
 	}
+}
+
+func testReconfiguration(t *testing.T, sConfig *api.Config) {
+	h := NewHivedAlgorithm(sConfig)
+	for _, chains := range h.chains {
+		sortChains(chains)
+	}
+	testCasesThatShouldSucceed(t, h)
+
+	// case: physical cell not found
+	(*sConfig.PhysicalCluster).PhysicalCells[5].CellChildren[0].CellChildren[0].CellAddress = "0.0.3.100"
+	// case: insufficient VC quota
+	(*sConfig.VirtualClusters)["VC2"].VirtualCells[0].CellNumber = 1
+	// case: inconsistent physical and virtual cell hierarchies
+	originalCell := (*sConfig.PhysicalCluster).PhysicalCells[6]
+	(*sConfig.PhysicalCluster).PhysicalCells[6] = originalCell.CellChildren[0].CellChildren[0]
+	(*sConfig.PhysicalCluster).PhysicalCells = append((*sConfig.PhysicalCluster).PhysicalCells, originalCell.CellChildren[0].CellChildren[1])
+	(*sConfig.PhysicalCluster).PhysicalCells = append((*sConfig.PhysicalCluster).PhysicalCells, originalCell.CellChildren[1].CellChildren[0])
+	(*sConfig.PhysicalCluster).PhysicalCells = append((*sConfig.PhysicalCluster).PhysicalCells, originalCell.CellChildren[1].CellChildren[1])
+	h = NewHivedAlgorithm(sConfig)
+	for _, chains := range h.chains {
+		sortChains(chains)
+	}
+	for _, pod := range allocatedPods {
+		h.AddAllocatedPod(pod)
+	}
+	testDeleteAllocatedPods(t, h)
 }
 
 func testInvalidInitialAssignment(t *testing.T, sConfig *api.Config) {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -80,23 +80,23 @@ func (s *defaultIntraVCScheduler) getReservedCellList() map[api.ReservationId]Ch
 
 func (s *defaultIntraVCScheduler) schedule(sr schedulingRequest) map[int32][]CellList {
 	var scheduler *topologyAwareScheduler
+	var str string
 	if sr.reservationId != "" {
 		scheduler = s.reservedSchedulers[sr.reservationId]
+		str = fmt.Sprintf("reservation %v", sr.reservationId)
 	} else {
 		scheduler = s.nonReservedSchedulers[sr.chain]
+		str = fmt.Sprintf("chain %v", sr.chain)
 	}
 	var placement map[int32][]CellList
 	if scheduler != nil {
 		placement = scheduler.Schedule(sr.affinityGroup, sr.priority)
 	}
 	if placement == nil {
-		var str string
-		if sr.reservationId != "" {
-			str = fmt.Sprintf("reservation %v", sr.reservationId)
-		} else {
-			str = fmt.Sprintf("chain %v", sr.chain)
-		}
 		klog.Infof("Insufficient quota in VC %v for scheduling request: %v, GPU numbers %v, priority %v",
+			sr.vc, str, sr.affinityGroup, sr.priority)
+	} else {
+		klog.Infof("Succeeded in scheduling in VC %v for scheduling request: %v, GPU numbers %v, priority %v",
 			sr.vc, str, sr.affinityGroup, sr.priority)
 	}
 	return placement

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/intra_vc_scheduler.go
@@ -25,6 +25,7 @@ package algorithm
 import (
 	"fmt"
 	"github.com/microsoft/hivedscheduler/pkg/api"
+	"github.com/microsoft/hivedscheduler/pkg/common"
 	"k8s.io/klog"
 )
 
@@ -57,10 +58,10 @@ func newDefaultIntraVCScheduler(
 	snr := map[CellChain]*topologyAwareScheduler{}
 	sr := map[api.ReservationId]*topologyAwareScheduler{}
 	for chain, ccl := range nonReservedVcl {
-		snr[chain] = NewTopologyAwareScheduler(ccl, gpuNums[chain], true)
+		snr[chain] = NewTopologyAwareScheduler(ccl, gpuNums[chain], true, false)
 	}
 	for rid, ccl := range reservedVcl {
-		sr[rid] = NewTopologyAwareScheduler(ccl, gpuNums[ccl[CellLevel(1)][0].GetChain()], true)
+		sr[rid] = NewTopologyAwareScheduler(ccl, gpuNums[ccl[CellLevel(1)][0].GetChain()], true, false)
 	}
 	return &defaultIntraVCScheduler{
 		virtualNonReservedCellList: nonReservedVcl,
@@ -90,7 +91,7 @@ func (s *defaultIntraVCScheduler) schedule(sr schedulingRequest) map[int32][]Cel
 	}
 	var placement map[int32][]CellList
 	if scheduler != nil {
-		placement = scheduler.Schedule(sr.affinityGroup, sr.priority)
+		placement = scheduler.Schedule(sr.affinityGroup, sr.priority, common.NewSet())
 	}
 	if placement == nil {
 		klog.Infof("Insufficient quota in VC %v for scheduling request: %v, GPU numbers %v, priority %v",

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/topology_aware_scheduler.go
@@ -63,6 +63,8 @@ func NewTopologyAwareScheduler(ccl ChainCellList,
 		considerSuggestedNodes: considerSuggestedNodes}
 }
 
+// ancestorNoHigherThanNode finds an ancestor at a level no higher than node level for a cell.
+// If the input cell is at node (or higher) level, will return the cell itself.
 func ancestorNoHigherThanNode(c Cell) Cell {
 	if c.AtOrHigherThanNode() || c.GetParent() == nil {
 		return c

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -104,10 +104,10 @@ func (ccl ChainCellList) remove(c Cell, l CellLevel) {
 // AlgoAffinityGroup is the algorithm-internal representation of an affinity group.
 type AlgoAffinityGroup struct {
 	name                 string
-	totalPodNums         map[int32]int32       // GpuNum -> PodNum
-	allocatedPods        map[int32][]*core.Pod // GpuNum -> a list of allocated pods
-	physicalGpuPlacement map[int32][]CellList  // GpuNum -> a list of pods -> a list of physical GPUs of each pod
-	virtualGpuPlacement  map[int32][]CellList  // GpuNum -> a list of pods -> a list of virtual GPUs of each pod
+	totalPodNums         map[int32]int32        // GpuNum -> PodNum
+	allocatedPods        map[int32][]*podOnNode // GpuNum -> a list of allocated pods and node addresses
+	physicalGpuPlacement map[int32][]CellList   // GpuNum -> a list of pods -> a list of physical GPUs of each pod
+	virtualGpuPlacement  map[int32][]CellList   // GpuNum -> a list of pods -> a list of virtual GPUs of each pod
 }
 
 func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
@@ -118,7 +118,7 @@ func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
 	group := &AlgoAffinityGroup{
 		name:                 g.Name,
 		totalPodNums:         podNums,
-		allocatedPods:        map[int32][]*core.Pod{},
+		allocatedPods:        map[int32][]*podOnNode{},
 		physicalGpuPlacement: map[int32][]CellList{},
 		virtualGpuPlacement:  map[int32][]CellList{},
 	}
@@ -131,4 +131,9 @@ func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
 		}
 	}
 	return group
+}
+
+type podOnNode struct {
+	pod  *core.Pod
+	node string
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -111,15 +111,24 @@ type AlgoAffinityGroup struct {
 }
 
 func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
-	numPods := make(map[int32]int32)
+	podNums := make(map[int32]int32)
 	for _, m := range g.Members {
-		numPods[m.GpuNumber] += m.PodNumber
+		podNums[m.GpuNumber] += m.PodNumber
 	}
-	return &AlgoAffinityGroup{
+	group := &AlgoAffinityGroup{
 		name:                 g.Name,
-		totalPodNums:         numPods,
+		totalPodNums:         podNums,
 		allocatedPods:        map[int32][]*core.Pod{},
 		physicalGpuPlacement: map[int32][]CellList{},
 		virtualGpuPlacement:  map[int32][]CellList{},
 	}
+	for gpuNum, podNum := range podNums {
+		group.physicalGpuPlacement[gpuNum] = make([]CellList, podNum)
+		group.virtualGpuPlacement[gpuNum] = make([]CellList, podNum)
+		for i := int32(0); i < podNum; i++ {
+			group.physicalGpuPlacement[gpuNum][i] = make(CellList, gpuNum)
+			group.virtualGpuPlacement[gpuNum][i] = make(CellList, gpuNum)
+		}
+	}
+	return group
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/types.go
@@ -104,10 +104,10 @@ func (ccl ChainCellList) remove(c Cell, l CellLevel) {
 // AlgoAffinityGroup is the algorithm-internal representation of an affinity group.
 type AlgoAffinityGroup struct {
 	name                 string
-	totalPodNums         map[int32]int32        // GpuNum -> PodNum
-	allocatedPods        map[int32][]*podOnNode // GpuNum -> a list of allocated pods and node addresses
-	physicalGpuPlacement map[int32][]CellList   // GpuNum -> a list of pods -> a list of physical GPUs of each pod
-	virtualGpuPlacement  map[int32][]CellList   // GpuNum -> a list of pods -> a list of virtual GPUs of each pod
+	totalPodNums         map[int32]int32       // GpuNum -> PodNum
+	allocatedPods        map[int32][]*core.Pod // GpuNum -> a list of allocated pods and node addresses
+	physicalGpuPlacement map[int32][]CellList  // GpuNum -> a list of pods -> a list of physical GPUs of each pod
+	virtualGpuPlacement  map[int32][]CellList  // GpuNum -> a list of pods -> a list of virtual GPUs of each pod
 }
 
 func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
@@ -118,7 +118,7 @@ func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
 	group := &AlgoAffinityGroup{
 		name:                 g.Name,
 		totalPodNums:         podNums,
-		allocatedPods:        map[int32][]*podOnNode{},
+		allocatedPods:        map[int32][]*core.Pod{},
 		physicalGpuPlacement: map[int32][]CellList{},
 		virtualGpuPlacement:  map[int32][]CellList{},
 	}
@@ -131,9 +131,4 @@ func newAlgoAffinityGroup(g *api.AffinityGroupSpec) *AlgoAffinityGroup {
 		}
 	}
 	return group
-}
-
-type podOnNode struct {
-	pod  *core.Pod
-	node string
 }

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
@@ -106,9 +106,9 @@ type AffinityGroupMemberBindInfo struct {
 }
 
 type PodPlacementInfo struct {
-	PhysicalNode       string  `yaml:"physicalNode"`
-	PhysicalGpuIndices []int32 `yaml:"physicalGpuIndices"`
-	VirtualCellIndices []int32 `yaml:"virtualCellIndices"`
+	PhysicalNode          string  `yaml:"physicalNode"`
+	PhysicalGpuIndices    []int32 `yaml:"physicalGpuIndices"`
+	PreassignedCellLevels []int32 `yaml:"preassignedCellLevels"`
 }
 
 type WebServerPaths struct {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
@@ -106,8 +106,10 @@ type AffinityGroupMemberBindInfo struct {
 }
 
 type PodPlacementInfo struct {
-	PhysicalNode          string  `yaml:"physicalNode"`
-	PhysicalGpuIndices    []int32 `yaml:"physicalGpuIndices"`
+	PhysicalNode       string  `yaml:"physicalNode"`
+	PhysicalGpuIndices []int32 `yaml:"physicalGpuIndices"`
+	// levels of the preassigned cells used by the pods. used to locate the virtual cells
+	// when adding an allocated pod
 	PreassignedCellLevels []int32 `yaml:"preassignedCellLevels"`
 }
 


### PR DESCRIPTION
Support for reconfigurations.
1. Physical cell of a pod cannot be found: ignore the pod (won't add it to the internal view).
2. Virtual cell of a pod cannot be found, i.e., usage exceeds quota: downgrade the affinity group to opportunistic.
3. Physical and virtual cells cannot be bound, i.e., cell hierarchies don't match: downgrade the affinity group to opportunistic.

Aware of K8s suggested nodes: will use nodes suggested by K8s first. Note that this is best-effort, meaning that if we have to use a node not in the suggested nodes for safety reasons, we will still return that node. Such a case will result in a panic during scheduling, which will terminate this scheduling cycle immediately and start the next one.

This PR also has several minor bug fixes.