### PR TITLE
[Rest Server] Application token api

### DIFF
--- a/docs/rest-server/API.md
+++ b/docs/rest-server/API.md
@@ -195,6 +195,118 @@ Status: 500
 }
 ```
 
+### `POST application token`
+
+Create an application access token in the system.<br />
+Application access token can only be used for job related operations.<br />
+Application access token has no expiration time and can be revoked manually.
+
+*Request*
+
+```json
+POST /api/v1/token/application
+Authorization: Bearer <ACCESS_TOKEN>
+```
+
+*Response if succeeded*
+
+```json
+Status: 200
+
+{
+  "token": "your access token",
+  "application": true,
+}
+```
+
+*Response if not authorized*
+
+```json
+Status: 401
+
+{
+  "code": "UnauthorizedUserError",
+  "message": "Guest is not allowed to do this operation."
+}
+```
+
+### `GET token`
+
+Get your currently signed tokens.
+
+*Request*
+
+```json
+GET /api/v1/token/
+Authorization: Bearer <ACCESS_TOKEN>
+```
+
+*Response if succeeded*
+
+```json
+Status: 200
+
+{
+  "tokens": [
+    "jwt string",
+  ]
+}
+```
+
+*Response if not authorized*
+
+```json
+Status: 401
+
+{
+  "code": "UnauthorizedUserError",
+  "message": "Guest is not allowed to do this operation."
+}
+```
+
+### `DELETE token/:token`
+
+Revoke a token.
+
+*Request*
+
+```json
+DELETE /api/v1/token/:token
+Authorization: Bearer <ACCESS_TOKEN>
+```
+
+*Response if succeeded*
+
+```json
+Status: 200
+
+{
+  "message": "revoke successfully"
+}
+```
+
+*Response if not authorized*
+
+```json
+Status: 401
+
+{
+  "code": "UnauthorizedUserError",
+  "message": "Guest is not allowed to do this operation."
+}
+```
+
+*Response if current user has no permission*
+
+```json
+Status: 403
+
+{
+  "code": "ForbiddenUserError",
+  "message": "User is not allow to do this operation."
+}
+```
+
 ### `POST user` (administrator only, basic authentication mode only)
 
 Admin can create a user in system.

--- a/src/rest-server/deploy/delete.sh
+++ b/src/rest-server/deploy/delete.sh
@@ -41,4 +41,10 @@ if kubectl get namespace | grep -q "pai-storage "; then
     kubectl delete ns pai-storage || exit $?
 fi
 
+echo "Delete pai-user-token namespace"
+if kubectl get namespace | grep -q "pai-user-token "; then
+    kubectl delete ns pai-user-token || exit $?
+fi
+
+
 popd > /dev/null

--- a/src/rest-server/src/config/kubernetes.js
+++ b/src/rest-server/src/config/kubernetes.js
@@ -19,9 +19,9 @@
 const assert = require('assert');
 const {readFileSync} = require('fs');
 const path = require('path');
-const config = Object.create(null);
 const logger = require('@pai/config/logger');
-const apiserverConfig = config.apiserver = Object.create(null);
+
+const apiserverConfig = {};
 
 const {
   K8S_APISERVER_URI,
@@ -63,4 +63,6 @@ if (process.env.RBAC_IN_CLUSTER === 'false') {
 
 assert(apiserverConfig.uri, 'K8S_APISERVER_URI should be set in environments');
 
-module.exports = config;
+module.exports = {
+  apiserver: apiserverConfig,
+};

--- a/src/rest-server/src/controllers/v2/user.js
+++ b/src/rest-server/src/controllers/v2/user.js
@@ -442,26 +442,6 @@ const deleteUser = async (req, res, next) => {
   }
 };
 
-const checkUserPassword = async (req, res, next) => {
-  try {
-    const username = req.body.username;
-    const password = req.body.password;
-    let userValue = await userModel.getUser(username);
-    let newUserValue = JSON.parse(JSON.stringify(userValue));
-    newUserValue['password'] = password;
-    newUserValue = await userModel.getEncryptPassword(newUserValue);
-    if (newUserValue['password'] !== userValue['password']) {
-      return next(createError('Bad Request', 'IncorrectPasswordError', 'Password is incorrect.'));
-    }
-    next();
-  } catch (error) {
-    if (error.status && error.status === 404) {
-      return next(createError('Bad Request', 'NoUserError', `User ${req.body.username} is not found.`));
-    }
-    return next(createError.unknown((error)));
-  }
-};
-
 // module exports
 module.exports = {
   getUser,
@@ -478,7 +458,6 @@ module.exports = {
   deleteUser,
   updateUserPassword,
   createUser,
-  checkUserPassword,
   getUserVCs,
   getUserStorageConfigs,
 };

--- a/src/rest-server/src/models/k8s-secret.js
+++ b/src/rest-server/src/models/k8s-secret.js
@@ -18,6 +18,7 @@
 const axios = require('axios');
 const _ = require('lodash');
 const {Agent} = require('https');
+const {URL} = require('url');
 
 const {apiserver} = require('@pai/config/kubernetes');
 

--- a/src/rest-server/src/models/k8s-secret.js
+++ b/src/rest-server/src/models/k8s-secret.js
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const axios = require('axios');
+const _ = require('lodash');
+const {Agent} = require('https');
+
+const {apiserver} = require('@pai/config/kubernetes');
+
+const initClient = (namespace) => {
+  if (!namespace) {
+    throw new Error('K8S SECRET: invalid namespace');
+  }
+  const config = {
+    baseURL: new URL(`/api/v1/namespaces/${namespace}/secrets`, apiserver.uri).href,
+    maxRedirects: 0,
+    headers: {
+      'Accept': 'application/json',
+    },
+  };
+  if (apiserver.ca) {
+    config.httpsAgent = new Agent({ca: apiserver.ca});
+  }
+  if (apiserver.token) {
+    config.headers['Authorization'] = `Bearer ${apiserver.token}`;
+  }
+  return axios.create(config);
+};
+
+const serialize = (object) => {
+  if (object == null) {
+    return {};
+  }
+
+  const result = {};
+  for (const [key, val] of Object.entries(object)) {
+    result[key] = Buffer.from(val).toString('base64');
+  }
+  return result;
+};
+
+
+const deserialize = (object) => {
+  if (object == null) {
+    return {};
+  }
+
+  const result = {};
+  for (const [key, val] of Object.entries(object)) {
+    result[key] = Buffer.from(val, 'base64').toString();
+  }
+  return result;
+};
+
+const encodeLabeLSelector = (labelSelector) => {
+  const builder = [];
+  for (const [key, val] of Object.entries(labelSelector)) {
+    builder.push(`${key}=${val}`);
+  }
+  return builder.join(',');
+};
+
+const createNamespace = async (namespace) => {
+  const url = new URL(`/api/v1/namespaces/`, apiserver.uri).href;
+  const config = {
+    maxRedirects: 0,
+    headers: {
+      'Accept': 'application/json',
+    },
+  };
+  if (apiserver.ca) {
+    config.httpsAgent = new Agent({ca: apiserver.ca});
+  }
+  if (apiserver.token) {
+    config.headers['Authorization'] = `Bearer ${apiserver.token}`;
+  }
+  try {
+    await axios.post(url, {
+      metadata: {
+        name: namespace,
+      },
+    }, config);
+  } catch (err) {
+    if (err.response && err.response.status === 409 && err.response.data.reason === 'AlreadyExists') {
+      // pass
+    } else {
+      throw err;
+    }
+  }
+};
+
+const get = async (namespace, key) => {
+  if (!key) {
+    return list(namespace);
+  }
+  const client = initClient(namespace);
+  const hexKey = Buffer.from(key).toString('hex');
+
+  try {
+    const response = await client.get(`/${hexKey}`);
+    return deserialize(response.data.data);
+  } catch (err) {
+    if (err.response && err.response.status === 404 && err.response.data) {
+      return null;
+    } else {
+      throw err;
+    }
+  }
+};
+
+const list = async (namespace, labelSelector) => {
+  const labelSelectorStr = encodeLabeLSelector(labelSelector);
+  const client = initClient(namespace);
+  let continueValue = null;
+  let result = [];
+  do {
+    let response;
+    try {
+      // param
+      const params = {
+        labelSelector: labelSelectorStr,
+      };
+      if (continueValue) {
+        params.continue = continueValue;
+      }
+      // request
+      response = await client.get('/', {params});
+    } catch (err) {
+      if (err.response && err.response.status === 410) {
+        // restart
+        continueValue = null;
+        result = [];
+        continue;
+      } else {
+        throw err;
+      }
+    }
+    continueValue = response.metadata && response.metadata.continue;
+    const items = _.get(response, 'data.items') || [];
+    result.push(...items);
+  } while (continueValue !== undefined);
+
+  const output = {};
+  for (const item of result) {
+    const name = Buffer.from(item.metadata.name, 'hex').toString();
+    output[name] = deserialize(item.data);
+  }
+  return output;
+};
+
+const create = async (namespace, key, data, labels) => {
+  const client = initClient(namespace);
+  const hexKey = Buffer.from(key).toString('hex');
+
+  const response = await client.post('/', {
+    metadata: {
+      name: hexKey,
+      namespace,
+      labels,
+    },
+    data: serialize(data),
+  });
+
+  return response.data;
+};
+
+const replace = async (namespace, key, data, labels) => {
+  const client = initClient(namespace);
+  const hexKey = Buffer.from(key).toString('hex');
+
+  const response = await client.put(`/${hexKey}`, {
+    metadata: {
+      name: hexKey,
+      namespace,
+      labels,
+    },
+    data: serialize(data),
+  });
+
+  return response.data;
+};
+
+const remove = async (namespace, key) => {
+  const client = initClient(namespace);
+  const hexKey = Buffer.from(key).toString('hex');
+
+  await client.delete(`/${hexKey}`);
+};
+
+module.exports = {
+  createNamespace,
+  get,
+  list,
+  create,
+  replace,
+  remove,
+};

--- a/src/rest-server/src/models/k8s-secret.js
+++ b/src/rest-server/src/models/k8s-secret.js
@@ -42,6 +42,12 @@ const initClient = (namespace) => {
   return axios.create(config);
 };
 
+
+/**
+ * Serialize key-value object to k8s secret's base64 encoded data structure
+ * @param {Object} object - key-value dictionary, value should be string
+ * @returns {Object}
+ */
 const serialize = (object) => {
   if (object == null) {
     return {};
@@ -54,7 +60,11 @@ const serialize = (object) => {
   return result;
 };
 
-
+/**
+ * Deserialize k8s secret's base64 encoded data structure to key-value object
+ * @param {Object} object - k8s secret's data
+ * @returns {Object} key-value dictionary, value is string.
+ */
 const deserialize = (object) => {
   if (object == null) {
     return {};
@@ -109,6 +119,8 @@ const get = async (namespace, key) => {
     return list(namespace);
   }
   const client = initClient(namespace);
+  // k8s resource's name must consisst of only digits (0-9), lower case letters (a-z), -, and ..
+  // We encode the key here to ensure it is valid.
   const hexKey = Buffer.from(key).toString('hex');
 
   try {

--- a/src/rest-server/src/models/token.js
+++ b/src/rest-server/src/models/token.js
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const jwt = require('jsonwebtoken');
+const uuid = require('uuid');
+const logger = require('@pai/config/logger');
+const {secret, tokenExpireTime} = require('@pai/config/token');
+const k8sSecret = require('@pai/models/k8s-secret');
+
+const namespace = process.env.PAI_TOKEN_NAMESPACE || 'pai-user-token';
+
+// create namespace if not exists
+if (process.env.NODE_ENV !== 'test') {
+  logger.info(`Create token secret namespace (${namespace}) if not exist`);
+  k8sSecret.createNamespace(namespace);
+}
+
+const sign = async (username, application, expiration) => {
+  return new Promise((res, rej) => {
+    jwt.sign(
+      {
+        username,
+        application,
+      },
+      secret,
+      expiration != null ? {expiresIn: expiration} : {},
+      (signError, token) => {
+        signError ? rej(signError) : res(token);
+      }
+    );
+  });
+};
+
+const purge = (data) => {
+  const result = {};
+  for (const [key, val] of Object.entries(data)) {
+    try {
+      jwt.verify(val, secret);
+      result[key] = val;
+    } catch (err) {
+      // pass;
+    }
+  }
+  return result;
+};
+
+const list = async (username) => {
+  const item = await k8sSecret.get(namespace, username);
+  if (item === null) {
+    return {};
+  }
+
+  const purged = purge(item);
+  if (Object.keys(item).length !== Object.keys(purged).length) {
+    await k8sSecret.replace(namespace, username, purged);
+  }
+  return Object.values(purged);
+};
+
+const create = async (username, application = false, expiration) => {
+  if (application) {
+    expiration = expiration || undefined;
+  } else {
+    expiration = expiration || tokenExpireTime;
+  }
+  const token = await sign(username, application, expiration);
+  const item = await k8sSecret.get(namespace, username);
+  if (item === null) {
+    await k8sSecret.create(namespace, username, {
+      [uuid()]: token,
+    });
+  } else {
+    const result = purge(item);
+    result[uuid()] = token;
+    await k8sSecret.replace(namespace, username, result);
+  }
+  return token;
+};
+
+const revoke = async (token) => {
+  const payload = jwt.verify(token, secret);
+  const username = payload.username;
+  if (!username) {
+    throw new Error('Token is invalid');
+  }
+  const item = await k8sSecret.get(namespace, username);
+  if (item === null) {
+    throw new Error('Token is invalid');
+  }
+  const result = purge(item);
+  for (const [key, val] of Object.entries(result)) {
+    if (val === token) {
+      delete result[key];
+    }
+  }
+  await k8sSecret.replace(namespace, username, result);
+};
+
+const verify = async (token) => {
+  const payload = jwt.verify(token, secret);
+  const username = payload.username;
+  if (!username) {
+    throw new Error('Token is invalid');
+  }
+  const item = await k8sSecret.get(namespace, username);
+  if (item === null) {
+    throw new Error('Token is invalid');
+  }
+  const purged = purge(item);
+  for (const [, val] of Object.entries(purged)) {
+    if (val === token) {
+      return payload;
+    }
+  }
+  if (Object.keys(item).length !== Object.keys(purged).length) {
+    await k8sSecret.replace(namespace, username, purged);
+  }
+  throw new Error('Token has been revoked');
+};
+
+module.exports = {
+  list,
+  create,
+  revoke,
+  verify,
+};

--- a/src/rest-server/src/models/token.js
+++ b/src/rest-server/src/models/token.js
@@ -45,6 +45,12 @@ const sign = async (username, application, expiration) => {
   });
 };
 
+
+/**
+ * Remove invalid (expired/malformed) tokens from given token list object.
+ * @param {Object} data - id -> token format data object (data stored in k8s secret)
+ * @returns {Object} Purged data in the same format
+ */
 const purge = (data) => {
   const result = {};
   for (const [key, val] of Object.entries(data)) {

--- a/src/rest-server/src/routes/authn.js
+++ b/src/rest-server/src/routes/authn.js
@@ -20,7 +20,7 @@ const express = require('express');
 const tokenConfig = require('@pai/config/token');
 const param = require('@pai/middlewares/parameter');
 const userController = require('@pai/controllers/v2/user');
-const tokenV2Controller = require('@pai/controllers/v2/token');
+const tokenController = require('@pai/controllers/v2/token');
 const azureADController = require('@pai/controllers/v2/azureAD');
 const authnConfig = require('@pai/config/authn');
 
@@ -61,7 +61,7 @@ if (authnConfig.authnMethod === 'OIDC') {
       azureADController.parseTokenData,
       userController.createUserIfUserNotExist,
       userController.updateUserGroupListFromExternal,
-      tokenV2Controller.getAAD
+      tokenController.getAAD
     )
     /** POST /api/v1/authn/oidc/return - AAD AUTH RETURN */
     .post(
@@ -69,13 +69,13 @@ if (authnConfig.authnMethod === 'OIDC') {
       azureADController.parseTokenData,
       userController.createUserIfUserNotExist,
       userController.updateUserGroupListFromExternal,
-      tokenV2Controller.getAAD
+      tokenController.getAAD
     );
 } else {
   router.route('/basic/login')
   /** POST /api/v1/authn/basic/login - Return a token if username and password is correct */
     .post(
-      param.validate(tokenConfig.tokenPostInputSchema), userController.checkUserPassword, tokenV2Controller.get);
+      param.validate(tokenConfig.tokenPostInputSchema), tokenController.get);
 }
 
 // module exports

--- a/src/rest-server/src/routes/v2/group.js
+++ b/src/rest-server/src/routes/v2/group.js
@@ -34,27 +34,27 @@ router.route('/')
 
 router.route('/:groupname/extension')
 /** Put /api/v2/group/:groupname/extension */
-  .put(token.check, param.validate(groupInputSchema.groupExtensionUpdateInputSchema), groupController.updateGroupExtension);
+  .put(token.checkNotApplication, param.validate(groupInputSchema.groupExtensionUpdateInputSchema), groupController.updateGroupExtension);
 
 router.route('/:groupname/extension/*')
 /** Put /api/v2/group/:groupname/extension/:attribute */
-  .put(token.check, param.validate(groupInputSchema.groupExtensionAttrUpdateInputSchema), groupController.updateGroupExtensionAttr);
+  .put(token.checkNotApplication, param.validate(groupInputSchema.groupExtensionAttrUpdateInputSchema), groupController.updateGroupExtensionAttr);
 
 router.route('/:groupname/description')
 /** Put /api/v2/group/:groupname/description */
-  .put(token.check, param.validate(groupInputSchema.groupDescriptionUpdateInputSchema), groupController.updateGroupDescription);
+  .put(token.checkNotApplication, param.validate(groupInputSchema.groupDescriptionUpdateInputSchema), groupController.updateGroupDescription);
 
 router.route('/:groupname')
 /** Post /api/v2/group/:groupname */
-  .delete(token.check, groupController.deleteGroup);
+  .delete(token.checkNotApplication, groupController.deleteGroup);
 
 router.route('/')
 /** Create /api/v2/group */
-  .post(token.check, param.validate(groupInputSchema.groupCreateInputSchema), groupController.createGroup);
+  .post(token.checkNotApplication, param.validate(groupInputSchema.groupCreateInputSchema), groupController.createGroup);
 
 router.route('/:groupname/externalname')
 /** put /api/v2/group/:groupname/external' */
-  .put(token.check, param.validate(groupInputSchema.groupExternalNameUpdateInputSchema), groupController.updateGroupExternalName);
+  .put(token.checkNotApplication, param.validate(groupInputSchema.groupExternalNameUpdateInputSchema), groupController.updateGroupExternalName);
 
 router.route('/:groupname/userlist')
 /** get /api/v2/group/:groupname/userlist */

--- a/src/rest-server/src/routes/v2/user.js
+++ b/src/rest-server/src/routes/v2/user.js
@@ -36,41 +36,41 @@ router.route('/')
 
 router.route('/:username/extension')
   /** Put /api/v2/user/:username/extension */
-  .put(token.check, param.validate(userInputSchema.userExtensionUpdateInputSchema), userController.updateUserExtension);
+  .put(token.checkNotApplication, param.validate(userInputSchema.userExtensionUpdateInputSchema), userController.updateUserExtension);
 
 if (authnConfig.authnMethod === 'basic') {
   router.route('/:username')
   /** Delete /api/v2/user/:username */
-    .delete(token.check, userController.deleteUser);
+    .delete(token.checkNotApplication, userController.deleteUser);
 
   router.route('/:username/virtualcluster')
   /** Update /api/v2/user/:username/virtualcluster */
-    .put(token.check, param.validate(userInputSchema.userVirtualClusterUpdateInputSchema), userController.updateUserVirtualCluster);
+    .put(token.checkNotApplication, param.validate(userInputSchema.userVirtualClusterUpdateInputSchema), userController.updateUserVirtualCluster);
 
   router.route('/:username/password')
   /** Update /api/v2/user/:username/password */
-    .put(token.check, param.validate(userInputSchema.userPasswordUpdateInputSchema), userController.updateUserPassword);
+    .put(token.checkNotApplication, param.validate(userInputSchema.userPasswordUpdateInputSchema), userController.updateUserPassword);
 
   router.route('/')
   /** Create /api/v2/user */
-    .post(token.check, param.validate(userInputSchema.userCreateInputSchema), userController.createUser);
+    .post(token.checkNotApplication, param.validate(userInputSchema.userCreateInputSchema), userController.createUser);
 
   router.route('/:username/email')
   /** Update /api/v2/user/:username/email */
-    .put(token.check, param.validate(userInputSchema.userEmailUpdateInputSchema), userController.updateUserEmail);
+    .put(token.checkNotApplication, param.validate(userInputSchema.userEmailUpdateInputSchema), userController.updateUserEmail);
 
   router.route('/:username/admin')
   /** Update /api/v2/user/:username/admin */
-    .put(token.check, param.validate(userInputSchema.userAdminPermissionUpdateInputSchema), userController.updateUserAdminPermission);
+    .put(token.checkNotApplication, param.validate(userInputSchema.userAdminPermissionUpdateInputSchema), userController.updateUserAdminPermission);
 
   router.route('/:username/grouplist')
-    .put(token.check, param.validate(userInputSchema.userGrouplistUpdateInputSchema), userController.updateUserGroupList);
+    .put(token.checkNotApplication, param.validate(userInputSchema.userGrouplistUpdateInputSchema), userController.updateUserGroupList);
 
   router.route('/:username/group')
-    .put(token.check, param.validate(userInputSchema.addOrRemoveGroupInputSchema), userController.addGroupIntoUserGrouplist);
+    .put(token.checkNotApplication, param.validate(userInputSchema.addOrRemoveGroupInputSchema), userController.addGroupIntoUserGrouplist);
 
   router.route('/:username/group')
-    .delete(token.check, param.validate(userInputSchema.addOrRemoveGroupInputSchema), userController.removeGroupFromUserGrouplist);
+    .delete(token.checkNotApplication, param.validate(userInputSchema.addOrRemoveGroupInputSchema), userController.removeGroupFromUserGrouplist);
 }
 
 router.use('/:username/jobs', jobRouter);

--- a/src/rest-server/src/routes/v2/virtual-cluster.js
+++ b/src/rest-server/src/routes/v2/virtual-cluster.js
@@ -32,13 +32,13 @@ router.route('/:virtualClusterName')
   /** GET /api/v2/virtual-clusters/:virtualClusterName - Get virtual cluster */
   .get(controller.get)
   /** PUT /api/v2/virtual-clusters/:virtualClusterName - Create a virtual cluster */
-  .put(token.check, param.validate(vcConfig.vcCreateInputSchema), controller.update)
+  .put(token.checkNotApplication, param.validate(vcConfig.vcCreateInputSchema), controller.update)
   /** DELETE /api/v2/virtual-clusters/:virtualClusterName - Remove a virtual cluster */
-  .delete(token.check, controller.remove);
+  .delete(token.checkNotApplication, controller.remove);
 
 router.route('/:virtualClusterName/status')
   /** PUT /api/v2/virtual-clusters/:virtualClusterName/status - Change virtual cluster status (running or stopped) */
-  .put(token.check, param.validate(vcConfig.vcStatusPutInputSchema), controller.updateStatus);
+  .put(token.checkNotApplication, param.validate(vcConfig.vcStatusPutInputSchema), controller.updateStatus);
 
 router.route('/:virtualClusterName/resource-units')
   /** GET /api/v2/virtual-clusters/:virtualClusterName/resource-units - Get virtual cluster available resource units */

--- a/src/rest-server/src/routes/vc.js
+++ b/src/rest-server/src/routes/vc.js
@@ -31,14 +31,14 @@ router.route('/:vcName')
     /** GET /api/v1/virtual-clusters/vcName - Return cluster specified virtual cluster info */
     .get(vcController.get)
     /** PUT /api/v1/virtual-clusters/vcName - Update a vc */
-    .put(token.check, param.validate(vcConfig.vcCreateInputSchema), vcController.update)
+    .put(token.checkNotApplication, param.validate(vcConfig.vcCreateInputSchema), vcController.update)
     /** DELETE /api/v1/virtual-clusters/vcName - Remove a vc */
-    .delete(token.check, vcController.remove);
+    .delete(token.checkNotApplication, vcController.remove);
 
 
 router.route('/:vcName/status')
     /** PUT /api/v1/virtual-clusters/vcName - Change vc status (running or stopped) */
-    .put(token.check, param.validate(vcConfig.vcStatusPutInputSchema), vcController.updateStatus);
+    .put(token.checkNotApplication, param.validate(vcConfig.vcStatusPutInputSchema), vcController.updateStatus);
 
 
 router.param('vcName', vcController.validate);

--- a/src/rest-server/src/utils/manager/user/user.js
+++ b/src/rest-server/src/utils/manager/user/user.js
@@ -63,4 +63,4 @@ async function encryptUserPassword(userValue) {
   await encryptPassword(userValue);
 }
 
-module.exports = {encryptUserPassword, createUser: userValidate};
+module.exports = {encrypt, encryptUserPassword, createUser: userValidate};

--- a/src/rest-server/test/data/nock/group-template.yaml
+++ b/src/rest-server/test/data/nock/group-template.yaml
@@ -1,0 +1,11 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: 61646d696e47726f7570 # adminGroup (hex)
+type: Opaque
+data:
+  groupname: YWRtaW5Hcm91cA== # adminGroup (base64)
+  description: dGVzdA==
+  externalName: MTIzNA==
+  extension: >-
+    eyJhY2xzIjp7ImFkbWluIjp0cnVlLCJ2aXJ0dWFsQ2x1c3RlcnMiOlsiZGVmYXVsdCJdfX0= # {"acls":{"admin":true,"virtualClusters":["default"]}}

--- a/src/rest-server/test/data/nock/user-template.yaml
+++ b/src/rest-server/test/data/nock/user-template.yaml
@@ -1,0 +1,13 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: 61646d696e
+  namespace: pai-user-v2
+type: Opaque
+data:
+  password: >- # admin
+    ZDgzMzY3NGY1ZGQ3NjE3OWU2MWEwN2NiNzdjOTE4ZTg4Nzg2ZDMyMDFlZWI0ZGYzNDk1ODA2ODEzZTZiYmZiYjRlYjk1M2YyNDYwMDlhMWIxNDkwNjY5ZTA5ODA3ZGQ0M2UxMjViNjEyMWMxZjA3YjQ0NzQ3MzcyNTEzNDJjMjU=
+  username: YWRtaW4= # admin
+  email: dGVzdEBwYWkuY29t # test@pai.com
+  grouplist: WyJhZG1pbkdyb3VwIl0= # ["adminGroup"]
+  extension: e30= # {}

--- a/src/rest-server/test/groupManagement.js
+++ b/src/rest-server/test/groupManagement.js
@@ -15,6 +15,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+const nockUtils = require('./utils/nock');
+
 const defaultGroupSchema = {
   'kind': 'Secret',
   'apiVersion': 'v1',
@@ -30,12 +32,6 @@ const defaultGroupSchema = {
   'type': 'Opaque',
 };
 
-//
-// Get a valid token that expires in 60 seconds.
-//
-
-const validToken = global.jwt.sign({username: 'new_user', admin: true}, process.env.JWT_SECRET, {expiresIn: 60});
-const nonAdminToken = global.jwt.sign({username: 'non_admin_user', admin: false}, process.env.JWT_SECRET, {expiresIn: 60});
 // const invalidToken = '';
 
 describe('Group Model k8s secret extension attrs update test', () => {
@@ -81,6 +77,8 @@ describe('Group Model k8s secret extension attrs update test', () => {
         'type': 'Opaque',
       });
 
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
+
     global.chai.request(global.server)
       .put('/api/v2/group/default/extension/acls/virtualClusters')
       .set('Authorization', 'Bearer ' + validToken)
@@ -94,6 +92,7 @@ describe('Group Model k8s secret extension attrs update test', () => {
   });
 
   it('Case 2 (Negative): non-admin should not update group extension vc', (done) => {
+    const nonAdminToken = nockUtils.registerUserTokenCheck('userX');
     global.chai.request(global.server)
       .put('/api/v2/group/default/extension/acls/virtualClusters')
       .set('Authorization', 'Bearer ' + nonAdminToken)
@@ -141,6 +140,7 @@ describe('Group Model k8s secret extension attrs update test', () => {
         'type': 'Opaque',
       });
 
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/group/default/extension/acls/admin')
       .set('Authorization', 'Bearer ' + validToken)
@@ -170,6 +170,7 @@ describe('Group Model k8s secret extension attrs update test', () => {
         'code': 404,
       });
 
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/group/non-exist/extension/acls/admin')
       .set('Authorization', 'Bearer ' + validToken)
@@ -217,6 +218,7 @@ describe('Group Model k8s secret extension attrs update test', () => {
         'type': 'Opaque',
       });
 
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/group/default/extension/testfield')
       .set('Authorization', 'Bearer ' + validToken)

--- a/src/rest-server/test/jobExecutionType.js
+++ b/src/rest-server/test/jobExecutionType.js
@@ -15,6 +15,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+const nockUtils = require('./utils/nock');
 
 // test
 describe('Job execution type API /api/v2/user/:username/jobs/:jobName/executionType', () => {
@@ -105,9 +106,11 @@ describe('Job execution type API /api/v2/user/:username/jobs/:jobName/executionT
 
   // PUT /api/v1/jobs/:jobName/executionType
   it('should stop job successfully', (done) => {
+    const token = nockUtils.registerAdminTokenCheck('iamadmin');
+
     chai.request(server)
       .put('/api/v2/user/iamadmin/jobs/test1/executionType')
-      .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImlhbWFkbWluIiwiYWRtaW4iOnRydWUsImlhdCI6MTUyMDU3OTg5OX0.Dwopr33c_OV6glaN3vbM1Ja_Ox70xABigHzHnEsNsYw')
+      .set('Authorization', `Bearer ${token}`)
       .send({
         'value': 'STOP',
       })
@@ -120,9 +123,11 @@ describe('Job execution type API /api/v2/user/:username/jobs/:jobName/executionT
   });
 
   it('admin should stop other user\'s job successfully', (done) => {
+    const token = nockUtils.registerAdminTokenCheck('iamadmin');
+
     chai.request(server)
       .put('/api/v2/user/test2/jobs/test2/executionType')
-      .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImlhbWFkbWluIiwiYWRtaW4iOnRydWUsImlhdCI6MTUyMDU3OTg5OX0.Dwopr33c_OV6glaN3vbM1Ja_Ox70xABigHzHnEsNsYw')
+      .set('Authorization', `Bearer ${token}`)
       .send({
         'value': 'STOP',
       })
@@ -151,7 +156,7 @@ describe('Job execution type API /api/v2/user/:username/jobs/:jobName/executionT
   it('#909: should check request payload', (done) => {
     chai.request(server)
       .put('/api/v2/user/iamadmin/jobs/test1/executionType')
-      .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImlhbWFkbWluIiwiYWRtaW4iOnRydWUsImlhdCI6MTUyMDU3OTg5OX0.Dwopr33c_OV6glaN3vbM1Ja_Ox70xABigHzHnEsNsYw')
+      .set('Authorization', 'Bearer token') // API will check payload schema before token.
       .set('Content-Type', 'text/unknown')
       .send('value=STOP')
       .end((err, res) => {
@@ -229,9 +234,10 @@ describe('Job execution type API /api/v1/jobs/:jobName/executionType', () => {
 
   // PUT /api/v1/jobs/:jobName/executionType
   it('can stop job without namespace', (done) => {
+    const token = nockUtils.registerAdminTokenCheck('iamadmin');
     chai.request(server)
       .put('/api/v1/jobs/test1/executionType')
-      .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImlhbWFkbWluIiwiYWRtaW4iOnRydWUsImlhdCI6MTUyMDU3OTg5OX0.Dwopr33c_OV6glaN3vbM1Ja_Ox70xABigHzHnEsNsYw')
+      .set('Authorization', `Bearer ${token}`)
       .send({
         'value': 'STOP',
       })

--- a/src/rest-server/test/userManagement.js
+++ b/src/rest-server/test/userManagement.js
@@ -15,6 +15,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+const nockUtils = require('./utils/nock');
+
 /* const deleteUserTemplate = JSON.stringify({
   'username': '{{username}}',
 }); */
@@ -296,9 +298,6 @@ const adminGroupSchema = {
 // Get a valid token that expires in 60 seconds.
 //
 
-const validToken = global.jwt.sign({username: 'new_user', admin: true}, process.env.JWT_SECRET, {expiresIn: 60});
-const nonAdminToken = global.jwt.sign({username: 'non_admin_user', admin: false}, process.env.JWT_SECRET, {expiresIn: 60});
-// const invalidToken = '';
 
 describe('Add new user: post /api/v2/user', () => {
   after(function() {
@@ -422,6 +421,8 @@ describe('Add new user: post /api/v2/user', () => {
   //
 
   it('Case 1 (Positive): Add admin user', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
+
     global.chai.request(global.server)
       .post('/api/v2/user')
       .set('Authorization', 'Bearer ' + validToken)
@@ -441,6 +442,7 @@ describe('Add new user: post /api/v2/user', () => {
   });
 
   it('Case 2 (Positive): Add non_admin user', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .post('/api/v2/user')
       .set('Authorization', 'Bearer ' + validToken)
@@ -464,6 +466,7 @@ describe('Add new user: post /api/v2/user', () => {
   //
 
   it('Case 3 (Negative): Should fail to add user with non-admin token.', (done) => {
+    const nonAdminToken = nockUtils.registerUserTokenCheck('userX');
     global.chai.request(global.server)
       .post('/api/v2/user')
       .set('Authorization', 'Bearer ' + nonAdminToken)
@@ -483,6 +486,7 @@ describe('Add new user: post /api/v2/user', () => {
   });
 
   it('Case 4 (Negative): Should fail to add user with exist name.', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .post('/api/v2/user')
       .set('Authorization', 'Bearer ' + validToken)
@@ -629,6 +633,7 @@ describe('update user: put /api/v2/user', () => {
   //
 
   it('Case 1 (Positive): Update user password.', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/update_user/password')
       .set('Authorization', 'Bearer ' + validToken)
@@ -645,6 +650,7 @@ describe('update user: put /api/v2/user', () => {
   });
 
   it('Case 2 (Positive): Update user set admin=false.', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/update_user/admin')
       .set('Authorization', 'Bearer ' + validToken)
@@ -664,6 +670,7 @@ describe('update user: put /api/v2/user', () => {
   //
 
   it('Case 3 (Negative): Should fail to modify a non-exist user.', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/non_exist_user/password')
       .set('Authorization', 'Bearer ' + validToken)
@@ -680,6 +687,7 @@ describe('update user: put /api/v2/user', () => {
   });
 
   it('Case 4 (Negative): Should trigger validation error if password sets null.', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/new_user/password')
       .set('Authorization', 'Bearer ' + validToken)
@@ -693,6 +701,7 @@ describe('update user: put /api/v2/user', () => {
   });
 
   it('Case 5 (Negative): Should fail to update user with non-admin token.', (done) => {
+    const nonAdminToken = nockUtils.registerUserTokenCheck('userX');
     global.chai.request(global.server)
       .put('/api/v2/user/new_user/admin')
       .set('Authorization', 'Bearer ' + nonAdminToken)
@@ -807,6 +816,7 @@ describe('delete user : delete /api/v2/user', () => {
   //
 
   it('Case 1 (Positive): delete exist non_admin user', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .delete('/api/v2/user/non_admin')
       .set('Authorization', 'Bearer ' + validToken)
@@ -822,6 +832,7 @@ describe('delete user : delete /api/v2/user', () => {
 
 
   it('Case 2 (Negative): Should fail to delete admin user', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .delete('/api/v2/user/admin')
       .set('Authorization', 'Bearer ' + validToken)
@@ -835,6 +846,7 @@ describe('delete user : delete /api/v2/user', () => {
   });
 
   it('Case 3 (Negative): Should fail to delete non-exist user.', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .delete('/api/v2/user/nonexist')
       .set('Authorization', 'Bearer ' + validToken)
@@ -848,6 +860,7 @@ describe('delete user : delete /api/v2/user', () => {
   });
 
   it('Case 4 (Negative): Should fail to delete user with non-admin token.', (done) => {
+    const nonAdminToken = nockUtils.registerUserTokenCheck('userX');
     global.chai.request(global.server)
       .delete('/api/v2/user/delete_non_admin_user')
       .set('Authorization', 'Bearer ' + nonAdminToken)
@@ -1088,17 +1101,10 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
   });
 
   //
-  // Get a valid token that expires in 60 seconds.
-  //
-
-  const validToken = global.jwt.sign({username: 'admin_user', admin: true}, process.env.JWT_SECRET, {expiresIn: 60});
-  const nonAdminToken = global.jwt.sign({username: 'non_admin_user', admin: false}, process.env.JWT_SECRET, {expiresIn: 60});
-  // const invalidToken = '';
-
-  //
   // Positive cases
   //
   it('Case 1 (Positive): should update non-admin user with valid virtual cluster successfully', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/test/virtualcluster')
       .set('Authorization', 'Bearer ' + validToken)
@@ -1112,6 +1118,7 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
   });
 
   it('Case 2 (Positive): should delete all virtual clusters except default when virtual cluster value sets to be empty ', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/test3/virtualcluster')
       .set('Authorization', 'Bearer ' + validToken)
@@ -1127,6 +1134,7 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
 
   // Negative cases
   it('Case 3 (Negative): add new user with invalid virtual cluster, should return error NoVirtualClusterError', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/test2/virtualcluster')
       .set('Authorization', 'Bearer ' + validToken)
@@ -1140,6 +1148,7 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
   });
 
   it('Case 4 (Negative): should fail to update non-admin user with invalid virtual cluster', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/test_invalid/virtualcluster')
       .set('Authorization', 'Bearer ' + validToken)
@@ -1153,6 +1162,7 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
   });
 
   it('Case 5 (Negative): should fail to update non-exist user virtual cluster', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/non_exist/virtualcluster')
       .set('Authorization', 'Bearer ' + validToken)
@@ -1166,6 +1176,7 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
   });
 
   it('Case 6 (Negative): should fail to update user with virtual cluster by non-admin user', (done) => {
+    const nonAdminToken = nockUtils.registerUserTokenCheck('userX');
     global.chai.request(global.server)
       .put('/api/v2/user/test6/virtualcluster')
       .set('Authorization', 'Bearer ' + nonAdminToken)
@@ -1179,6 +1190,7 @@ describe('update user virtual cluster : put /api/v2/user/:username/virtualCluste
   });
 
   it('Case 7 (Negative): should fail to update admin virtual cluster', (done) => {
+    const validToken = nockUtils.registerAdminTokenCheck('adminX');
     global.chai.request(global.server)
       .put('/api/v2/user/test7/virtualcluster')
       .set('Authorization', 'Bearer ' + validToken)

--- a/src/rest-server/test/utils/nock.js
+++ b/src/rest-server/test/utils/nock.js
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the 'Software'), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const jwt = require('jsonwebtoken');
+const nock = require('nock');
+
+const groupTemplate = path.join(__dirname, '../data/nock/group-template.yaml');
+const userTemplate = path.join(__dirname, '../data/nock/user-template.yaml');
+
+const encrypt = (username, password) => {
+  const iterations = 10000;
+  const keylen = 64;
+  const salt = crypto.createHash('md5').update(username).digest('hex');
+  return crypto.pbkdf2Sync(password, salt, iterations, keylen, 'sha512').toString('hex');
+};
+
+/**
+ * @param {Object} data - user info.
+ * @param {string} data.username
+ * @param {string} data.password
+ * @param {string[]} data.grouplist
+ */
+const getUserPayload = (data = {}) => {
+  const payload = yaml.safeLoad(fs.readFileSync(userTemplate));
+  const username = data.username || 'admin';
+  const password = data.password || 'default_password';
+  const grouplist = data.grouplist || [];
+  payload.metadata.name = Buffer.from(username).toString('hex');
+  payload.data.username = Buffer.from(username).toString('base64');
+  payload.data.password = Buffer.from(encrypt(username, password)).toString('base64');
+  payload.data.grouplist = Buffer.from(JSON.stringify(grouplist)).toString('base64');
+  return payload;
+};
+
+/**
+ * @param {Object} data - group info.
+ * @param {string} data.groupname
+ * @param {boolean} data.admin
+ * @param {string[]} data.virtualClusters
+ */
+const getGroupPayload = (data = {}) => {
+  const payload = yaml.safeLoad(fs.readFileSync(groupTemplate));
+  const groupname = data.groupname || 'admin';
+  const admin = data.admin || false;
+  const virtualClusters = data.virtualClusters || [];
+  payload.metadata.name = Buffer.from(groupname).toString('hex');
+  payload.data.groupname = Buffer.from(groupname).toString('base64');
+  payload.data.extension = Buffer.from(JSON.stringify({
+    acls: {
+      admin,
+      virtualClusters,
+    },
+  })).toString('base64');
+  return payload;
+};
+
+/**
+ * @param {Object} nock - nock client.
+ * @param {Object} data - user info.
+ * @param {string} data.username
+ * @param {string} data.password
+ * @param {string[]} data.grouplist
+ */
+const registerUser = (data = {}) => {
+  const payload = getUserPayload(data);
+  nock(apiServerRootUri)
+    .get(`/api/v1/namespaces/pai-user-v2/secrets/${payload.metadata.name}`)
+    .reply(200, payload);
+};
+
+/**
+ * @param {Object} data - group info.
+ * @param {string} data.groupname
+ * @param {boolean} data.admin
+ * @param {string[]} data.virtualClusters
+ */
+const registerGroup = (data = {}) => {
+  const payload = getGroupPayload(data);
+  nock(apiServerRootUri)
+    .get(`/api/v1/namespaces/pai-group/secrets/${payload.metadata.name}`)
+    .reply(200, payload);
+};
+
+const registerToken = (username, tokens) => {
+  const data = {};
+  for (const [idx, token] of tokens.entries()) {
+    data[idx] = Buffer.from(token).toString('base64');
+  }
+  nock(apiServerRootUri)
+    .get(`/api/v1/namespaces/pai-user-token/secrets/${Buffer.from(username).toString('hex')}`)
+    .reply(200, {
+      data,
+    });
+};
+
+/**
+ * @param {string} username
+ * @param {Object} options
+ * @param {string} options.password
+ * @param {boolean} options.application - application token flag.
+ * @param {(string|number)} options.expiresIn
+ */
+const registerUserTokenCheck = (username, options={}) => {
+  const password = options.password || 'default_password';
+  const expiresIn = options.expiresIn || 60;
+  const application = options.application || false;
+  registerUser({username, password});
+  const token = jwt.sign({username, application}, process.env.JWT_SECRET, {expiresIn});
+  registerToken(username, [token]);
+  return token;
+};
+
+/**
+ * @param {string} username
+ * @param {Object} options
+ * @param {string} options.password
+ * @param {boolean} options.application - application token flag.
+ * @param {(string|number)} options.expiresIn
+ */
+const registerAdminTokenCheck = (username, options={}) => {
+  const password = options.password || 'default_password';
+  const expiresIn = options.expiresIn || 60;
+  const application = options.application || false;
+  registerUser({username, password, grouplist: ['adminGroup']});
+  registerGroup({groupname: 'adminGroup', admin: true});
+  const token = jwt.sign({username, application}, process.env.JWT_SECRET, {expiresIn});
+  registerToken(username, [token]);
+  return token;
+};
+
+module.exports = {
+  getUserPayload,
+  getGroupPayload,
+  registerUser,
+  registerGroup,
+  registerToken,
+  registerAdminTokenCheck,
+  registerUserTokenCheck,
+};

--- a/src/rest-server/test/vc.js
+++ b/src/rest-server/test/vc.js
@@ -15,6 +15,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+const nockUtils = require('./utils/nock');
 
 const yarnDefaultResponse = {
     'scheduler': {
@@ -1157,8 +1158,6 @@ describe('VC API  Get /api/v2/virtual-clusters', () => {
 
 
 describe('VC API PUT /api/v2/virtual-clusters', () => {
-  const userToken = jwt.sign({username: 'test_user', admin: false}, process.env.JWT_SECRET, {expiresIn: 60});
-  const adminToken = jwt.sign({username: 'test_admin', admin: true}, process.env.JWT_SECRET, {expiresIn: 60});
   // Mock yarn rest api
   beforeEach(() => {
     nock.cleanAll();
@@ -1257,6 +1256,8 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         'type': 'Opaque',
       });
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
+
     chai.request(server)
       .put('/api/v2/virtual-clusters/b')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1289,6 +1290,8 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         },
         'type': 'Opaque',
       });
+
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
 
     chai.request(server)
       .put('/api/v2/virtual-clusters/a')
@@ -1323,6 +1326,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         'type': 'Opaque',
       });
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1338,6 +1342,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
 
   it('[Negative] shouldn\'t update vc when maxCapacity less than capacity', (done) => {
     nock.cleanAll();
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1356,7 +1361,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
     nock.cleanAll();
     chai.request(server)
       .put('/api/v2/virtual-clusters/default')
-      .set('Authorization', `Bearer ${adminToken}`)
+      .set('Authorization', 'Bearer token') // token is not checked
       .send({
         'vcCapacity': 30,
       })
@@ -1369,6 +1374,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
 
   it('[Negative] Non-admin should not update vc', (done) => {
     nock.cleanAll();
+    const userToken = nockUtils.registerUserTokenCheck('userX');
     chai.request(server)
       .put('/api/v2/virtual-clusters/b')
       .set('Authorization', `Bearer ${userToken}`)
@@ -1400,6 +1406,8 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         },
         'type': 'Opaque',
       });
+
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/b')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1437,6 +1445,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         'type': 'Opaque',
       });
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1454,7 +1463,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
     nock.cleanAll();
     chai.request(server)
       .put('/api/v2/virtual-clusters/aaa%20bbb')
-      .set('Authorization', `Bearer ${adminToken}`)
+      .set('Authorization', 'Bearer adminToken') // token is not checked
       .send({
         'vcCapacity': 80,
       })
@@ -1486,6 +1495,7 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         'type': 'Opaque',
       });
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1517,6 +1527,8 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
         },
         'type': 'Opaque',
       });
+
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/dedicated_vc')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1533,8 +1545,6 @@ describe('VC API PUT /api/v2/virtual-clusters', () => {
 
 
 describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
-  const userToken = jwt.sign({username: 'test_user', admin: false}, process.env.JWT_SECRET, {expiresIn: 60});
-  const adminToken = jwt.sign({username: 'test_admin', admin: true}, process.env.JWT_SECRET, {expiresIn: 60});
   // Mock yarn rest api
   beforeEach(() => {
     nock.cleanAll();
@@ -1557,6 +1567,7 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
       .put('/ws/v1/cluster/scheduler-conf')
       .reply(200);
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a/status')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1574,6 +1585,7 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
       .put('/ws/v1/cluster/scheduler-conf')
       .reply(200);
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a/status')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1588,10 +1600,9 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
 
   it('[Negative] should not change default vc status', (done) => {
     nock.cleanAll();
-
     chai.request(server)
       .put('/api/v2/virtual-clusters/default/status')
-      .set('Authorization', `Bearer ${adminToken}`)
+      .set('Authorization', 'Bearer adminToken') // token is not checked
       .send({
         'vcStatus': 'running',
       })
@@ -1605,6 +1616,7 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
   it('[Negative] Non-admin should not change vc status', (done) => {
     nock.cleanAll();
 
+    const userToken = nockUtils.registerUserTokenCheck('userX');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a/status')
       .set('Authorization', `Bearer ${userToken}`)
@@ -1619,6 +1631,7 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
   });
 
   it('[Negative] should not change a non-exist vc b', (done) => {
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/b/status')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1638,6 +1651,7 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
       .put('/ws/v1/cluster/scheduler-conf')
       .reply(404, 'Error response in YARN');
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .put('/api/v2/virtual-clusters/a/status')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1655,8 +1669,6 @@ describe('VC API PUT /api/v2/virtual-clusters/:vcName/status', () => {
 
 
 describe('VC API DELETE /api/v2/virtual-clusters', () => {
-  const userToken = jwt.sign({username: 'test_user', admin: false}, process.env.JWT_SECRET, {expiresIn: 60});
-  const adminToken = jwt.sign({username: 'test_admin', admin: true}, process.env.JWT_SECRET, {expiresIn: 60});
   // Mock yarn rest api
   beforeEach(() => {
     nock(yarnUri)
@@ -1754,6 +1766,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
         },
         'type': 'Opaque',
       });
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
 
     chai.request(server)
       .delete('/api/v2/virtual-clusters/a')
@@ -1767,6 +1780,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
   it('[Negative] Non-admin should not delete vc a', (done) => {
     nock.cleanAll();
 
+    const userToken = nockUtils.registerUserTokenCheck('userX');
     chai.request(server)
       .delete('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${userToken}`)
