### PR TITLE
Update default docker image list

### DIFF
--- a/src/webportal/src/app/job-submission/utils/constants.js
+++ b/src/webportal/src/app/job-submission/utils/constants.js
@@ -164,7 +164,8 @@ export const DOCKER_OPTIONS = [
     image: 'openpai/standard:python_3.6-tensorflow_1.15.0-cpu',
   },
 ];
-export const DEFAULT_DOCKER_URI = 'openpai/standard:python_3.6-pytorch_1.2.0-gpu';
+export const DEFAULT_DOCKER_URI =
+  'openpai/standard:python_3.6-pytorch_1.2.0-gpu';
 // For PAI runtime only
 export const PAI_PLUGIN = 'com.microsoft.pai.runtimeplugin';
 

--- a/src/webportal/src/app/job-submission/utils/constants.js
+++ b/src/webportal/src/app/job-submission/utils/constants.js
@@ -114,42 +114,67 @@ All lines will be concatenated by "&&". So do not use characters like "#", "\\" 
 
 export const DOCKER_OPTIONS = [
   {
-    key: 'tensorflow-gpu-python3.6',
+    key: 'python_3.6-pytorch_1.4.0-gpu',
     text:
-      'tensorflow1.12 + python3.6 with gpu, cuda 9.0 (image: openpai/tensorflow-py36-cu90)',
-    image: 'openpai/tensorflow-py36-cu90',
+      'PyTorch 1.4.0 + Python 3.6 with GPU, CUDA 10.1',
+    image: 'openpai/standard:python_3.6-pytorch_1.4.0-gpu',
   },
   {
-    key: 'tensorflow-cpu-python3.6',
+    key: 'python_3.6-pytorch_1.2.0-gpu',
     text:
-      'tensorflow2.0dev + python3.6 with cpu (image: openpai/tensorflow-py36-cpu)',
-    image: 'openpai/tensorflow-py36-cpu',
+      'PyTorch 1.2.0 + Python 3.6 with GPU, CUDA 10.0',
+    image: 'openpai/standard:python_3.6-pytorch_1.2.0-gpu',
   },
   {
-    key: 'tensorflow-gpu-python2.7',
+    key: 'python_3.6-tensorflow_2.1.0-gpu',
     text:
-      'tensorflow1.12 + python2.7 with gpu, cuda 9.0 (image: openpai/tensorflow-py27-cu90)',
-    image: 'openpai/tensorflow-py27-cu90',
+      'TensorFlow 2.1.0 + Python 3.6 with GPU, CUDA 10.1',
+    image: 'openpai/standard:python_3.6-tensorflow_2.1.0-gpu',
   },
   {
-    key: 'tensorflow-cpu-python2.7',
+    key: 'python_3.6-tensorflow_1.15.0-gpu',
     text:
-      'tensorflow1.12 + python2.7 with cpu (image: openpai/tensorflow-py27-cpu)',
-    image: 'openpai/tensorflow-py27-cpu',
+      'TensorFlow 1.15.0 + Python 3.6 with GPU, CUDA 10.0',
+    image: 'openpai/standard:python_3.6-tensorflow_1.15.0-gpu',
   },
   {
-    key: 'pytorch-gpu',
+    key: 'python_3.6-mxnet_1.5.1-gpu',
     text:
-      'pytorch1.0 + python3.6 with gpu, cuda 9.0 (image: openpai/pytorch-py36-cu90)',
-    image: 'openpai/pytorch-py36-cu90',
+      'MXNet 1.5.1 + Python 3.6 with GPU, CUDA 10.1',
+    image: 'openpai/standard:python_3.6-mxnet_1.5.1-gpu',
   },
   {
-    key: 'pytorch-cpu',
-    text: 'pytorch1.2 + python3.6 with cpu (image: openpai/pytorch-py36-cpu)',
-    image: 'openpai/pytorch-py36-cpu',
+    key: 'python_3.6-cntk_2.7-gpu',
+    text:
+      'CNTK 2.7 + Python 3.6 with GPU, CUDA 10.1',
+    image: 'openpai/standard:python_3.6-cntk_2.7-gpu',
+  },
+  {
+    key: 'python_3.6-pytorch_1.4.0-cpu',
+    text:
+      'PyTorch 1.4.0 + Python 3.6 with CPU',
+    image: 'openpai/standard:python_3.6-pytorch_1.4.0-cpu',
+  },
+  {
+    key: 'python_3.6-pytorch_1.2.0-cpu',
+    text:
+      'PyTorch 1.2.0 + Python 3.6 with CPU',
+    image: 'openpai/standard:python_3.6-pytorch_1.2.0-cpu',
+  },
+  {
+    key: 'python_3.6-tensorflow_2.1.0-cpu',
+    text:
+      'TensorFlow 2.1.0 + Python 3.6 with CPU',
+    image: 'openpai/standard:python_3.6-tensorflow_2.1.0-cpu',
+  },
+  {
+    key: 'python_3.6-tensorflow_1.15.0-cpu',
+    text:
+      'TensorFlow 1.15.0 + Python 3.6 with CPU',
+    image: 'openpai/standard:python_3.6-tensorflow_1.15.0-cpu',
   },
 ];
-export const DEFAULT_DOCKER_URI = 'openpai/tensorflow-py36-cu90';
+export const DEFAULT_DOCKER_URI = 'python_3.6-pytorch_1.2.0-gpu';
 // For PAI runtime only
 export const PAI_PLUGIN = 'com.microsoft.pai.runtimeplugin';
 

