### PR TITLE
HiveD: record cell type in pod annotation

### DIFF
--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -799,11 +799,10 @@ func generatePodScheduleResult(
 			if groupVirtualPlacement != nil {
 				waitReason = fmt.Sprintf("insufficient quota in VC %v", vc)
 			}
-		}
-		if selectedNode == "" {
-			waitReason = "cannot find a K8s candidate node in physical cluster"
+		} else if selectedNode == "" {
+			waitReason = "cannot find a K8s candidate node within physical cluster"
 			if groupVirtualPlacement != nil {
-				waitReason = fmt.Sprintf("cannot find a K8s candidate node with VC %v's quota", vc)
+				waitReason = fmt.Sprintf("cannot find a K8s candidate node within VC %v's quota", vc)
 			}
 		}
 		if waitReason != "" {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm.go
@@ -776,7 +776,7 @@ func generatePodScheduleResult(
 	if len(preemptionVictims) > 0 {
 		// we collect victims on a random node, as K8S preempts victims from only one node once.
 		// random is to let different pods preempt victims on different nodes
-		// (but we don't rely on this randomness for the eventual-completeness of preemption).
+		// (note that this randomness is not necessary for the eventual-completeness of preemption).
 		nodeToPreempt := nodesHaveVictims[rand.Int31n(int32(len(nodesHaveVictims)))]
 		var victimPods []*core.Pod
 		var victimNames []string
@@ -807,7 +807,7 @@ func generatePodScheduleResult(
 		if selectedNode == "" {
 			return internal.PodScheduleResult{
 				PodWaitInfo: &internal.PodWaitInfo{
-					Reason: fmt.Sprintf("node %v picked by algorithm but not in K8S candidates", selectedNode),
+					Reason: fmt.Sprintf("insufficient capacity in physical cluster with respect to K8s candidates"),
 				},
 			}
 		}

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/algorithm/hived_algorithm_test.go
@@ -491,6 +491,12 @@ func testReconfiguration(t *testing.T, sConfig *api.Config) {
 	}
 	testCasesThatShouldSucceed(t, h)
 
+	// case: shorten cell chain
+	(*sConfig.PhysicalCluster).CellTypes["DGX2-V100-NODE"] = api.CellTypeSpec{
+		ChildCellType:   "DGX2-V100",
+		ChildCellNumber: 16,
+		IsNodeLevel:     true,
+	}
 	// case: physical cell not found
 	(*sConfig.PhysicalCluster).PhysicalCells[7].CellChildren[0].CellChildren[0].CellAddress = "0.0.3.100"
 	// case: insufficient VC quota

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/api/types.go
@@ -110,9 +110,9 @@ type AffinityGroupMemberBindInfo struct {
 type PodPlacementInfo struct {
 	PhysicalNode       string  `yaml:"physicalNode"`
 	PhysicalGpuIndices []int32 `yaml:"physicalGpuIndices"`
-	// levels of the preassigned cells used by the pods. used to locate the virtual cells
+	// preassigned cell types used by the pods. used to locate the virtual cells
 	// when adding an allocated pod
-	PreassignedCellLevels []int32 `yaml:"preassignedCellLevels"`
+	PreassignedCellTypes []CellType `yaml:"preassignedCellTypes"`
 }
 
 type WebServerPaths struct {

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/internal/types.go
@@ -91,7 +91,7 @@ type SchedulerAlgorithm interface {
 // Notes:
 // 1. If the SchedulerAlgorithm found sufficient free resource, only PodBindInfo
 //    should be set.
-//    If the SchedulerAlgorithm found sufficient preemptable resource, only
+//    If the SchedulerAlgorithm found sufficient preemptible resource, only
 //    PodPreemptInfo should be set.
 //    Otherwise, only PodWaitInfo can be optionally set.
 // 2. The selected node in PodBindInfo requires:
@@ -146,13 +146,13 @@ const PodUnknown PodState = "Unknown"
 
 // [AllocatedState]: The Pod is considered to be allocated from the scheduler view.
 const (
-	// Pod is waiting for preemptable or free resource to appear.
+	// Pod is waiting for preemptible or free resource to appear.
 	// [StartState]
 	// -> PodPreempting
 	// -> PodBinding
 	PodWaiting PodState = "Waiting"
 
-	// Pod is waiting for the appeared preemptable resource to be free by preemption.
+	// Pod is waiting for the appeared preemptible resource to be free by preemption.
 	// -> PodBinding
 	// -> PodWaiting
 	PodPreempting PodState = "Preempting"
@@ -174,7 +174,7 @@ func IsAllocated(state PodState) bool {
 
 // No need to use it recover scheduler waiting resource
 type PodWaitInfo struct {
-	// The reason why no preemptable or free resource to allocate the Pod now.
+	// The reason why no preemptible or free resource to allocate the Pod now.
 	Reason string
 }
 

--- a/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/scheduler/scheduler.go
+++ b/subprojects/GOPATH/src/github.com/microsoft/hivedscheduler/pkg/scheduler/scheduler.go
@@ -552,7 +552,7 @@ func (s *HivedScheduler) filterRoutine(args ei.ExtenderArgs) *ei.ExtenderFilterR
 		if result.PodWaitInfo != nil {
 			return &ei.ExtenderFilterResult{
 				Error: fmt.Sprintf(
-					"Pod is waiting for preemptable or free resource to appear: %v",
+					"Pod is waiting for preemptible or free resource to appear: %v",
 					result.PodWaitInfo.Reason),
 			}
 		} else {
@@ -646,7 +646,7 @@ func (s *HivedScheduler) preemptRoutine(args ei.ExtenderPreemptionArgs) *ei.Exte
 	// At this point, podState must be in:
 	// {PodWaiting}
 
-	// The Pod should keep on waiting for preemptable or free resource to appear,
+	// The Pod should keep on waiting for preemptible or free resource to appear,
 	// so do not preempt any victim.
 	return &ei.ExtenderPreemptionResult{}
 }


### PR DESCRIPTION
Record cell type name (instead of the level) in pod annotation. This enables us to shorten / lengthen cell chain.
This PR also adds some log enrichment.