### PR TITLE
update api version to 2.0.0

### DIFF
--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: 'https://github.com/microsoft/pai/blob/master/LICENSE'
-  version: 0.16.0
+  version: 2.0.0
 externalDocs:
   description: Find out more about OpenPAI
   url: 'https://github.com/microsoft/pai'


### PR DESCRIPTION
Our current API version (now `0.16.0` is set by release version). However, it is confusing since we prefix APIs by `v2`. I want to change the API version to `2.0.0`, which will be decoupled with the release version. 

Then the policy of version updating could be 
- hot fixes (e.g. fixing typo, correcting formatting) will update `patch` version (e.g. `2.0.0` to `2.0.1`)
- non-breaking API changes (e.g. adding new api, supporting new params in an existing api) will update `minor` version (e.g. `2.0.0` to `2.1.0`)
- big breaking changes will change the `major` version (e.g. `2.0.0` to `3.0.0`)