### PR TITLE
[runtime] decompress the framework when the size is large

### DIFF
--- a/src/kube-runtime/build/kube-runtime.dockerfile
+++ b/src/kube-runtime/build/kube-runtime.dockerfile
@@ -27,7 +27,7 @@ COPY GOPATH/src/github.com/microsoft/runtime/ ${PROJECT_DIR}
 RUN ${PROJECT_DIR}/build/runtime/go-build.sh && \
   mv ${PROJECT_DIR}/dist/runtime/ ${INSTALL_DIR}
 
-FROM python:2.7-alpine3.8
+FROM python:3.7-alpine
 
 RUN pip install PyYAML
 

--- a/src/kube-runtime/src/init.d/initializer.py
+++ b/src/kube-runtime/src/init.d/initializer.py
@@ -40,7 +40,7 @@ def run_script(script_path, parameters, plugin_scripts):
         line = proc.stdout.readline()
         if not line:
             break
-        line = line.encode("UTF-8").strip()
+        line = line.decode("utf-8").strip()
         logger.info(line)
     proc.wait()
     if proc.returncode:


### PR DESCRIPTION
FC will compress the framework when it's size is large.
Since we need the FC spec in runtime, decompress here.

Also update the python from 2.7 to 3.7