### PR TITLE
[runtime] Make ssh barrier timeout configurable

### DIFF
--- a/src/kube-runtime/src/plugins/ssh/README.md
+++ b/src/kube-runtime/src/plugins/ssh/README.md
@@ -19,5 +19,5 @@ extras:
 ```
 - jobssh: true to enable job container wise ssh, false to disable.
 - sshbarrier: if set to true, wait until can ssh to all corresponding job containers. If not set, the defalut value is false.
-- sshbarrierTimeout: the timeout minutes for ssh barrier, default is 30 mins.
+- sshbarrierTimeout: the timeout (in minutes) of ssh barrier, default is 30 mins.
 - userssh: currently the userssh type should be ```custom```. Type ```custom``` means use the userssh value as the SSH public key to run job. User can use the corresponding SSH private key to connect to job container.

--- a/src/kube-runtime/src/plugins/ssh/README.md
+++ b/src/kube-runtime/src/plugins/ssh/README.md
@@ -11,14 +11,13 @@ extras:
       parameters:
         jobssh: boolean
         sshbarrier: boolean
-        sshbarriertaskroles:
-          - taskrole
-        userssh: 
+        sshbarrierTimeout: number
+        userssh:
           type: string
           value: string
       failurePolicy: ignore/fail
 ```
 - jobssh: true to enable job container wise ssh, false to disable.
 - sshbarrier: if set to true, wait until can ssh to all corresponding job containers. If not set, the defalut value is false.
-- sshbarriertaskroles: only valid if sshbarrier set to true. Defines the task roles that the barrier will test ssh to. If not defind, all taskroles will be included.
+- sshbarrierTimeout: the timeout minutes for ssh barrier, default is 30 mins.
 - userssh: currently the userssh type should be ```custom```. Type ```custom``` means use the userssh value as the SSH public key to run job. User can use the corresponding SSH private key to connect to job container.

--- a/src/kube-runtime/src/plugins/ssh/init.py
+++ b/src/kube-runtime/src/plugins/ssh/init.py
@@ -39,7 +39,8 @@ def main():
 
     gang_allocation = os.environ.get("GANG_ALLOCATION", "true")
     if gang_allocation == "false":
-        LOGGER.warning("Job ssh is conflict with gang allocation, set job ssh to false")
+        LOGGER.warning(
+            "Job ssh is conflict with gang allocation, set job ssh to false")
         jobssh = "false"
     elif "jobssh" in parameters:
         jobssh = str(parameters["jobssh"]).lower()
@@ -58,20 +59,21 @@ def main():
         LOGGER.info("Skip sshd script since neither jobssh or userssh is set")
     else:
         command = [
-            try_to_install_by_cache("ssh", fallback_cmds=[
-                "apt-get update",
-                "apt-get install -y openssh-client openssh-server",
-            ]),
-            "{}/sshd.sh {}\n".format(os.path.dirname(os.path.abspath(__file__)),
-                                     " ".join(cmd_params))
+            try_to_install_by_cache(
+                "ssh",
+                fallback_cmds=[
+                    "apt-get update",
+                    "apt-get install -y openssh-client openssh-server",
+                ]), "{}/sshd.sh {}\n".format(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    " ".join(cmd_params))
         ]
 
     # ssh barrier
     if jobssh == "true" and "sshbarrier" in parameters and str(
             parameters["sshbarrier"]).lower() == "true":
