### PR TITLE
[pylon] Update openssl-1.1.0f's url and fix GitPython version in dev-box

### DIFF
--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -y update && \
       net-tools && \
     mkdir -p /cluster-configuration &&\
     git clone https://github.com/Microsoft/pai.git &&\
-    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython jsonschema attrs dicttoxml beautifulsoup4 future &&\
+    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython jsonschema attrs dicttoxml beautifulsoup4 future configparser &&\
     python -m easy_install --upgrade pyOpenSSL && \
     pip3 install kubernetes
 

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -y update && \
       net-tools && \
     mkdir -p /cluster-configuration &&\
     git clone https://github.com/Microsoft/pai.git &&\
-    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython jsonschema attrs dicttoxml beautifulsoup4 future configparser six &&\
+    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future &&\
     python -m easy_install --upgrade pyOpenSSL && \
     pip3 install kubernetes
 

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -y update && \
       net-tools && \
     mkdir -p /cluster-configuration &&\
     git clone https://github.com/Microsoft/pai.git &&\
-    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython jsonschema attrs dicttoxml beautifulsoup4 future configparser &&\
+    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython jsonschema attrs dicttoxml beautifulsoup4 future configparser six &&\
     python -m easy_install --upgrade pyOpenSSL && \
     pip3 install kubernetes
 

--- a/src/pylon/build/pylon.common.dockerfile
+++ b/src/pylon/build/pylon.common.dockerfile
@@ -41,7 +41,7 @@ RUN wget http://www.zlib.net/zlib-1.2.11.tar.gz && \
     tar -zxf zlib-1.2.11.tar.gz
 
 # OpenSSL version 1.0.2 - 1.1.0
-RUN wget https://www.openssl.org/source/openssl-1.1.0f.tar.gz && \
+RUN wget https://www.openssl.org/source/old/1.1.0/openssl-1.1.0f.tar.gz && \
     tar -zxf openssl-1.1.0f.tar.gz
 
 # subs_filter


### PR DESCRIPTION
- Fix Pylon building process. Change the url of openssl.
- Fix GitPython version to 2.x.x, due to that python2 is no longer supported in GitPython