### PR TITLE
[Runtime, Rest-server] Pass secret from frontend to runtime

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install kubernetes pyyaml requests jinja2 pylint
+        pip install kubernetes pyyaml requests jinja2 pystache pylint
     - name: Lint kube-runtime
       run: |
         cd src/kube-runtime

--- a/src/kube-runtime/build/kube-runtime.dockerfile
+++ b/src/kube-runtime/build/kube-runtime.dockerfile
@@ -29,7 +29,7 @@ RUN ${PROJECT_DIR}/build/runtime/go-build.sh && \
 
 FROM python:3.7-alpine
 
-RUN pip install kubernetes pyyaml requests jinja2
+RUN pip install kubernetes pyyaml requests jinja2 pystache
 
 ENV INSTALL_DIR=/opt/kube-runtime
 ARG BARRIER_DIR=/opt/frameworkcontroller/frameworkbarrier

--- a/src/kube-runtime/src/init
+++ b/src/kube-runtime/src/init
@@ -89,7 +89,7 @@ PAI_INIT_DIR=${PAI_WORK_DIR}/init.d
 PAI_RUNTIME_DIR=${PAI_WORK_DIR}/runtime.d
 
 PAI_LOG_DIR=${PAI_WORK_DIR}/logs/${FC_POD_UID}
-PAI_SERCRET_FILE=${PAI_WORK_DIR}/secret
+PAI_SERCRET_DIR=${PAI_WORK_DIR}/secrets
 
 # Move previous logs to another folder. Notice: exclude for init.log, new log will append to previous log file
 LOG_FILES=$(find $PAI_LOG_DIR -maxdepth 1 -type f ! -name "init.log")
@@ -177,7 +177,7 @@ python ${PAI_INIT_DIR}/image_checker.py ${PAI_RUNTIME_DIR}/job_config.yaml
 # write user commands to user.sh
 # priority=100
 CHILD_PROCESS="RENDER_USER_COMMAND"
-python ${PAI_INIT_DIR}/user_command_render.py ${USER_CMD} ${PAI_SERCRET_FILE} ${PAI_RUNTIME_DIR}/user.sh
+python ${PAI_INIT_DIR}/user_command_renderer.py ${PAI_SERCRET_DIR}/secrets.yaml ${PAI_RUNTIME_DIR}/user.sh
 
 # for debug
 echo -e "finished entry\nuser.sh has:"

--- a/src/kube-runtime/src/init
+++ b/src/kube-runtime/src/init
@@ -89,6 +89,7 @@ PAI_INIT_DIR=${PAI_WORK_DIR}/init.d
 PAI_RUNTIME_DIR=${PAI_WORK_DIR}/runtime.d
 
 PAI_LOG_DIR=${PAI_WORK_DIR}/logs/${FC_POD_UID}
+PAI_SERCRET_FILE=${PAI_WORK_DIR}/secret
 
 # Move previous logs to another folder. Notice: exclude for init.log, new log will append to previous log file
 LOG_FILES=$(find $PAI_LOG_DIR -maxdepth 1 -type f ! -name "init.log")
@@ -175,7 +176,8 @@ python ${PAI_INIT_DIR}/image_checker.py ${PAI_RUNTIME_DIR}/job_config.yaml
 
 # write user commands to user.sh
 # priority=100
-echo "${USER_CMD}" >> ${PAI_RUNTIME_DIR}/user.sh
+CHILD_PROCESS="RENDER_USER_COMMAND"
+python ${PAI_INIT_DIR}/user_command_render.py ${USER_CMD} ${PAI_SERCRET_FILE} ${PAI_RUNTIME_DIR}/user.sh
 
 # for debug
 echo -e "finished entry\nuser.sh has:"

--- a/src/kube-runtime/src/init
+++ b/src/kube-runtime/src/init
@@ -180,7 +180,5 @@ CHILD_PROCESS="RENDER_USER_COMMAND"
 python ${PAI_INIT_DIR}/user_command_renderer.py ${PAI_SECRET_DIR}/secrets.yaml ${PAI_RUNTIME_DIR}/user.sh
 
 # for debug
