### PR TITLE
[Cluster Objec Model]Don't check hadoop rm uri when in pure k8s cluster.

### DIFF
--- a/src/webportal/config/webportal.py
+++ b/src/webportal/config/webportal.py
@@ -76,7 +76,7 @@ class Webportal:
             ('node-exporter', 'port'),
             ('prometheus', 'scrape_interval'),
         )
-        if cluster_object_model['common']['cluster-type'] == 'yarn':
+        if cluster_object_model['cluster']['common']['cluster-type'] == 'yarn':
             check_tuple = (('hadoop-resource-manager', 'master-ip'),)+check_tuple
         for (service, config) in check_tuple:
             if service not in cluster_object_model or config not in cluster_object_model[service]:

--- a/src/webportal/config/webportal.py
+++ b/src/webportal/config/webportal.py
@@ -67,16 +67,18 @@ class Webportal:
 
     #### All service and main module (kubrenetes, machine) is generated. And in this check steps, you could refer to the service object model which you will used in your own service, and check its existence and correctness.
     def validation_post(self, cluster_object_model):
-        for (service, config) in (
+        check_tuple = (
             ('rest-server', 'uri'),
             ('prometheus', 'url'),
-            ('hadoop-resource-manager', 'master-ip'),
             ('grafana', 'url'),
             # TODO
-            #('kubernetes', 'dashboard-url'),
+            # ('kubernetes', 'dashboard-url'),
             ('node-exporter', 'port'),
             ('prometheus', 'scrape_interval'),
-        ):
+        )
+        if cluster_object_model['common']['cluster-type'] == 'yarn':
+            check_tuple = (('hadoop-resource-manager', 'master-ip'),)+check_tuple
+        for (service, config) in check_tuple:
             if service not in cluster_object_model or config not in cluster_object_model[service]:
                 return False, '{0}.{1} is required'.format(service, config)
 

--- a/src/webportal/deploy/webportal.yaml.template
+++ b/src/webportal/deploy/webportal.yaml.template
@@ -48,8 +48,10 @@ spec:
 {%- else %}
           value: yarn
 {%- endif %}
+{%- if cluster_cfg["cluster"]["common"]["cluster-type"] == "yarn" %}
         - name: YARN_WEB_PORTAL_URI
           value: http://{{ cluster_cfg['hadoop-resource-manager']['master-ip'] }}:8088
+{%- endif %}
         - name: GRAFANA_URI
           value: {{ cluster_cfg['grafana']['url'] }}
         - name: K8S_DASHBOARD_URI


### PR DESCRIPTION
**Change**

1: Skip ```hadoop-resource-manager.master-ip``` check it when the ```cluster-type``` isn't yarn.
2: Remove the env named ```YARN_WEB_PORTAL_URI``` from the pod of webportal if the ```cluster-type``` isn't yarn.


**TODO**

The file need to be changed after this change.

https://github.com/microsoft/pai/blob/15ed057560553cd86a6041bc159b1a4065ca7611/src/webportal/src/app/env.js.template#L4
https://github.com/microsoft/pai/blob/ca0e213e05cfc5024b4886be249186173204709f/src/webportal/src/app/vc/vc.component.js#L33
https://github.com/microsoft/pai/blob/ea429d6b82cac78d7d2b4807981f23c94db12aeb/src/webportal/src/app/vc/vc.component.ejs#L68
https://github.com/microsoft/pai/blob/ea429d6b82cac78d7d2b4807981f23c94db12aeb/src/webportal/src/app/vc/vc.component.ejs#L137

I think this page or the link should be replaced if the cluster-type isn't yarn.

@debuggy @abuccts @sunqinzheng 