--- a/src/webportal/src/app/job-submission/utils/constants.js
+++ b/src/webportal/src/app/job-submission/utils/constants.js
@@ -115,62 +115,52 @@ All lines will be concatenated by "&&". So do not use characters like "#", "\\" 
 export const DOCKER_OPTIONS = [
   {
     key: 'python_3.6-pytorch_1.4.0-gpu',
-    text:
-      'PyTorch 1.4.0 + Python 3.6 with GPU, CUDA 10.1',
+    text: 'PyTorch 1.4.0 + Python 3.6 with GPU, CUDA 10.1',
     image: 'openpai/standard:python_3.6-pytorch_1.4.0-gpu',
   },
   {
     key: 'python_3.6-pytorch_1.2.0-gpu',
-    text:
-      'PyTorch 1.2.0 + Python 3.6 with GPU, CUDA 10.0',
+    text: 'PyTorch 1.2.0 + Python 3.6 with GPU, CUDA 10.0',
     image: 'openpai/standard:python_3.6-pytorch_1.2.0-gpu',
   },
   {
     key: 'python_3.6-tensorflow_2.1.0-gpu',
-    text:
-      'TensorFlow 2.1.0 + Python 3.6 with GPU, CUDA 10.1',
+    text: 'TensorFlow 2.1.0 + Python 3.6 with GPU, CUDA 10.1',
     image: 'openpai/standard:python_3.6-tensorflow_2.1.0-gpu',
   },
   {
     key: 'python_3.6-tensorflow_1.15.0-gpu',
-    text:
-      'TensorFlow 1.15.0 + Python 3.6 with GPU, CUDA 10.0',
+    text: 'TensorFlow 1.15.0 + Python 3.6 with GPU, CUDA 10.0',
     image: 'openpai/standard:python_3.6-tensorflow_1.15.0-gpu',
   },
   {
     key: 'python_3.6-mxnet_1.5.1-gpu',
-    text:
-      'MXNet 1.5.1 + Python 3.6 with GPU, CUDA 10.1',
+    text: 'MXNet 1.5.1 + Python 3.6 with GPU, CUDA 10.1',
     image: 'openpai/standard:python_3.6-mxnet_1.5.1-gpu',
   },
   {
     key: 'python_3.6-cntk_2.7-gpu',
-    text:
-      'CNTK 2.7 + Python 3.6 with GPU, CUDA 10.1',
+    text: 'CNTK 2.7 + Python 3.6 with GPU, CUDA 10.1',
     image: 'openpai/standard:python_3.6-cntk_2.7-gpu',
   },
   {
     key: 'python_3.6-pytorch_1.4.0-cpu',
-    text:
-      'PyTorch 1.4.0 + Python 3.6 with CPU',
+    text: 'PyTorch 1.4.0 + Python 3.6 with CPU',
     image: 'openpai/standard:python_3.6-pytorch_1.4.0-cpu',
   },
   {
     key: 'python_3.6-pytorch_1.2.0-cpu',
-    text:
-      'PyTorch 1.2.0 + Python 3.6 with CPU',
+    text: 'PyTorch 1.2.0 + Python 3.6 with CPU',
     image: 'openpai/standard:python_3.6-pytorch_1.2.0-cpu',
   },
   {
     key: 'python_3.6-tensorflow_2.1.0-cpu',
-    text:
-      'TensorFlow 2.1.0 + Python 3.6 with CPU',
+    text: 'TensorFlow 2.1.0 + Python 3.6 with CPU',
     image: 'openpai/standard:python_3.6-tensorflow_2.1.0-cpu',
   },
   {
     key: 'python_3.6-tensorflow_1.15.0-cpu',
-    text:
-      'TensorFlow 1.15.0 + Python 3.6 with CPU',
+    text: 'TensorFlow 1.15.0 + Python 3.6 with CPU',
     image: 'openpai/standard:python_3.6-tensorflow_1.15.0-cpu',
   },
 ];

--- a/src/webportal/src/app/job-submission/utils/constants.js
+++ b/src/webportal/src/app/job-submission/utils/constants.js
@@ -174,7 +174,7 @@ export const DOCKER_OPTIONS = [
     image: 'openpai/standard:python_3.6-tensorflow_1.15.0-cpu',
   },
 ];
-export const DEFAULT_DOCKER_URI = 'python_3.6-pytorch_1.2.0-gpu';
+export const DEFAULT_DOCKER_URI = 'openpai/standard:python_3.6-pytorch_1.2.0-gpu';
 // For PAI runtime only
 export const PAI_PLUGIN = 'com.microsoft.pai.runtimeplugin';
 


### PR DESCRIPTION
Current default docker image list is outdated: the latest stable release of TensorFlow and PyTorch is 2.1.0 and 1.4.0 now. And the version is not aligned: something like 2.0dev appears for TensorFlow.

<img src="https://user-images.githubusercontent.com/7499023/77604227-f497ad00-6f4c-11ea-827b-3cf2e14f55a4.png" width="80%"/>

This PR update the default image list to:

<img src="https://user-images.githubusercontent.com/7499023/77604548-c1a1e900-6f4d-11ea-8d25-4b54785ae4f4.png" width="80%"/>

The images come from https://github.com/microsoft/pai/pull/4231 and have been tested.








