### PR TITLE
fix missing dependencies during installation

### DIFF
--- a/docs/pai-management/doc/how-to-install-depdencey.md
+++ b/docs/pai-management/doc/how-to-install-depdencey.md
@@ -53,9 +53,13 @@ apt-get -y install \
       inotify-tools \
       rsync \
       realpath \
-      net-tools
+      net-tools \
+      python3-pip
 
-pip install --upgrade python-etcd docker kubernetes paramiko==2.6.0 GitPython
+pip install --upgrade python-etcd docker kubernetes paramiko==2.6.0 GitPython futures
+
+pip3 install kubernetes
+
 python -m easy_install --upgrade pyOpenSSL
 
 # replace version number to latest, like v0.9.5.

--- a/docs/pai-management/doc/how-to-install-depdencey.md
+++ b/docs/pai-management/doc/how-to-install-depdencey.md
@@ -56,7 +56,7 @@ apt-get -y install \
       net-tools \
       python3-pip
 
-pip install --upgrade python-etcd docker kubernetes paramiko==2.6.0 GitPython futures
+pip install --upgrade python-etcd docker kubernetes paramiko==2.6.0 GitPython future
 
 pip3 install kubernetes
 


### PR DESCRIPTION
Fix some missing dependencies during installation (introduced by v0.14.0)

1. python2 "future" package

2. python3 "kubernetes" package
used in: 
https://github.com/microsoft/pai/blob/master/src/rest-server/deploy/user_v2_migrate.py
https://github.com/microsoft/pai/blob/master/src/rest-server/deploy/legacy_user_migrate.py