-echo -e "finished entry\nuser.sh has:"
-cat ${PAI_RUNTIME_DIR}/user.sh
 echo -e "\nruntime_env.sh has:"
 cat ${PAI_RUNTIME_DIR}/runtime_env.sh

--- a/src/kube-runtime/src/init
+++ b/src/kube-runtime/src/init
@@ -89,7 +89,7 @@ PAI_INIT_DIR=${PAI_WORK_DIR}/init.d
 PAI_RUNTIME_DIR=${PAI_WORK_DIR}/runtime.d
 
 PAI_LOG_DIR=${PAI_WORK_DIR}/logs/${FC_POD_UID}
-PAI_SERCRET_DIR=${PAI_WORK_DIR}/secrets
+PAI_SECRET_DIR=${PAI_WORK_DIR}/secrets
 
 # Move previous logs to another folder. Notice: exclude for init.log, new log will append to previous log file
 LOG_FILES=$(find $PAI_LOG_DIR -maxdepth 1 -type f ! -name "init.log")
@@ -177,7 +177,7 @@ python ${PAI_INIT_DIR}/image_checker.py ${PAI_RUNTIME_DIR}/job_config.yaml
 # write user commands to user.sh
 # priority=100
 CHILD_PROCESS="RENDER_USER_COMMAND"
-python ${PAI_INIT_DIR}/user_command_renderer.py ${PAI_SERCRET_DIR}/secrets.yaml ${PAI_RUNTIME_DIR}/user.sh
+python ${PAI_INIT_DIR}/user_command_renderer.py ${PAI_SECRET_DIR}/secrets.yaml ${PAI_RUNTIME_DIR}/user.sh
 
 # for debug
 echo -e "finished entry\nuser.sh has:"

--- a/src/kube-runtime/src/init.d/user_command_render.py
+++ b/src/kube-runtime/src/init.d/user_command_render.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import argparse
+import logging
+import os
+import re
+import sys
+
+import pystache
+import yaml
+
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+from common.utils import init_logger  #pylint: disable=wrong-import-position
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _convert_to_dict(obj):
+    coverted_obj = {}
+    if isinstance(obj, list):
+        for i, value in enumerate(obj):
+            coverted_obj[str(i)] = value
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            coverted_obj[key] = _convert_to_dict(value)
+    else:
+        coverted_obj = obj
+    return coverted_obj
+
+
+def _render_user_command(user_command, secrets) -> str:
+    LOGGER.info("not rendered user command is %s", user_command)
+    secret_dict = _convert_to_dict(secrets)
+    parsed = pystache.parse(user_command, delimiters=("<%", "%>"))
+    for token in parsed._parse_tree:  #pylint: disable=protected-access
+        if isinstance(token, pystache.parser._EscapeNode):  #pylint: disable=protected-access
+            token.key = re.sub(
+                r"\[(\d+)\]", r".\1",
+                token.key)  # make format such as $secrets.data[0] works
+    return pystache.Renderer().render(parsed,
+                                      {"$secrets": secret_dict["secrets"]})
+
+
+def _output_user_command(user_command, output_file):
+    with open(output_file, "w+") as f:
+        f.write(user_command)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("user_command", help="user command")
+    parser.add_argument("secret_file", help="file which contains secret info")
+    parser.add_argument("output_file", help="output file name")
+    args = parser.parse_args()
+
+    logging.info("Starting to render user command")
+    with open(args.secret_file) as f:
+        secrets = yaml.safe_load(f.read())
+
+    rendered_user_command = _render_user_command(args.user_command, secrets)
+    _output_user_command(rendered_user_command, args.output_file)
+    logging.info("User command already rendered and output to %s",
+                 args.output_file)
+
+
+if __name__ == "__main__":
+    init_logger()
+    main()

--- a/src/kube-runtime/src/init.d/user_command_renderer.py
+++ b/src/kube-runtime/src/init.d/user_command_renderer.py
@@ -32,17 +32,17 @@ from common.utils import init_logger  #pylint: disable=wrong-import-position
 LOGGER = logging.getLogger(__name__)
 
 
