### PR TITLE
Fix typo in history API error message

### DIFF
--- a/src/webportal/src/app/job/job-view/fabric/job-detail/util.js
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/util.js
@@ -74,4 +74,4 @@ export function getTaskConfig(rawJobConfig, name) {
 export const HISTORY_DISABLE_MESSAGE =
   'The job history was not enabled when deploying.';
 export const HISTORY_API_ERROR_MESSAGE =
-  'The job hisotry API is not healthy right now.';
+  'The job history API is not healthy right now.';


### PR DESCRIPTION
I just saw this typo when using PAI.