### PR TITLE
[BugFix] Update deploy-rules for internal storage and postgresql

### DIFF
--- a/src/internal-storage/deploy/create.yaml.template
+++ b/src/internal-storage/deploy/create.yaml.template
@@ -29,15 +29,6 @@ spec:
       labels:
         app: internal-storage-create
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                - {{ cluster_cfg["internal-storage"]["master-ip"] }}
       hostNetwork: false
       containers:
       - name: internal-storage-create

--- a/src/internal-storage/deploy/delete.yaml.template
+++ b/src/internal-storage/deploy/delete.yaml.template
@@ -29,15 +29,6 @@ spec:
       labels:
         app: internal-storage-delete
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                - {{ cluster_cfg["internal-storage"]["master-ip"] }}
       hostNetwork: false
       containers:
       - name: internal-storage-delete

--- a/src/internal-storage/deploy/service.yaml
+++ b/src/internal-storage/deploy/service.yaml
@@ -30,3 +30,6 @@ start-script: start.sh
 stop-script: stop.sh
 delete-script: delete.sh
 refresh-script: refresh.sh
+
+deploy-rules:
+  - in: pai-master

--- a/src/postgresql/deploy/postgresql.yaml.template
+++ b/src/postgresql/deploy/postgresql.yaml.template
@@ -29,15 +29,6 @@ spec:
       labels:
         app: postgresql
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: In
-                values:
-                - {{ cluster_cfg["postgresql"]["host"] }}
       hostNetwork: true
       containers:
       - name: postgresql

--- a/src/postgresql/deploy/service.yaml
+++ b/src/postgresql/deploy/service.yaml
@@ -30,3 +30,6 @@ start-script: start.sh
 stop-script: stop.sh
 delete-script: delete.sh
 refresh-script: refresh.sh
+
+deploy-rules:
+  - in: pai-master


### PR DESCRIPTION
Currently internal storage and postgresql uses master-ip as host selector. It will not work if hostname != host_ip.