### PR TITLE
[Webportal] Remove storage plugin command inject

### DIFF
--- a/src/kube-runtime/src/plugins/teamwise_storage/README.md
+++ b/src/kube-runtime/src/plugins/teamwise_storage/README.md
@@ -7,7 +7,7 @@ The teamwise storage plugin offer user to mount storage provided by admin.
 ```yaml
 extras:
   com.microsoft.pai.runtimeplugin:
-    - plugin: teamwiase_storage
+    - plugin: teamwise_storage
       parameters:
         storageConfigNames:
           - PAI_SAHRE  # storage config name provided by admin

--- a/src/webportal/src/app/job-submission/components/data/data-component.jsx
+++ b/src/webportal/src/app/job-submission/components/data/data-component.jsx
@@ -192,10 +192,6 @@ export const DataComponent = React.memo(props => {
   const onMountDirChange = useCallback(
     // Will only update extra field, jobData will be updated by useEffect function
     mountDir => {
-      if (config.launcherType !== 'k8s') {
-        return;
-      }
-
       const plugins = get(extras, [PAI_PLUGIN], []);
       const updatedRuntimePlugins = generateUpdatedRuntimePlugins(
         mountDir.selectedConfigs,

--- a/src/webportal/src/app/job-submission/components/data/team-storage.jsx
+++ b/src/webportal/src/app/job-submission/components/data/team-storage.jsx
@@ -69,11 +69,21 @@ export const TeamStorage = ({
     });
   });
 
+  const [mountPoints, setMountPoints] = useState(() => {
+    return mountDirs.selectedConfigs.flatMap(ele =>
+      ele.mountInfos.map(mountInfo => mountInfo.mountPoint),
+    );
+  });
+
   useEffect(() => {
     const names = defaultTeamConfigs.map(element => {
       return element.name;
     });
+    const mountPoints = defaultTeamConfigs.flatMap(ele =>
+      ele.mountInfos.map(mountInfo => mountInfo.mountPoint),
+    );
     setSelectedConfigNames(names);
+    setMountPoints(mountPoints);
   }, [defaultTeamConfigs]);
 
   const [teamDetail, setTeamDetail] = useState({ isOpen: false });
@@ -113,20 +123,40 @@ export const TeamStorage = ({
             }
             onChange={(ev, isChecked) => {
               let newSelectedConfigNames = [];
+              let updatedMountPoints = [...mountPoints];
               if (!isChecked && selectedConfigNames.includes(item.name)) {
                 const idx = selectedConfigNames.indexOf(item.name);
                 newSelectedConfigNames = [
                   ...selectedConfigNames.slice(0, idx),
                   ...selectedConfigNames.slice(idx + 1),
                 ];
+                const toRemovedMountPoints = item.mountInfos.map(
+                  mountInfo => mountInfo.mountPoint,
+                );
+                updatedMountPoints = updatedMountPoints.filter(
+                  mountPoint => !toRemovedMountPoints.includes(mountPoint),
+                );
               } else if (
                 isChecked &&
                 !selectedConfigNames.includes(item.name)
               ) {
+                for (const mountInfo of item.mountInfos) {
+                  if (mountPoints.includes(mountInfo.mountPoint)) {
+                    alert(
+                      `Mount point error! More than one mount point ${mountInfo.mountPoint}!`,
+                    );
+                    return;
+                  }
+                }
                 newSelectedConfigNames = cloneDeep(selectedConfigNames);
                 newSelectedConfigNames.push(item.name);
+
+                item.mountInfos.forEach(mountInfo =>
+                  updatedMountPoints.push(mountInfo.mountPoint),
+                );
               }
               setSelectedConfigNames(newSelectedConfigNames);
+              setMountPoints(updatedMountPoints);
             }}
           />
         );

--- a/src/webportal/src/app/job-submission/components/data/team-storage.jsx
+++ b/src/webportal/src/app/job-submission/components/data/team-storage.jsx
@@ -23,12 +23,7 @@
  * SOFTWARE.
  */
 
-import React, {
-  useEffect,
-  useLayoutEffect,
-  useState,
-  useCallback,
-} from 'react';
+import React, { useLayoutEffect, useState, useCallback, useMemo } from 'react';
 
 import {
   Checkbox,
@@ -46,7 +41,7 @@ import { TooltipIcon } from '../controls/tooltip-icon';
 
 import c from 'classnames';
 import PropTypes from 'prop-types';
-import { cloneDeep, isEqual, isNil } from 'lodash';
+import { cloneDeep, isNil } from 'lodash';
 
 import { MountDirectories } from '../../models/data/mount-directories';
 import { dispatchResizeEvent } from '../../utils/utils';
@@ -63,39 +58,33 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
     dispatchResizeEvent();
   });
 
-  const [selectedConfigNames, setSelectedConfigNames] = useState([]);
-  const [mountPoints, setMountPoints] = useState([]);
-
-  useEffect(() => {
-    if (
-      isNil(mountDirs) ||
-      isNil(mountDirs.selectedConfigs) ||
-      isNil(mountDirs.selectedConfigs)
-    ) {
-      return;
+  const selectedConfigNames = useMemo(() => {
+    if (isNil(mountDirs) || isNil(mountDirs.selectedConfigs)) {
+      return [];
     }
-
-    const updatedNames = mountDirs.selectedConfigs.map(element => {
+    return mountDirs.selectedConfigs.map(element => {
       return element.name;
     });
-    const updatedMountPoints = mountDirs.selectedConfigs.flatMap(ele =>
+  }, [mountDirs]);
+
+  const mountPoints = useMemo(() => {
+    if (isNil(mountDirs) || isNil(mountDirs.selectedConfigs)) {
+      return [];
+    }
+    return mountDirs.selectedConfigs.flatMap(ele =>
       ele.mountInfos.map(mountInfo => mountInfo.mountPoint),
     );
-    if (!isEqual(updatedNames, selectedConfigNames)) {
-      setSelectedConfigNames(updatedNames);
-    }
-    if (!isEqual(updatedMountPoints, mountPoints)) {
-      setMountPoints(updatedMountPoints);
-    }
   }, [mountDirs]);
 
   const [teamDetail, setTeamDetail] = useState({ isOpen: false });
-  const openTeamDetail = config => {
+
+  const openTeamDetail = useCallback(config => {
     setTeamDetail({ isOpen: true, config: config, servers: mountDirs.servers });
-  };
-  const hideTeamDetail = () => {
+  });
+
+  const hideTeamDetail = useCallback(() => {
     setTeamDetail({ isOpen: false });
-  };
+  });
 
   const updateMountDir = useCallback(
     selectedConfigNames => {
@@ -161,8 +150,6 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
                   updatedMountPoints.push(mountInfo.mountPoint),
                 );
               }
-              setSelectedConfigNames(newSelectedConfigNames);
-              setMountPoints(updatedMountPoints);
               updateMountDir(newSelectedConfigNames);
             }}
           />

--- a/src/webportal/src/app/job-submission/components/data/team-storage.jsx
+++ b/src/webportal/src/app/job-submission/components/data/team-storage.jsx
@@ -51,7 +51,11 @@ import TeamDetail from './team-detail';
 
 const { spacing } = getTheme();
 
-export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
+export const TeamStorage = ({
+  teamStorageConfigs,
+  mountDirs,
+  onMountDirChange,
+}) => {
   // workaround for fabric's bug
   // https://github.com/OfficeDev/office-ui-fabric-react/issues/5280#issuecomment-489619108
   useLayoutEffect(() => {
@@ -90,7 +94,7 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
     selectedConfigNames => {
       let selectedConfigs = [];
       if (selectedConfigNames.length > 0) {
-        selectedConfigs = teamConfigs.filter(element => {
+        selectedConfigs = teamStorageConfigs.filter(element => {
           return selectedConfigNames.includes(element.name);
         });
       }
@@ -98,7 +102,7 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
       newMountDirs.selectedConfigs = selectedConfigs;
       onMountDirChange(newMountDirs);
     },
-    [teamConfigs, mountDirs],
+    [teamStorageConfigs, mountDirs],
   );
 
   const columns = [
@@ -118,19 +122,12 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
             }
             onChange={(ev, isChecked) => {
               let newSelectedConfigNames = [];
-              let updatedMountPoints = [...mountPoints];
               if (!isChecked && selectedConfigNames.includes(item.name)) {
                 const idx = selectedConfigNames.indexOf(item.name);
                 newSelectedConfigNames = [
                   ...selectedConfigNames.slice(0, idx),
                   ...selectedConfigNames.slice(idx + 1),
                 ];
-                const toRemovedMountPoints = item.mountInfos.map(
-                  mountInfo => mountInfo.mountPoint,
-                );
-                updatedMountPoints = updatedMountPoints.filter(
-                  mountPoint => !toRemovedMountPoints.includes(mountPoint),
-                );
               } else if (
                 isChecked &&
                 !selectedConfigNames.includes(item.name)
@@ -145,10 +142,6 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
                 }
                 newSelectedConfigNames = cloneDeep(selectedConfigNames);
                 newSelectedConfigNames.push(item.name);
-
-                item.mountInfos.forEach(mountInfo =>
-                  updatedMountPoints.push(mountInfo.mountPoint),
-                );
               }
               updateMountDir(newSelectedConfigNames);
             }}
@@ -227,7 +220,7 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
           columns={columns}
           disableSelectionZone
           selectionMode={SelectionMode.none}
-          items={teamConfigs}
+          items={teamStorageConfigs}
           layoutMode={DetailsListLayoutMode.fixedColumns}
           compact
         />
@@ -248,7 +241,7 @@ export const TeamStorage = ({ teamConfigs, mountDirs, onMountDirChange }) => {
 };
 
 TeamStorage.propTypes = {
-  teamConfigs: PropTypes.array,
+  teamStorageConfigs: PropTypes.array,
   mountDirs: PropTypes.instanceOf(MountDirectories),
   onMountDirChange: PropTypes.func,
 };

--- a/src/webportal/src/app/job-submission/job-submission-page.jsx
+++ b/src/webportal/src/app/job-submission/job-submission-page.jsx
@@ -25,14 +25,19 @@
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Fabric, Stack, StackItem } from 'office-ui-fabric-react';
-import { isNil, isEmpty, get, cloneDeep } from 'lodash';
+import { isNil, isEmpty, get } from 'lodash';
 import PropTypes from 'prop-types';
 
 import { JobInformation } from './components/job-information';
 import { SubmissionSection } from './components/submission-section';
 import { TaskRoles } from './components/task-roles';
 import Context from './components/context';
-import { fetchJobConfig, listUserVirtualClusters } from './utils/conn';
+import {
+  fetchJobConfig,
+  listUserVirtualClusters,
+  listUserStorageConfigs,
+  fetchStorageConfigs,
+} from './utils/conn';
 import { TaskRolesManager } from './utils/task-roles-manager';
 
 // sidebar
@@ -53,7 +58,7 @@ import {
 } from './utils/utils';
 import { SpinnerLoading } from '../components/loading';
 import config from '../config/webportal.config';
-import { PAI_PLUGIN } from './utils/constants';
+import { PAI_PLUGIN, STORAGE_PLUGIN } from './utils/constants';
 
 const SIDEBAR_PARAM = 'param';
 const SIDEBAR_SECRET = 'secret';
@@ -117,7 +122,6 @@ export const JobSubmissionPage = ({
 
   // Context variables
   const [vcNames, setVcNames] = useState([]);
-  const [storageConfigs, setStorageConfigs] = useState(undefined);
   const [errorMessages, setErrorMessages] = useState({});
 
   const setJobTaskRoles = useCallback(
@@ -216,6 +220,54 @@ export const JobSubmissionPage = ({
     }
   }, [jobTaskRoles]);
 
+  // init extras
+  useEffect(() => {
+    // for import and clone, will respect original protocol
+    const params = new URLSearchParams(window.location.search);
+    if (
+      !isEmpty(yamlText) ||
+      params.get('op') === 'resubmit' ||
+      config.launcherType !== 'k8s'
+    ) {
+      return;
+    }
+
+    const setExtrasValue = async () => {
+      const extras = {
+        [PAI_PLUGIN]: [],
+      };
+      // set ssh plugin default value
+      const sshPlugin = {
+        plugin: 'ssh',
+        parameters: {
+          jobssh: true,
+        },
+      };
+      extras[PAI_PLUGIN].push(sshPlugin);
+      // set storage plugin default value
+      const defaultStorageConfig = [];
+      try {
+        const configNames = await listUserStorageConfigs(loginUser);
+        const storageConfigs = await fetchStorageConfigs(configNames);
+        for (const config of storageConfigs) {
+          if (config.default === true) {
+            defaultStorageConfig.push(config.name);
+            break;
+          }
+        }
+      } catch {} // ignore all exceptions here
+      const storagePlugin = {
+        plugin: STORAGE_PLUGIN,
+        parameters: {
+          storageConfigNames: defaultStorageConfig,
+        },
+      };
+      extras[PAI_PLUGIN].push(storagePlugin);
+      setExtras(extras);
+    };
+    setExtrasValue();
+  }, []);
+
   // fill protocol if cloned job
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -283,42 +335,6 @@ export const JobSubmissionPage = ({
       setJobProtocol(updatedJob);
     }
   }, []);
-
-  // Init plugins for pure k8s based PAI
-  useEffect(() => {
-    if (config.launcherType !== 'k8s') {
-      return;
-    }
-
-    const plugin = get(extras, PAI_PLUGIN);
-    if (!plugin) {
-      // Init SSH default settings for old/empty jobs
-      const updatedPlugin = [
-        {
-          plugin: 'ssh',
-          parameters: {
-            jobssh: true,
-          },
-        },
-      ];
-      const updatedExtras = cloneDeep(extras);
-      updatedExtras[PAI_PLUGIN] = updatedPlugin;
-      setExtras(updatedExtras);
-    }
-
-    const storagePlugin = get(extras, [PAI_PLUGIN], []).find(
-      plugin => plugin.plugin === 'teamwise_storage',
-    );
-    const updatedStorageConfig = get(
-      storagePlugin,
-      'parameters.storageConfigNames',
-    );
-    if (
-      JSON.stringify(updatedStorageConfig) !== JSON.stringify(storageConfigs)
-    ) {
-      setStorageConfigs(updatedStorageConfig);
-    }
-  }, [extras]);
 
   useEffect(() => {
     const taskRolesManager = new TaskRolesManager(jobTaskRoles);
@@ -441,7 +457,6 @@ export const JobSubmissionPage = ({
                     onChange={setJobData}
                     extras={extras}
                     onExtrasChange={setExtras}
-                    storageConfigs={storageConfigs}
                   />
                   <ToolComponent
                     selected={selected === SIDEBAR_TOOL}

--- a/src/webportal/src/app/job-submission/job-submission-page.jsx
+++ b/src/webportal/src/app/job-submission/job-submission-page.jsx
@@ -225,9 +225,9 @@ export const JobSubmissionPage = ({
     // for import and clone, will respect original protocol
     const params = new URLSearchParams(window.location.search);
     if (
+      config.launcherType !== 'k8s' ||
       !isEmpty(yamlText) ||
-      params.get('op') === 'resubmit' ||
-      config.launcherType !== 'k8s'
+      params.get('op') === 'resubmit'
     ) {
       return;
     }
@@ -243,7 +243,7 @@ export const JobSubmissionPage = ({
           jobssh: true,
         },
       };
-      extras[PAI_PLUGIN].push(sshPlugin);
+
       // set storage plugin default value
       const defaultStorageConfig = [];
       try {
@@ -262,7 +262,8 @@ export const JobSubmissionPage = ({
           storageConfigNames: defaultStorageConfig,
         },
       };
-      extras[PAI_PLUGIN].push(storagePlugin);
+
+      extras[PAI_PLUGIN].push(sshPlugin, storagePlugin);
       setExtras(extras);
     };
     setExtrasValue();

--- a/src/webportal/src/app/job-submission/job-submission-page.jsx
+++ b/src/webportal/src/app/job-submission/job-submission-page.jsx
@@ -426,6 +426,8 @@ export const JobSubmissionPage = ({
                     onSelect={selectData}
                     jobName={jobInformation.name}
                     onChange={setJobData}
+                    extras={extras}
+                    onExtrasChange={setExtras}
                     storageConfigs={storageConfigs}
                   />
                   <ToolComponent

--- a/src/webportal/src/app/job-submission/job-submission-page.jsx
+++ b/src/webportal/src/app/job-submission/job-submission-page.jsx
@@ -53,7 +53,7 @@ import {
 } from './utils/utils';
 import { SpinnerLoading } from '../components/loading';
 import config from '../config/webportal.config';
-import { PAI_PLUGIN, PAI_STORAGE } from './utils/constants';
+import { PAI_PLUGIN } from './utils/constants';
 
 const SIDEBAR_PARAM = 'param';
 const SIDEBAR_SECRET = 'secret';
@@ -286,24 +286,37 @@ export const JobSubmissionPage = ({
 
   // Init plugins for pure k8s based PAI
   useEffect(() => {
-    if (config.launcherType === 'k8s') {
-      const plugin = get(extras, PAI_PLUGIN);
-      if (!plugin) {
-        // Init SSH default settings for old/empty jobs
-        const updatedPlugin = [
-          {
-            plugin: 'ssh',
-            parameters: {
-              jobssh: true,
-            },
-          },
-        ];
-        const updatedExtras = cloneDeep(extras);
-        updatedExtras[PAI_PLUGIN] = updatedPlugin;
-        setExtras(updatedExtras);
-      }
+    if (config.launcherType !== 'k8s') {
+      return;
+    }
 
-      setStorageConfigs(get(extras, PAI_STORAGE));
+    const plugin = get(extras, PAI_PLUGIN);
+    if (!plugin) {
+      // Init SSH default settings for old/empty jobs
+      const updatedPlugin = [
+        {
+          plugin: 'ssh',
+          parameters: {
+            jobssh: true,
+          },
+        },
+      ];
+      const updatedExtras = cloneDeep(extras);
+      updatedExtras[PAI_PLUGIN] = updatedPlugin;
+      setExtras(updatedExtras);
+    }
+
+    const storagePlugin = get(extras, [PAI_PLUGIN], []).find(
+      plugin => plugin.plugin === 'teamwise_storage',
+    );
+    const updatedStorageConfig = get(
+      storagePlugin,
+      'parameters.storageConfigNames',
+    );
+    if (
+      JSON.stringify(updatedStorageConfig) !== JSON.stringify(storageConfigs)
+    ) {
+      setStorageConfigs(updatedStorageConfig);
     }
   }, [extras]);
 

--- a/src/webportal/src/app/job-submission/models/protocol-schema.js
+++ b/src/webportal/src/app/job-submission/models/protocol-schema.js
@@ -24,6 +24,7 @@
  */
 
 import Joi from 'joi-browser';
+import { PAI_PLUGIN } from '../utils/constants';
 
 export const taskRoleSchema = Joi.object().keys({
   instances: Joi.number()
@@ -148,6 +149,7 @@ export const jobProtocolSchema = Joi.object().keys({
     .keys({
       submitFrom: Joi.string(),
       tensorBoard: tensorBoardExtrasSchema,
+      [PAI_PLUGIN]: Joi.array(),
     })
     .unknown(),
 });

--- a/src/webportal/src/app/job-submission/utils/constants.js
+++ b/src/webportal/src/app/job-submission/utils/constants.js
@@ -155,6 +155,8 @@ export const DEFAULT_DOCKER_URI = 'openpai/tensorflow-py36-cu90';
 // For PAI runtime only
 export const PAI_PLUGIN = 'com.microsoft.pai.runtimeplugin';
 
+export const STORAGE_PLUGIN = 'teamwise_storage';
+
 export const PAI_STORAGE = 'pai.storage';
 
 export const SSH_KEY_BITS = 1024;

--- a/src/webportal/src/app/job-submission/utils/constants.js
+++ b/src/webportal/src/app/job-submission/utils/constants.js
@@ -157,8 +157,6 @@ export const PAI_PLUGIN = 'com.microsoft.pai.runtimeplugin';
 
 export const STORAGE_PLUGIN = 'teamwise_storage';
 
-export const PAI_STORAGE = 'pai.storage';
-
 export const SSH_KEY_BITS = 1024;
 
 export const USERSSH_TYPE_OPTIONS = [

--- a/src/webportal/src/app/job-submission/utils/utils.js
+++ b/src/webportal/src/app/job-submission/utils/utils.js
@@ -14,6 +14,7 @@ import {
   AUTO_GENERATE_NOTIFY,
   PAI_STORAGE,
 } from './constants';
+import config from '../../config/webportal.config';
 
 const HIDE_SECRET = '******';
 
@@ -187,6 +188,11 @@ export async function populateProtocolWithDataAndTensorboard(
   protocol,
   jobData,
 ) {
+  // for k8s, we use runtime plugin and not inject code into the command
+  if (config.launcherType === 'k8s') {
+    return;
+  }
+
   // add tensorboard commands
   addTensorBoardCommandsToProtocolTaskRoles(protocol);
 

--- a/src/webportal/src/app/job-submission/utils/utils.js
+++ b/src/webportal/src/app/job-submission/utils/utils.js
@@ -1,4 +1,4 @@
-import { isObject, isEmpty, isNil, isArrayLike } from 'lodash';
+import { isObject, isEmpty, isNil, isArrayLike, get } from 'lodash';
 import { basename } from 'path';
 
 import { JobBasicInfo } from '../models/job-basic-info';
@@ -13,6 +13,7 @@ import {
   TENSORBOARD_LOG_PATH,
   AUTO_GENERATE_NOTIFY,
   PAI_STORAGE,
+  PAI_PLUGIN,
 } from './constants';
 import config from '../../config/webportal.config';
 
@@ -312,4 +313,12 @@ export function isValidUpdatedTensorBoardExtras(
     return false;
   }
   return true;
+}
+
+export function getStoragePlugin(extras) {
+  const plugins = get(extras, [PAI_PLUGIN], []);
+  if (isEmpty(plugins)) {
+    return;
+  }
+  return plugins.find(plugin => plugin.plugin === 'teamwise_storage');
 }

--- a/src/webportal/src/app/job-submission/utils/utils.js
+++ b/src/webportal/src/app/job-submission/utils/utils.js
@@ -12,7 +12,6 @@ import {
   TENSORBOARD_CMD_END,
   TENSORBOARD_LOG_PATH,
   AUTO_GENERATE_NOTIFY,
-  PAI_STORAGE,
   PAI_PLUGIN,
 } from './constants';
 import config from '../../config/webportal.config';
@@ -207,16 +206,6 @@ export async function populateProtocolWithDataAndTensorboard(
     protocol.name || '',
   );
   addPreCommandsToProtocolTaskRoles(protocol, preCommands);
-
-  if (protocol.extras) {
-    if (isEmpty(jobData.mountDirs.selectedConfigs)) {
-      protocol.extras[PAI_STORAGE] = [];
-    } else {
-      protocol.extras[PAI_STORAGE] = jobData.mountDirs.selectedConfigs.map(
-        config => config.name,
-      );
-    }
-  }
 }
 
 function removeTagSection(commands, beginTag, endTag) {


### PR DESCRIPTION
When using storage plugin, we will not inject commands into the user command. Just change the extra field in the protocol.
Sample:
```yaml
extras:
  com.microsoft.pai.runtimeplugin:
    - plugin: teamwiase_storage
      parameters:
        storageConfigNames:
          - PAI_SAHRE  # storage config name provided by admin
```

#### Other changes 
- Fix plugin can not be removed bug