### PR TITLE
[Prometheus ] Fix prometheus high io issue

### DIFF
--- a/src/prometheus/deploy/prometheus-deployment.yaml.template
+++ b/src/prometheus/deploy/prometheus-deployment.yaml.template
@@ -42,11 +42,13 @@ spec:
       hostNetwork: true
       initContainers:
       - name: init
-        image: bash:4
+        image: busybox:1.31.1
+        securityContext:
+          runAsUser: 0
         volumeMounts:
         - name: prometheus-data
           mountPath: /prometheus-data
-        command: ["chmod", "777", "/prometheus-data"] # newly create dir have permission 755, which makes prometheus container unable to write
+        command: ["chown", "-R", "nobody:nogroup", "/prometheus-data"] # prometheus run as nobody:nogroup, refer to: https://github.com/prometheus/prometheus/pull/2859
       containers:
       - name: prometheus
         image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}prometheus:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}


### PR DESCRIPTION
Prometheus cause high io usage because some folders owner is root and permission is 755. But Prometheus default user is nobody:nogroup.
Prometheus service can not change the previous folder, and stuck at compacting logs. So high disk io occur.
Fix this issue by change the folder owner to nobody:nogroup