### PR TITLE
[Webportal] static content caching optimization

### DIFF
--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -263,7 +263,7 @@ const config = (env, argv) => ({
       { from: 'src/assets/img/favicon.ico', to: 'favicon.ico' },
     ]),
     new MiniCssExtractPlugin({
-      filename: 'styles/[name].bundle.css',
+      filename: 'styles/[name].[contenthash].css',
     }),
     // required by ejs loader
     new webpack.ProvidePlugin({

--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -81,7 +81,7 @@ const config = (env, argv) => ({
   },
   output: {
     path: helpers.root('dist'),
-    filename: 'scripts/[name].bundle.js',
+    filename: 'scripts/[name].[contenthash].js',
     jsonpFunction: 'webportalWebpackJsonp',
   },
   resolve: {
@@ -353,6 +353,8 @@ const config = (env, argv) => ({
     port: 9286,
   },
   optimization: {
+    moduleIds: 'hashed',
+    runtimeChunk: 'single',
     minimizer: [
       new TerserPlugin({
         cache: true,
@@ -364,7 +366,7 @@ const config = (env, argv) => ({
       cacheGroups: {
         vendors: {
           chunks: 'all',
-          minSize: 0,
+          minSize: 30000,
           minChunks: 2,
           maxAsyncRequests: Infinity,
           maxInitialRequests: Infinity,

--- a/src/webportal/package.json
+++ b/src/webportal/package.json
@@ -27,7 +27,7 @@
     "preanalyze": "webpack --mode production --profile --json > bundle.profile.json",
     "analyze": "webpack-bundle-analyzer bundle.profile.json dist",
     "dev": "yarn prebuild && yarn prestart && webpack-dev-server --progress --mode development --debug --devtool eval-cheap-module-source-map --output-pathinfo",
-    "prestart": "mkdirp dist/scripts && envsub --env-file .env --system src/app/env.js.template dist/scripts/env.js",
+    "prestart": "mkdirp dist && envsub --env-file .env --system src/app/env.js.template dist/env.js",
     "start": "node server"
   },
   "dependencies": {

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -43,8 +43,8 @@ app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
 // setup the root path
 const oneMonth = 3600 * 24 * 30 * 1000;
 
-app.use(express.static(path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
-app.use(express.static(path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
+app.use(express.static('/assets', path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
+app.use(express.static('/scripts', path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
 app.use(express.static(path.join(appRoot.path, 'dist')));
 
 // catch 404 and forward to error handler

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -43,9 +43,18 @@ app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
 // setup the root path
 const oneMonth = 3600 * 24 * 30 * 1000;
 
-app.use('/assets', express.static(path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
-app.use('/styles', express.static(path.join(appRoot.path, 'dist/styles'), { maxAge: oneMonth }));
-app.use('/scripts', express.static(path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
+app.use(
+  '/assets',
+  express.static(path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }),
+);
+app.use(
+  '/styles',
+  express.static(path.join(appRoot.path, 'dist/styles'), { maxAge: oneMonth }),
+);
+app.use(
+  '/scripts',
+  express.static(path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }),
+);
 app.use(express.static(path.join(appRoot.path, 'dist')));
 
 // catch 404 and forward to error handler

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -43,8 +43,8 @@ app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
 // setup the root path
 const oneMonth = 3600 * 24 * 30 * 1000;
 
-app.use(express.static('/assets', path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
-app.use(express.static('/scripts', path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
+app.use('/assets', express.static(path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
+app.use('/scripts', express.static(path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
 app.use(express.static(path.join(appRoot.path, 'dist')));
 
 // catch 404 and forward to error handler

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -41,6 +41,10 @@ app.use(morgan('dev', { stream: logger.stream }));
 app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
 
 // setup the root path
+const oneMonth = 3600 * 24 * 30 * 1000;
+
+app.use(express.static(path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
+app.use(express.static(path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
 app.use(express.static(path.join(appRoot.path, 'dist')));
 
 // catch 404 and forward to error handler

--- a/src/webportal/server/config/express.js
+++ b/src/webportal/server/config/express.js
@@ -44,6 +44,7 @@ app.use(favicon(path.join(appRoot.path, 'dist', 'favicon.ico')));
 const oneMonth = 3600 * 24 * 30 * 1000;
 
 app.use('/assets', express.static(path.join(appRoot.path, 'dist/assets'), { maxAge: oneMonth }));
+app.use('/styles', express.static(path.join(appRoot.path, 'dist/styles'), { maxAge: oneMonth }));
 app.use('/scripts', express.static(path.join(appRoot.path, 'dist/scripts'), { maxAge: oneMonth }));
 app.use(express.static(path.join(appRoot.path, 'dist')));
 

--- a/src/webportal/src/app/home/index.ejs
+++ b/src/webportal/src/app/home/index.ejs
@@ -9,6 +9,6 @@
 </head>
 <body>
   <div id="content"></div>
-  <script src="/scripts/env.js"></script>
+  <script src="/env.js"></script>
 </body>
 </html>

--- a/src/webportal/src/app/layout/layout.component.ejs
+++ b/src/webportal/src/app/layout/layout.component.ejs
@@ -135,6 +135,6 @@
 
   </div>
   <script>window.PAI_VERSION = <%=JSON.stringify(htmlWebpackPlugin.options.version)%></script>
-  <script src="/scripts/env.js"></script>
+  <script src="/env.js"></script>
 </body>
 </html>


### PR DESCRIPTION
There are 2 main issues about static content (js, style css, font, svg, .., etc) in current webportal:

  - They are caching-disabled. The `max-age` in the response header for them is 0. Thus, the browser will always download these contents, which increases both the front-end loading time and the server's traffic.
  - Many js files are splitted into very small chunks (<1kb), which means they should also be transferred by new HTTP connection.

This PR sets a `max-age` for those contents,  use `contenthash` in webpack to ensure correct caching, 
and only js files larger than 30kb would be chunked.

Loading `submit.html` before and after optimization (tested for 5 times in each case):
   - Before optimization + First loading: 4.19s ~ 8.61s
   - Before optimization + Second loading: 4.21s~6.49s
   - After optimization   + First loading: 3.71s ~ 4.76s
   - After optimization   + Second loading: **0.65s~0.94s**
 
Since "second loading" would be the main use case, the user experience could be enhanced a lot by this optimization.

Chrome `Network` page for "Before optimization + Second loading":

![before](https://user-images.githubusercontent.com/7499023/68919441-1b7af100-07ad-11ea-8fc5-3d56decb2766.png)

Chrome `Network` page for "After optimization + Second loading":

![after](https://user-images.githubusercontent.com/7499023/68919472-351c3880-07ad-11ea-808a-3266e4873d9e.png)


