### PR TITLE
Upgrade deprecated k8s apiversion

### DIFF
--- a/src/device-plugin/config/device-plugin.yaml
+++ b/src/device-plugin/config/device-plugin.yaml
@@ -19,4 +19,3 @@ service_type: "k8s"
 
 devices:
   - "nvidia.com/gpu"
-  - "rdma/hca"

--- a/src/device-plugin/deploy/device-plugin.yaml
+++ b/src/device-plugin/deploy/device-plugin.yaml
@@ -24,6 +24,9 @@ metadata:
   name: k8s-host-device-plugin-daemonset
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: k8s-host-device-plugin-ds
   template:
     metadata:
       annotations:

--- a/src/device-plugin/deploy/device-plugin.yaml
+++ b/src/device-plugin/deploy/device-plugin.yaml
@@ -18,7 +18,7 @@ data:
       ]
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: k8s-host-device-plugin-daemonset

--- a/src/device-plugin/deploy/start.sh.template
+++ b/src/device-plugin/deploy/start.sh.template
@@ -33,10 +33,7 @@ kubectl apply --overwrite=true -f https://raw.githubusercontent.com/NVIDIA/k8s-d
 {% if 'rdma/hca' in cluster_cfg['device-plugin']['devices'] %}
 
 kubectl apply --overwrite=true -f https://raw.githubusercontent.com/Mellanox/k8s-rdma-sriov-dev-plugin/master/example/hca/rdma-hca-node-config.yaml || exit $?
-curl -s https://raw.githubusercontent.com/Mellanox/k8s-rdma-sriov-dev-plugin/master/example/device-plugin.yaml \
-  | sed "s/extensions\/v1beta1/apps\/v1/g" \
-  | kubectl apply --overwrite=true -f - \
-  || exit $?
+kubectl apply --overwrite=true -f https://raw.githubusercontent.com/Mellanox/k8s-rdma-sriov-dev-plugin/master/example/device-plugin.yaml || exit $?
 
 {% endif %}
 

--- a/src/device-plugin/deploy/start.sh.template
+++ b/src/device-plugin/deploy/start.sh.template
@@ -25,7 +25,7 @@ kubectl apply --overwrite=true -f device-plugin.yaml || exit $?
 # NVIDIA GPU device plugin
 {% if 'nvidia.com/gpu' in cluster_cfg['device-plugin']['devices'] %}
 
-kubectl apply --overwrite=true -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta/nvidia-device-plugin.yml || exit $?
+kubectl apply --overwrite=true -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/1.0.0-beta4/nvidia-device-plugin.yml || exit $?
 
 {% endif %}
 
@@ -33,7 +33,10 @@ kubectl apply --overwrite=true -f https://raw.githubusercontent.com/NVIDIA/k8s-d
 {% if 'rdma/hca' in cluster_cfg['device-plugin']['devices'] %}
 
 kubectl apply --overwrite=true -f https://raw.githubusercontent.com/Mellanox/k8s-rdma-sriov-dev-plugin/master/example/hca/rdma-hca-node-config.yaml || exit $?
-kubectl apply --overwrite=true -f https://raw.githubusercontent.com/Mellanox/k8s-rdma-sriov-dev-plugin/master/example/device-plugin.yaml || exit $?
+curl -s https://raw.githubusercontent.com/Mellanox/k8s-rdma-sriov-dev-plugin/master/example/device-plugin.yaml \
+  | sed "s/extensions\/v1beta1/apps\/v1/g" \
+  | kubectl apply --overwrite=true -f - \
+  || exit $?
 
 {% endif %}
 

--- a/src/fluentd/deploy/fluentd.yaml.template
+++ b/src/fluentd/deploy/fluentd.yaml.template
@@ -16,7 +16,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: fluentd-ds
 spec:

--- a/src/watchdog/test/data/no_condtion_pod.json
+++ b/src/watchdog/test/data/no_condtion_pod.json
@@ -18,7 +18,7 @@
                 },
                 "ownerReferences": [
                     {
-                        "apiVersion": "extensions/v1beta1",
+                        "apiVersion": "apps/v1",
                         "kind": "DaemonSet",
                         "name": "yarn-frameworklauncher-ds",
                         "uid": "b4918fda-8a77-11e8-a8fc-000d3ab25bb6",


### PR DESCRIPTION
Upgrade deprecated k8s apiversion "extensions/v1beta1" to "apps/v1".
Reference: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/