-def _convert_to_dict(obj):
-    coverted_obj = {}
+def _convert_to_dict(obj) -> dict:
+    converted_obj = {}
     if isinstance(obj, list):
         for i, value in enumerate(obj):
-            coverted_obj[str(i)] = value
+            converted_obj[str(i)] = value
     elif isinstance(obj, dict):
         for key, value in obj.items():
-            coverted_obj[key] = _convert_to_dict(value)
+            converted_obj[key] = _convert_to_dict(value)
     else:
-        coverted_obj = obj
-    return coverted_obj
+        converted_obj = obj
+    return converted_obj
 
 
 def _render_user_command(user_command, secrets) -> str:

--- a/src/kube-runtime/src/init.d/user_command_renderer.py
+++ b/src/kube-runtime/src/init.d/user_command_renderer.py
@@ -81,7 +81,7 @@ def main():
     user_command = os.getenv("USER_CMD")
     rendered_user_command = _render_user_command(user_command, secrets)
     _output_user_command(rendered_user_command, args.output_file)
-    logging.info("User command already rendered and output to %s",
+    logging.info("User command already rendered and outputted to %s",
                  args.output_file)
 
 

--- a/src/kube-runtime/test/render_test_secrets.yaml
+++ b/src/kube-runtime/test/render_test_secrets.yaml
@@ -1,0 +1,12 @@
+secrets:
+  time: 10
+---
+secrets:
+  time:
+    - 10
+    - 20
+---
+secrets:
+  time:
+    time1: 10
+    time2: 20

--- a/src/kube-runtime/test/render_test_secrets.yaml
+++ b/src/kube-runtime/test/render_test_secrets.yaml
@@ -1,12 +1,9 @@
-secrets:
-  time: 10
+time: 10
 ---
-secrets:
-  time:
-    - 10
-    - 20
+time:
+  - 10
+  - 20
 ---
-secrets:
-  time:
-    time1: 10
-    time2: 20
+time:
+  time1: 10
+  time2: 20

--- a/src/kube-runtime/test/render_test_secrets.yaml
+++ b/src/kube-runtime/test/render_test_secrets.yaml
@@ -7,3 +7,11 @@ time:
 time:
   time1: 10
   time2: 20
+---
+time:
+  date:
+    month: Jan,
+    year: 2019
+    workingDay:
+      - 1
+      - 2

--- a/src/kube-runtime/test/test_render_user_command.py
+++ b/src/kube-runtime/test/test_render_user_command.py
@@ -48,23 +48,17 @@ class TestUserCommandRender(unittest.TestCase):
             "sleep <% $secrets.time.time1 %>",
             "echo <% $secrets.time.date.year %> && sleep <% $secrets.time.date.workingDay.0 %>"
         ]
+        expected_commands = [
+            "sleep 10", "sleep 10", "sleep 10", "echo 2019 && sleep 1"
+        ]
         with open("render_test_secrets.yaml") as f:
             secrets = list(yaml.safe_load_all(f.read()))
-        res = user_command_renderer._render_user_command(
-            user_commands[0], secrets[0])
-        self.assertEqual(res, "sleep 10")
 
-        res = user_command_renderer._render_user_command(
-            user_commands[1], secrets[1])
-        self.assertEqual(res, "sleep 10")
-
-        res = user_command_renderer._render_user_command(
-            user_commands[2], secrets[2])
-        self.assertEqual(res, "sleep 10")
-
-        res = user_command_renderer._render_user_command(
-            user_commands[3], secrets[3])
-        self.assertEqual(res, "echo 2019 && sleep 1")
+        for user_command, expected_command, secret in zip(
+                user_commands, expected_commands, secrets):
+            res = user_command_renderer._render_user_command(
+                user_command, secret)
+            self.assertEqual(res, expected_command)
 
 
 if __name__ == '__main__':