-        if "sshbarriertaskroles" in parameters:
-            barrier_params = " ".join(
-                '"{}"'.format(tr) for tr in parameters["sshbarriertaskroles"])
+        if "sshbarrierTimeout" in parameters:
+            barrier_params = str(parameters["sshbarrierTimeout"])
         else:
             barrier_params = ""
         command.append("{}/sshbarrier.sh {}\n".format(

--- a/src/kube-runtime/src/plugins/ssh/sshbarrier.sh
+++ b/src/kube-runtime/src/plugins/ssh/sshbarrier.sh
@@ -19,68 +19,75 @@
 # no set -o errexit because use exitcode to judge ssh connectivity
 # no set -o nounset because use empty array to judge end
 set -o pipefail
+set -o errexit
+set -o nounset
 
-readonly MAX_RETRY_COUNT=20
-readonly RETRY_INTERVAL=1
+readonly RETRY_INTERVAL=10
 
 function check_ssh_connection()
 {
   ssh -q -o BatchMode=yes -o StrictHostKeyChecking=no $1 "exit 0"
-  _RCODE=$?
+  local _RCODE=$?
   return $_RCODE
 }
 
-taskRolesToCheck=()
-for barrierTaskRole in $@; do
-  taskRolesToCheck+=($barrierTaskRole)
-done
+function get_check_instances() {
+  local instancesToCheck=()
+  # Set ssh config for all task role instances
+  local taskRoleInstances=(${PAI_TASK_ROLE_INSTANCES//,/ })
+  for i in "${taskRoleInstances[@]}"; do
+    local instancePair=(${i//:/ })
+    local taskRole=${instancePair[0]}
+    local index=${instancePair[1]}
 
-instancesToCheck=()
-# Set ssh config for all task role instances
-taskRoleInstances=(${PAI_TASK_ROLE_INSTANCES//,/ })
-for i in "${taskRoleInstances[@]}"; do
-  instancePair=(${i//:/ })
-  taskRole=${instancePair[0]}
-  index=${instancePair[1]}
-
-  if [[ $taskRole = $FC_TASKROLE_NAME ]] && [[ $index = $FC_TASK_INDEX ]]; then
-    continue
-  fi
-
-# If barrier task roles defined, then only check instances for defined task roles. Otherwise check all instances.
-  if [[ ${#taskRolesToCheck[@]} != 0 ]]; then
-    if [[ ${taskRolesToCheck[@]} =~ ${taskRole} ]]; then
-      instancesToCheck+=("${taskRole}-${index}")
+    if [[ $taskRole = $FC_TASKROLE_NAME ]] && [[ $index = $FC_TASK_INDEX ]]; then
+      continue
     fi
-  else
+
     instancesToCheck+=("${taskRole}-${index}")
+  done
+  echo "${instancesToCheck}"
+}
+
+function main() {
+  MAX_RETRY_COUNT=1800
+  if [[ $# -eq 1 ]]; then
+    MAX_RETRY_COUNT=$(( $1 * 60 / RETRY_INTERVAL ))
   fi
-done
+  echo "Setting ssh barrier MAX_RETRY_COUNT to ${MAX_RETRY_COUNT}, pool interval is ${RETRY_INTERVAL} seconds"
 
-retryCount=0
-while true
-do
-  echo "Trying to SSH to instances: ${instancesToCheck[*]}"
+  retryCount=0
+  instancesToCheck="$(get_check_instances)"
 
-  instanceFailed=()
-  for instance in "${instancesToCheck[@]}"; do
-    check_ssh_connection "$instance"
-    if [[ $? != 0 ]]; then
-      instanceFailed+=("$instance")
+  while true
+  do
+    echo "Trying to SSH to instances: ${instancesToCheck[*]}"
+
+    instanceFailed=()
+    
+    set +o errexit
+    for instance in "${instancesToCheck[@]}"; do
+      check_ssh_connection "$instance"
+      if [[ $? != 0 ]]; then
+        instanceFailed+=("$instance")
+      fi
+    done
+    set -o errexit
+
+    [[ ${#instanceFailed[@]} = 0 ]] && break
+
+    if (( $retryCount >= $MAX_RETRY_COUNT )); then
+      echo "SSH barrier reaches max retry count. Failed instances: ${instancesToCheck[*]} Exit..." >&2
+      exit 10
     fi
+
+    instancesToCheck=(${instanceFailed[*]}) 
+    ((retryCount++))
+
+    sleep $RETRY_INTERVAL
   done
 
-  [[ ${#instanceFailed[@]} = 0 ]] && break
+  echo "All ssh connections are established, continue..."
+}
 
-  if (( $retryCount >= $MAX_RETRY_COUNT )); then
-    echo "SSH barrier reaches max retry count. Failed instances: ${instancesToCheck[*]} Exit..." >&2
-    exit 10
-  fi
-
-  instancesToCheck=(${instanceFailed[*]}) 
-  ((retryCount++))
-
-  sleep $RETRY_INTERVAL
-done
-
-echo "All ssh connections are established, continue..."
+main $@

--- a/src/kube-runtime/src/plugins/ssh/sshbarrier.sh
+++ b/src/kube-runtime/src/plugins/ssh/sshbarrier.sh
@@ -16,9 +16,9 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-# no set -o errexit because use exitcode to judge ssh connectivity
 # no set -o nounset because use empty array to judge end
 set -o pipefail
+set -o errexit
 
 readonly RETRY_INTERVAL=10
 
@@ -52,11 +52,13 @@ function main() {
   if [[ $# -eq 1 ]]; then
     MAX_RETRY_COUNT=$(( $1 * 60 / RETRY_INTERVAL ))
   fi
-  echo "Setting ssh barrier MAX_RETRY_COUNT to ${MAX_RETRY_COUNT}, pool interval is ${RETRY_INTERVAL} seconds"
+  echo "Setting ssh barrier MAX_RETRY_COUNT to ${MAX_RETRY_COUNT}, poll interval is ${RETRY_INTERVAL} seconds"
 
   retryCount=0
   instancesToCheck="$(get_check_instances)"
 
+  # set +o errexit because use exitcode to judge ssh connectivity
+  set +o errexit
   while true
   do
     echo "Trying to SSH to instances: ${instancesToCheck[*]}"
@@ -82,6 +84,7 @@ function main() {
 
     sleep $RETRY_INTERVAL
   done
+  set -o errexit
 
   echo "All ssh connections are established, continue..."
 }

--- a/src/kube-runtime/src/plugins/ssh/sshbarrier.sh
+++ b/src/kube-runtime/src/plugins/ssh/sshbarrier.sh
@@ -19,8 +19,6 @@
 # no set -o errexit because use exitcode to judge ssh connectivity
 # no set -o nounset because use empty array to judge end
 set -o pipefail
-set -o errexit
-set -o nounset
 
 readonly RETRY_INTERVAL=10
 
@@ -65,14 +63,12 @@ function main() {
 
     instanceFailed=()
     
-    set +o errexit
     for instance in "${instancesToCheck[@]}"; do
       check_ssh_connection "$instance"
       if [[ $? != 0 ]]; then
         instanceFailed+=("$instance")
       fi
     done
-    set -o errexit
 
     [[ ${#instanceFailed[@]} = 0 ]] && break
 

--- a/src/webportal/src/app/job-submission/models/protocol-schema.js
+++ b/src/webportal/src/app/job-submission/models/protocol-schema.js
@@ -137,7 +137,6 @@ const runtimePluginSchema = Joi.object().keys({
         .keys({
           jobssh: Joi.boolean().required(),
           sshbarrier: Joi.boolean(),
-          sshbarriertaskroles: Joi.array(),
           sshbarrierTimeout: Joi.number(),
           userssh: Joi.object().keys({
             type: Joi.string(),

--- a/src/webportal/src/app/job-submission/models/protocol-schema.js
+++ b/src/webportal/src/app/job-submission/models/protocol-schema.js
@@ -138,6 +138,7 @@ const runtimePluginSchema = Joi.object().keys({
           jobssh: Joi.boolean().required(),
           sshbarrier: Joi.boolean(),
           sshbarriertaskroles: Joi.array(),
+          sshbarrierTimeout: Joi.number(),
           userssh: Joi.object().keys({
             type: Joi.string(),
             value: Joi.string(),


### PR DESCRIPTION
Make ssh barrier timeout configurable to avoid unexpected user job failure. The default timeout is 30 mins 

BTW: remove `sshbarriertaskroles`, since it's too complex

Fixes #4239 