@@ -1782,7 +1796,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
 
     chai.request(server)
       .delete('/api/v2/virtual-clusters/default')
-      .set('Authorization', `Bearer ${adminToken}`)
+      .set('Authorization', 'Bearer adminToken') // token is not checked
       .end((err, res) => {
         expect(res, 'status code').to.have.status(403);
         expect(res.body).to.have.property('code', 'ForbiddenUserError');
@@ -1791,6 +1805,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
   });
 
   it('[Positive] shouldn\'t delete dedicated vc', (done) => {
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .delete('/api/v2/virtual-clusters/dedicated_vc')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1802,6 +1817,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
   });
 
   it('[Negative] should not delete a non-exist vc b', (done) => {
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .delete('/api/v2/virtual-clusters/b')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1813,6 +1829,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
   });
 
   it('[Negative] should not delete vc when jobs are running', (done) => {
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .delete('/api/v2/virtual-clusters/c')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1840,6 +1857,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
       .put('/ws/v1/cluster/scheduler-conf')
       .reply(200);
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .delete('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${adminToken}`)
@@ -1868,6 +1886,7 @@ describe('VC API DELETE /api/v2/virtual-clusters', () => {
       .put('/ws/v1/cluster/scheduler-conf')
       .reply(404, 'Error in YARN when reactive queue');
 
+    const adminToken = nockUtils.registerAdminTokenCheck('admin');
     chai.request(server)
       .delete('/api/v2/virtual-clusters/a')
       .set('Authorization', `Bearer ${adminToken}`)

--- a/src/rest-server/yarn.lock
+++ b/src/rest-server/yarn.lock
@@ -3557,6 +3557,11 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
+uuid@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
+  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
# Changes
## Token format
- Application will be a JSON Web Token with an additional boolean field `application`
  - User / frontend service can decode the jwt and get if the token is an application token
- Since we will query `k8s secret` when authentication (check if it is revoked), the `admin` field in jwt is removed. The permission info will be retrieved dynamically from `k8s secret`
## Storage
- The signed jwt list will be stored in the `pai-user-token` namespace of `k8s secret`
- Each user's token list will be a k8s secret item
  - name: username's hex string
  - data: uuid -> token
- The namespace will be created (if not exist) when rest server starts
## Authentication error
- `Token is expired` error message is removed. 
- Only a `token is invalid` error message will be shown now.
## k8s secret model
- Since previous k8s secret interface is implemented for specific use, a new k8s secret interface (model) for general use is implemented.
## API routes
- GET /api/v1/token
  - Get list of available tokens (portal token + application token)
- POST /api/v1/token/application
  - Generate an application token
- DELETE /api/v1/token/:token
  - Revoke a token (portal token / application token)