--- a/src/kube-runtime/test/test_render_user_command.py
+++ b/src/kube-runtime/test/test_render_user_command.py
@@ -26,7 +26,7 @@ sys.path.append(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "../src"))
 sys.path.append(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "../src/init.d"))
-import user_command_render
+import user_command_renderer
 from common.utils import init_logger
 # pylint: enable=wrong-import-position
 
@@ -49,16 +49,16 @@ class TestUserCommandRender(unittest.TestCase):
         ]
         with open("render_test_secrets.yaml") as f:
             secrets = list(yaml.safe_load_all(f.read()))
-        res = user_command_render._render_user_command(user_commands[0],
-                                                       secrets[0])
+        res = user_command_renderer._render_user_command(
+            user_commands[0], secrets[0])
         self.assertEqual(res, "sleep 10")
 
-        res = user_command_render._render_user_command(user_commands[1],
-                                                       secrets[1])
+        res = user_command_renderer._render_user_command(
+            user_commands[1], secrets[1])
         self.assertEqual(res, "sleep 10")
 
-        res = user_command_render._render_user_command(user_commands[2],
-                                                       secrets[2])
+        res = user_command_renderer._render_user_command(
+            user_commands[2], secrets[2])
         self.assertEqual(res, "sleep 10")
 
 

--- a/src/kube-runtime/test/test_render_user_command.py
+++ b/src/kube-runtime/test/test_render_user_command.py
@@ -45,7 +45,8 @@ class TestUserCommandRender(unittest.TestCase):
     def test_user_command_render(self):
         user_commands = [
             "sleep <% $secrets.time %>", "sleep <% $secrets.time[0] %>",
-            "sleep <% $secrets.time.time1 %>"
+            "sleep <% $secrets.time.time1 %>",
+            "echo <% $secrets.time.date.year %> && sleep <% $secrets.time.date.workingDay.0 %>"
         ]
         with open("render_test_secrets.yaml") as f:
             secrets = list(yaml.safe_load_all(f.read()))
@@ -60,6 +61,10 @@ class TestUserCommandRender(unittest.TestCase):
         res = user_command_renderer._render_user_command(
             user_commands[2], secrets[2])
         self.assertEqual(res, "sleep 10")
+
+        res = user_command_renderer._render_user_command(
+            user_commands[3], secrets[3])
+        self.assertEqual(res, "echo 2019 && sleep 1")
 
 
 if __name__ == '__main__':

--- a/src/kube-runtime/test/test_render_user_command.py
+++ b/src/kube-runtime/test/test_render_user_command.py
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation
+# All rights reserved.
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+# to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+# BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import sys
+import unittest
+
+import yaml
+
+# pylint: disable=wrong-import-position
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../src"))
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "../src/init.d"))
+import user_command_render
+from common.utils import init_logger
+# pylint: enable=wrong-import-position
+
+PACKAGE_DIRECTORY_COM = os.path.dirname(os.path.abspath(__file__))
+init_logger()
+
+
+# pylint: disable=protected-access
+class TestUserCommandRender(unittest.TestCase):
+    def setUp(self):
+        try:
+            os.chdir(PACKAGE_DIRECTORY_COM)
+        except Exception:  #pylint: disable=broad-except
+            pass
+
+    def test_user_command_render(self):
+        user_commands = [
+            "sleep <% $secrets.time %>", "sleep <% $secrets.time[0] %>",
+            "sleep <% $secrets.time.time1 %>"
+        ]
+        with open("render_test_secrets.yaml") as f:
+            secrets = list(yaml.safe_load_all(f.read()))
+        res = user_command_render._render_user_command(user_commands[0],
+                                                       secrets[0])
+        self.assertEqual(res, "sleep 10")
+
+        res = user_command_render._render_user_command(user_commands[1],
+                                                       secrets[1])
+        self.assertEqual(res, "sleep 10")
+
+        res = user_command_render._render_user_command(user_commands[2],
+                                                       secrets[2])
+        self.assertEqual(res, "sleep 10")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/rest-server/src/config/paiConfig.js
+++ b/src/rest-server/src/config/paiConfig.js
@@ -21,7 +21,7 @@ const yaml = require('js-yaml');
 const {get} = require('lodash');
 const fs = require('fs');
 const logger = require('@pai/config/logger');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 
 let paiMachineList = [];
 try {

--- a/src/rest-server/src/middlewares/v2/protocol.js
+++ b/src/rest-server/src/middlewares/v2/protocol.js
@@ -56,6 +56,8 @@ const render = (template, dict, tags=['<%', '%>']) => {
       const value = context.lookup(tokenStr);
       if (value != null) {
         result += value;
+      } else {
+        result += tokenStr;
       }
     }
   }
@@ -156,10 +158,10 @@ const protocolRender = (protocolObj) => {
         commands = commands.concat(deployment.taskRoles[taskRole].postCommands);
       }
     }
-    commands = commands.map((command) => command.trim()).join(' && ');
+    commands = commands.map((command) => command.trim()).join('\n');
+    // Will not render secret here for security issue
     const entrypoint = render(commands, {
       '$parameters': protocolObj.parameters,
-      '$secrets': protocolObj.secrets,
       '$script': protocolObj.prerequisites['script'][protocolObj.taskRoles[taskRole].script],
       '$output': protocolObj.prerequisites['output'][protocolObj.taskRoles[taskRole].output],
       '$data': protocolObj.prerequisites['data'][protocolObj.taskRoles[taskRole].data],

--- a/src/rest-server/src/middlewares/v2/protocol.js
+++ b/src/rest-server/src/middlewares/v2/protocol.js
@@ -57,7 +57,7 @@ const render = (template, dict, tags=['<%', '%>']) => {
       if (value != null) {
         result += value;
       } else {
-        result += tokenStr;
+        result += `<% ${tokenStr} %>`;
       }
     }
   }

--- a/src/rest-server/src/models/kubernetes.js
+++ b/src/rest-server/src/models/kubernetes.js
@@ -17,7 +17,7 @@ const patchOption = {
 
 const rethrowResponseError = (error) => {
   const response = error.response;
-  if (response !== null) {
+  if (response != null) { // check null and undefined
     return Promise.reject(createError(response.status, 'UnknownError', response.data.message));
   } else {
     return Promise.reject(error);

--- a/src/rest-server/src/models/kubernetes/k8s-secret.js
+++ b/src/rest-server/src/models/kubernetes/k8s-secret.js
@@ -16,13 +16,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const _ = require('lodash');
-const {encodeSelector, getClient} = require('@pai/models/kubernetes');
+const createError = require('@pai/utils/error');
+const {encodeSelector, getClient, patchOption} = require('@pai/models/kubernetes/kubernetes');
+
+// TODO: we should use more specific error for k8s api error.
+const rethrowResponseError = (error) => {
+  const response = error.response;
+  if (response != null) {
+    return Promise.reject(createError(response.status, 'UnknownError', response.data.message));
+  } else {
+    return Promise.reject(error);
+  }
+};
 
 const initClient = (namespace) => {
   if (!namespace) {
     throw new Error('K8S SECRET: invalid namespace');
   }
-  return getClient(`/api/v1/namespaces/${namespace}/secrets`);
+  const client = getClient(`/api/v1/namespaces/${namespace}/secrets`);
+  client.interceptors.response.use((resp) => resp, rethrowResponseError);
+  return client;
 };
 
 
@@ -60,20 +73,24 @@ const deserialize = (object) => {
   return result;
 };
 
-const get = async (namespace, key) => {
-  if (!key) {
+const get = async (namespace, name, options = {}) => {
+  if (!name) {
     return list(namespace);
   }
   const client = initClient(namespace);
-  // k8s resource's name must consisst of only digits (0-9), lower case letters (a-z), -, and ..
-  // We encode the key here to ensure it is valid.
-  const hexKey = Buffer.from(key).toString('hex');
+  const {encode} = options;
+  let secretName = name;
+  if (encode != null) {
+    // k8s resource's name must consisst of only digits (0-9), lower case letters (a-z), -, and ..
+    // We encode the key here to ensure it is valid.
+    secretName = Buffer.from(name).toString('hex');
+  }
 
   try {
-    const response = await client.get(`/${hexKey}`);
+    const response = await client.get(`/${secretName}`);
     return deserialize(response.data.data);
   } catch (err) {
-    if (err.response && err.response.status === 404 && err.response.data) {
+    if (err.status === 404 && err.message) {
       return null;
     } else {
       throw err;
@@ -99,7 +116,7 @@ const list = async (namespace, labelSelector) => {
       // request
       response = await client.get('/', {params});
     } catch (err) {
-      if (err.response && err.response.status === 410) {
+      if (err.status === 410) {
         // restart
         continueValue = null;
         result = [];
@@ -121,43 +138,63 @@ const list = async (namespace, labelSelector) => {
   return output;
 };
 
-const create = async (namespace, key, data, labels) => {
+const create = async (namespace, name, data, options = {}) => {
+  const {labels, encode, type} = options;
   const client = initClient(namespace);
-  const hexKey = Buffer.from(key).toString('hex');
+
+  let secretName = name;
+  if (encode != null) {
+    secretName = Buffer.from(name).toString(encode);
+  }
 
   const response = await client.post('/', {
     metadata: {
-      name: hexKey,
-      namespace,
-      labels,
+      name: secretName,
+      namespace: namespace,
+      labels: labels,
     },
+    type: type,
     data: serialize(data),
   });
-
   return response.data;
 };
 
-const replace = async (namespace, key, data, labels) => {
+const replace = async (namespace, name, data, options = {}) => {
+  const {encode, labels} = options;
+  let secretName = name;
+  if (encode != null) {
+    secretName = Buffer.from(secretName).toString(encode);
+  }
   const client = initClient(namespace);
-  const hexKey = Buffer.from(key).toString('hex');
-
-  const response = await client.put(`/${hexKey}`, {
+  const response = client.put(`/${secretName}`, {
     metadata: {
-      name: hexKey,
-      namespace,
-      labels,
+      name: secretName,
+      namespace: namespace,
+      labels: labels,
     },
     data: serialize(data),
   });
-
   return response.data;
 };
 
-const remove = async (namespace, key) => {
+const remove = async (namespace, name, options = {}) => {
+  const {encode} = options;
+  let secretName = name;
+  if (encode != null) {
+    secretName = Buffer.from(name).toString(encode);
+  }
   const client = initClient(namespace);
-  const hexKey = Buffer.from(key).toString('hex');
+  await client.delete(`/${secretName}`);
+};
 
-  await client.delete(`/${hexKey}`);
+const patchMetadata = async (namespace, name, metadata, options = {}) => {
+  const {encode} = options;
+  let secretName = name;
+  if (encode != null) {
+    secretName = Buffer.from(name).toString(encode);
+  }
+  const client = initClient(namespace);
+  await client.patch(`/${secretName}`, {metadata: metadata}, patchOption);
 };
 
 module.exports = {
@@ -166,4 +203,5 @@ module.exports = {
   create,
   replace,
   remove,
+  patchMetadata,
 };

--- a/src/rest-server/src/models/kubernetes/kubernetes.js
+++ b/src/rest-server/src/models/kubernetes/kubernetes.js
@@ -6,22 +6,12 @@ const {Agent} = require('https');
 const {URL} = require('url');
 const {apiserver} = require('@pai/config/kubernetes');
 const status = require('statuses');
-const createError = require('@pai/utils/error');
 const logger = require('@pai/config/logger');
 
 const patchOption = {
   headers: {
     'Content-Type': 'application/merge-patch+json',
   },
-};
-
-const rethrowResponseError = (error) => {
-  const response = error.response;
-  if (response != null) { // check null and undefined
-    return Promise.reject(createError(response.status, 'UnknownError', response.data.message));
-  } else {
-    return Promise.reject(error);
-  }
 };
 
 const getClient = (baseURL = '') => {
@@ -106,41 +96,11 @@ const getPods = async (options = {}) => {
   return res.data;
 };
 
-const createSecret = async (namespace, name, data, type) => {
-  const client = getClient();
-  const url = `/api/v1/namespaces/${namespace}/secrets`;
-  client.interceptors.response.use((resp) => resp, rethrowResponseError);
-  return await client.post(url, {
-    metadata: {
-      name: name,
-      namespace: namespace,
-    },
-    data: data,
-    type: type,
-  });
-};
-
-const deleteSecret = async (namespace, name) => {
-  const client = getClient();
-  const url = `/api/v1/namespaces/${namespace}/secrets/${name}`;
-  client.interceptors.response.use((resp) => resp, rethrowResponseError);
-  await client.delete(url);
-};
-
-const patchSecret = async (namespace, name, data) => {
-  const client = getClient();
-  const url = `/api/v1/namespaces/${namespace}/secrets/${name}`;
-  client.interceptors.response.use((resp) => resp, rethrowResponseError);
-  await client.patch(url, data, patchOption);
-};
-
 module.exports = {
   getClient,
   encodeSelector,
   createNamespace,
   getNodes,
   getPods,
-  createSecret,
-  deleteSecret,
-  patchSecret,
+  patchOption,
 };

--- a/src/rest-server/src/models/kubernetes/kubernetes.js
+++ b/src/rest-server/src/models/kubernetes/kubernetes.js
@@ -14,6 +14,20 @@ const patchOption = {
   },
 };
 
+const rethrowResponseError = (error) => {
+  let message = error.message;
+  const response = error.response;
+  const request = error.request;
+  if (request && request.path) {
+    message = message + ` Url: ${request.path}`;
+  }
+  if (response && response.data && response.data.message) {
+    message = message + ` Response message: ${response.data.message}`;
+  }
+  error.message = message;
+  return Promise.reject(error);
+};
+
 const getClient = (baseURL = '') => {
   const config = {
     baseURL: new URL(baseURL, apiserver.uri).toString(),
@@ -35,7 +49,9 @@ const getClient = (baseURL = '') => {
       ...config.headers,
     };
   }
-  return axios.create(config);
+  const client = axios.create(config);
+  client.interceptors.response.use((resp) => resp, rethrowResponseError);
+  return client;
 };
 
 const encodeSelector = (selector = {}, negativeSelector = {}) => {

--- a/src/rest-server/src/models/v2/job-attempt.js
+++ b/src/rest-server/src/models/v2/job-attempt.js
@@ -24,7 +24,7 @@ const {isNil} = require('lodash');
 const {convertToJobAttempt} = require('@pai/utils/frameworkConverter');
 const launcherConfig = require('@pai/config/launcher');
 const createError = require('@pai/utils/error');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 const logger = require('@pai/config/logger');
 
 let elasticSearchClient;

--- a/src/rest-server/src/models/v2/job/index.js
+++ b/src/rest-server/src/models/v2/job/index.js
@@ -23,7 +23,7 @@ const config = require('@pai/config/index');
 const logger = require('@pai/config/logger');
 const yarnConfig = require('@pai/config/yarn');
 const launcherConfig = require('@pai/config/launcher');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 
 if (launcherConfig.type === 'yarn') {
   if (config.env !== 'test') {

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -781,7 +781,7 @@ const deleteDockerSecret = async (frameworkName) => {
       .getClient()
       .deleteSecret('default', `${encodeName(frameworkName)}-regcred`);
   } catch (error) {
-    logger.warn('Failed to delete protocol secret', error);
+    logger.warn('Failed to delete docker secret', error);
   }
 };
 

--- a/src/rest-server/src/models/v2/virtual-cluster/k8s.js
+++ b/src/rest-server/src/models/v2/virtual-cluster/k8s.js
@@ -20,7 +20,7 @@ const yaml = require('js-yaml');
 const createError = require('@pai/utils/error');
 const vcConfig = require('@pai/config/vc');
 const launcherConfig = require('@pai/config/launcher');
-const kubernetes = require('@pai/models/kubernetes');
+const kubernetes = require('@pai/models/kubernetes/kubernetes');
 const k8s = require('@pai/utils/k8sUtils');
 
 const {

--- a/src/rest-server/src/routes/kubernetes.js
+++ b/src/rest-server/src/routes/kubernetes.js
@@ -3,7 +3,7 @@
 
 const express = require('express');
 const token = require('@pai/middlewares/token');
-const kubernetes = require('@pai/models/kubernetes');
+const kubernetes = require('@pai/models/kubernetes/kubernetes');
 const createError = require('@pai/utils/error');
 
 const router = new express.Router();

--- a/src/rest-server/src/utils/frameworkConverter.js
+++ b/src/rest-server/src/utils/frameworkConverter.js
@@ -5,7 +5,7 @@ const path = require('path');
 const fs = require('fs');
 
 const launcherConfig = require('@pai/config/launcher');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 const k8s = require('@pai/utils/k8sUtils');
 const logger = require('@pai/config/logger');
 const env = require('@pai/utils/env');

--- a/src/rest-server/src/utils/manager/group/crudK8sSecret.js
+++ b/src/rest-server/src/utils/manager/group/crudK8sSecret.js
@@ -17,7 +17,7 @@
 
 const Group = require('./group');
 const logger = require('@pai/config/logger');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 
 const GROUP_NAMESPACE = process.env.PAI_GROUP_NAMESPACE || 'pai-group';
 

--- a/src/rest-server/src/utils/manager/storage/crudK8sSecret.js
+++ b/src/rest-server/src/utils/manager/storage/crudK8sSecret.js
@@ -18,7 +18,7 @@
 const Storage = require('./storage');
 const logger = require('@pai/config/logger');
 const createError = require('@pai/utils/error');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 
 const STORAGE_NAMESPACE = process.env.PAI_STORAGE_NAMESPACE || 'pai-storage';
 

--- a/src/rest-server/src/utils/manager/user/crudK8sSecret.js
+++ b/src/rest-server/src/utils/manager/user/crudK8sSecret.js
@@ -17,7 +17,7 @@
 
 const User = require('./user');
 const logger = require('@pai/config/logger');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 
 const USER_NAMESPACE = process.env.PAI_USER_NAMESPACE || 'pai-user-v2';
 

--- a/src/rest-server/src/utils/userSecret.js
+++ b/src/rest-server/src/utils/userSecret.js
@@ -16,7 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // module dependencies
-const {getClient} = require('@pai/models/kubernetes');
+const {getClient} = require('@pai/models/kubernetes/kubernetes');
 const StorageBase = require('./storageBase');
 
 class UserSecret extends StorageBase {

--- a/src/rest-server/test/k8sModel.js
+++ b/src/rest-server/test/k8sModel.js
@@ -3,7 +3,7 @@
 
 const chai = require('chai');
 const nockUtils = require('./utils/nock');
-const k8sModel = require('@pai/models/kubernetes');
+const k8sModel = require('@pai/models/kubernetes/kubernetes');
 
 describe('kubernetes model', () => {
   afterEach(function() {

--- a/src/rest-server/test/v2/protocol.js
+++ b/src/rest-server/test/v2/protocol.js
@@ -60,7 +60,7 @@ const validprotocolObjs = {
         'commands': [
           './examples/mnist/train_lenet.sh',
         ],
-        'entrypoint': './data/mnist/get_mnist.sh && ./examples/mnist/create_mnist.sh && ./examples/mnist/train_lenet.sh',
+        'entrypoint': './data/mnist/get_mnist.sh\n./examples/mnist/create_mnist.sh\n./examples/mnist/train_lenet.sh',
       },
     },
     'deployments': {


### PR DESCRIPTION
Pass secret from frontend to runtime.
**Changes:**
- Create k8s secret obj and mount it for init container
- User command will not concatenate with `&&`, change to concatenate with `\n`. Runtime will write user command to a file.

**Tested:**
- job w/ & w/o secret
- job w/ & w/o private docker auth