### PR TITLE
add release note

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -4,7 +4,7 @@
 
 There are **breaking changes** since OpenPAI v1.0.0. Before v1.0.0, OpenPAI was based on Yarn and Kubernetes. Now, OpenPAI has switched to a pure Kubernetes-based architecture. Also, we have created 5 separate repositories for individual OpenPAI components. Some of them are newly-introduced, some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
 
-  - [Hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for multi-tenant GPU clusters.
+  - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for multi-tenant GPU clusters.
   - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol.
   - [openpai-runtime](https://github.com/microsoft/openpai-runtime) is a module that provides runtime support to job containers.
   - [openpaisdk](https://github.com/microsoft/openpaisdk) is a The JavaScript SDK designed to facilitate the developers of OpenPAI to offer user friendly experience.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,7 +2,7 @@
 
 ## May 2020 (version 1.0.0)
 
-From v1.0.0 release, OpenPAI officially switches to [pure Kubernetes-based architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) and has more clear component separation. We have created 6 separate repositories for individual OpenPAI components. Some of them are newly-introduced, and some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
+With the v1.0.0 release, OpenPAI is officially switching to pure Kubernetes-based architecture. In addition to this, we had also made efforts on making our component design more modularized by re-organized the code structure to 1 main repo together with 6 standalone key component repos. Please refer to the [system architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) documentation for more detailed design thinkings about this change, and review the following list to get a better understanding about the 6 new component repos:
 
   - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new PAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
   - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -10,7 +10,14 @@ Please refer to the [system architecture](https://github.com/microsoft/pai/blob/
   - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is the specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.
   - [openpai-runtime](https://github.com/microsoft/openpai-runtime) provides runtime support which is necessary for the OpenPAI protocol. OpenPAI runtime can classify typical runtime error patterns and prevent unnecessay error retries. Therefore cluster resource can be saved.
   - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer more user-friendly experience.
-  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job. It enables cluster-level job templating and reuse.
+  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a service which stores examples and job templates. Users can use it from webportal plugin to share their jobs or run-and-learn others' sharing job.
+
+    Features:
+  
+    1. Provide a way for team collaboration among pai users.
+    2. Provide an easy-to-start and education for new users. Users could refer to shared templates in marketplace and learn how to use pai platform correct.
+    3. Provide admin review process to ensure the quality of templates in marketplace.
+  
   - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension, which makes users connect OpenPAI clusters, submit AI jobs, simulate jobs locally and manage files in VSCode easily.
 
 Other major new features and improvements come with this new release are:

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -21,6 +21,8 @@ Please refer to the [system architecture](https://github.com/microsoft/pai/blob/
   
   - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension, which makes users connect OpenPAI clusters, submit AI jobs, simulate jobs locally and manage files in VSCode easily.
 
+The version of each standalone repo used in OpenPAI `v1.0.0` is hivedscheduler `v0.3.2`, frameworkcontroller `v0.6.0`, openpai-protocol `v2.0.0-alpha`, openpai-runtime `v0.1.0`, openpaisdk `v0.1.0`, openpaimarketplace `v1.2.0` and openpaivscode `v0.3.0`.
+
 Other major new features and improvements come with this new release are:
 
   - Based on [kubespray](https://github.com/microsoft/pai/tree/master/contrib/kubespray), we provided a [quick start script](https://github.com/microsoft/pai/blob/master/contrib/kubespray/doc/quick-start.md) for you to deploy OpenPAI from scratch faster.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,22 +2,22 @@
 
 ## May 2020 (version 1.0.0)
 
-There are **breaking changes** since OpenPAI v1.0.0. Before v1.0.0, OpenPAI was based on Yarn and Kubernetes. Now, OpenPAI has switched to a pure Kubernetes-based architecture. Also, we have created 5 separate repositories for individual OpenPAI components. Some of them are newly-introduced, some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
+There are **breaking changes** since OpenPAI v1.0.0. Before v1.0.0, OpenPAI was based on Yarn and Kubernetes. Now, OpenPAI has switched to a pure Kubernetes-based architecture. Also, we have created 5 separate repositories for individual OpenPAI components. Some of them are newly-introduced, and some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
 
   - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for multi-tenant GPU clusters.
   - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol.
   - [openpai-runtime](https://github.com/microsoft/openpai-runtime) is a module that provides runtime support to job containers.
-  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a The JavaScript SDK designed to facilitate the developers of OpenPAI to offer user friendly experience.
+  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer user friendly experience.
   - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job.
   - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension to connect OpenPAI clusters, submit AI jobs, simulate jobs locally, manage files, and so on.
-
 
 Other new features and improvements include:
 
   - [Kubespray and a quick start script](https://github.com/microsoft/pai/tree/master/contrib/kubespray) is introduced for quick deployment of new clusters.
   - [Support for Azure Active Directory (AAD) authentication](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md) is added.
-  - [Storage interface](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) has been refactored to use Persistent Volume in Kubernetes
-  - [RESTful API](https://github.com/microsoft/pai/tree/master/src/rest-server) has been improved and [a swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is provided.
+  - [Storage interface](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) has been refactored to use Persistent Volume in Kubernetes.
+  - [A new UX design](https://github.com/microsoft/pai/issues/4024) for webportal.
+  - [RESTful API has been refined](https://github.com/microsoft/pai/issues/4337) and [a swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is provided.
   - [An end-to-end usage manual](https://openpai.readthedocs.io/) is provided for cluster users and administrators.
 
 For more details about this release, please refer to [detailed release note](https://github.com/microsoft/pai/releases/tag/v1.0.0).

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -14,11 +14,11 @@ Please refer to the [system architecture](https://github.com/microsoft/pai/blob/
   - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a service which stores examples and job templates. Users can use it from webportal plugin to share their jobs or run-and-learn others' sharing job.
 
     Features:
-  
+
     1. Provide a way for team collaboration among pai users.
     2. Provide an easy-to-start and education for new users. Users could refer to shared templates in marketplace and learn how to use pai platform correct.
     3. Provide admin review process to ensure the quality of templates in marketplace.
-  
+
   - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension, which makes users connect OpenPAI clusters, submit AI jobs, simulate jobs locally and manage files in VSCode easily.
 
 The version of each standalone repo used in OpenPAI `v1.0.0` is hivedscheduler `v0.3.2`, frameworkcontroller `v0.6.0`, openpai-protocol `v2.0.0-alpha`, openpai-runtime `v0.1.0`, openpaisdk `v0.1.0`, openpaimarketplace `v1.2.0` and openpaivscode `v0.3.0`.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,6 +2,25 @@
 
 ## May 2020 (version 1.0.0)
 
+There are **breaking changes** since OpenPAI v1.0.0. Before v1.0.0, OpenPAI was based on Yarn and Kubernetes. Now, OpenPAI has switched to a pure Kubernetes-based architecture. Also, we have created 5 separate repositories for individual OpenPAI components. Some of them are newly-introduced, some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
+
+  - [Hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for Multi-Tenant GPU clusters.
+  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) describes specification of OpenPAI jobs.
+  - [openpai-runtime](https://github.com/microsoft/openpai-runtime) is a module that provides runtime support to job containers.
+  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a The JavaScript SDK is designed to facilitate the developers of OpenPAI to offer user friendly experience.
+  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job.
+  - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension to connect OpenPAI clusters, submit AI jobs, simulate jobs locally, manage files, and so on.
+
+
+Other new features and improvements include:
+
+  - [Kubespray and a quick start script](https://github.com/microsoft/pai/tree/master/contrib/kubespray) is introduced for quick deployment of new clusters.
+  - [Support for Azure Active Directory (AAD) authentication](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md) is added.
+  - [Storage interface](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) has been refactored to use Persistent Volume in Kubernetes
+  - [RESTful API](https://github.com/microsoft/pai/tree/master/src/rest-server) has been improved and [a swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is provided.
+  - [An end-to-end usage manual](https://openpai.readthedocs.io/) is provided for cluster users and administrators.
+
+For more details about this release, please refer to [detailed release note](https://github.com/microsoft/pai/releases/tag/v1.0.0).
 
 ## July 2019 (version 0.14.0)
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,5 +1,8 @@
 # OpenPAI Release Note
 
+## May 2020 (version 1.0.0)
+
+
 ## July 2019 (version 0.14.0)
 
 Welcome to the July 2019 release of OpenPAI. There are a number of updates in this version that we hope you will like, some of the key highlights include:

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,23 +2,23 @@
 
 ## May 2020 (version 1.0.0)
 
-There are **breaking changes** since OpenPAI v1.0.0. Before v1.0.0, OpenPAI was based on Yarn and Kubernetes. Now, OpenPAI has switched to a pure Kubernetes-based architecture. Also, we have created 5 separate repositories for individual OpenPAI components. Some of them are newly-introduced, and some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
+From v1.0.0 release, OpenPAI has officially switched to [pure Kubernetes-based architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) and had more clear components separation. We have created 6 separate repositories for individual OpenPAI components. Some of them are newly-introduced, and some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
 
-  - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for multi-tenant GPU clusters.
-  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol.
-  - [openpai-runtime](https://github.com/microsoft/openpai-runtime) is a module that provides runtime support to job containers.
-  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer user friendly experience.
-  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job.
-  - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension to connect OpenPAI clusters, submit AI jobs, simulate jobs locally, manage files, and so on.
+  - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new PAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
+  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.
+  - [openpai-runtime](https://github.com/microsoft/openpai-runtime) provides runtime support which is necessary for the OpenPAI protocol. OpenPAI runtime can classify typical runtime error patterns and prevent unnecessay error retries. Therefore cluster resource can be saved.
+  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer more user-friendly experience.
+  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job. It enables cluster-level job templating and reuse.
+  - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension, which makes users connect OpenPAI clusters, submit AI jobs, simulate jobs locally and manage files in VSCode easily.
 
 Other new features and improvements include:
 
-  - [Kubespray and a quick start script](https://github.com/microsoft/pai/tree/master/contrib/kubespray) is introduced for quick deployment of new clusters.
-  - [Support for Azure Active Directory (AAD) authentication](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md) is added.
-  - [Storage interface](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) has been refactored to use Persistent Volume in Kubernetes.
-  - [A new UX design](https://github.com/microsoft/pai/issues/4024) for webportal.
-  - [RESTful API has been refined](https://github.com/microsoft/pai/issues/4337) and [a swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is provided.
-  - [An end-to-end usage manual](https://openpai.readthedocs.io/) is provided for cluster users and administrators.
+  - We introduce [kubespray](https://github.com/microsoft/pai/tree/master/contrib/kubespray) to boot up Kubernetes cluster quickly. Based on kubespray, a [quick start script](https://github.com/microsoft/pai/blob/master/contrib/kubespray/doc/quick-start.md) for you to deploy OpenPAI from scratch.
+  - In addition to basic authentication, we add [support for Azure Active Directory (AAD)](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md), which provides single sign-on and multi-factor authentication for users.
+  - [We have refactored built-in storage](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) to use Persistent Volume in Kubernetes. It supports more kinds of storage and has a unified interface.
+  - Webportal adopts [a new UX design](https://github.com/microsoft/pai/issues/4024), which looks more modern.
+  - [RESTful API has been refined](https://github.com/microsoft/pai/issues/4337) to be cleaner and more well-organized. [A detailed swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is also provided.
+  - In addition to current documents, we provide [an end-to-end usage manual](https://openpai.readthedocs.io/) for cluster users and administrators to learn how to use OpenPAI.
 
 For more details about this release, please refer to [detailed release note](https://github.com/microsoft/pai/releases/tag/v1.0.0).
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,7 +2,7 @@
 
 ## May 2020 (version 1.0.0)
 
-From v1.0.0 release, OpenPAI has officially switched to [pure Kubernetes-based architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) and had more clear components separation. We have created 6 separate repositories for individual OpenPAI components. Some of them are newly-introduced, and some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
+From v1.0.0 release, OpenPAI officially switches to [pure Kubernetes-based architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) and has more clear component separation. We have created 6 separate repositories for individual OpenPAI components. Some of them are newly-introduced, and some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
 
   - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new PAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
   - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,23 +2,25 @@
 
 ## May 2020 (version 1.0.0)
 
-With the v1.0.0 release, OpenPAI is officially switching to pure Kubernetes-based architecture. In addition to this, we had also made efforts on making our component design more modularized by re-organized the code structure to 1 main repo together with 6 standalone key component repos. Please refer to the [system architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) documentation for more detailed design thinkings about this change, and review the following list to get a better understanding about the 6 new component repos:
+With the v1.0.0 release, OpenPAI is officially switching to pure Kubernetes-based architecture. In addition to this, we had also made efforts on making our component design more modularized by re-organized the code structure to 1 main repo together with 6 standalone key component repos. 
 
-  - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new PAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
-  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.
+Please refer to the [system architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) documentation for more detailed design thinkings about this change, and review the following list to get a better understanding about the 6 new component repos:
+
+  - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new OpenPAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
+  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is the specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.
   - [openpai-runtime](https://github.com/microsoft/openpai-runtime) provides runtime support which is necessary for the OpenPAI protocol. OpenPAI runtime can classify typical runtime error patterns and prevent unnecessay error retries. Therefore cluster resource can be saved.
   - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer more user-friendly experience.
   - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job. It enables cluster-level job templating and reuse.
   - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension, which makes users connect OpenPAI clusters, submit AI jobs, simulate jobs locally and manage files in VSCode easily.
 
-Other new features and improvements include:
+Other major new features and improvements come with this new release are:
 
-  - We introduce [kubespray](https://github.com/microsoft/pai/tree/master/contrib/kubespray) to boot up Kubernetes cluster quickly. Based on kubespray, a [quick start script](https://github.com/microsoft/pai/blob/master/contrib/kubespray/doc/quick-start.md) for you to deploy OpenPAI from scratch.
-  - In addition to basic authentication, we add [support for Azure Active Directory (AAD)](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md), which provides single sign-on and multi-factor authentication for users.
-  - [We have refactored built-in storage](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) to use Persistent Volume in Kubernetes. It supports more kinds of storage and has a unified interface.
-  - Webportal adopts [a new UX design](https://github.com/microsoft/pai/issues/4024), which looks more modern.
+  - Based on [kubespray](https://github.com/microsoft/pai/tree/master/contrib/kubespray), we provided a [quick start script](https://github.com/microsoft/pai/blob/master/contrib/kubespray/doc/quick-start.md) for you to deploy OpenPAI from scratch faster.
+  - In addition to basic authentication, [support for Azure Active Directory (AAD)](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md) was added to provide SSO and multi-factor authentication for users.
+  - [Built-in storage](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) were refactored to support more storage types with a unified interface.
+  - [WebUI new look&feels and UX improvements](https://github.com/microsoft/pai/issues/4024).
   - [RESTful API has been refined](https://github.com/microsoft/pai/issues/4337) to be cleaner and more well-organized. [A detailed swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is also provided.
-  - In addition to current documents, we provide [an end-to-end usage manual](https://openpai.readthedocs.io/) for cluster users and administrators to learn how to use OpenPAI.
+  - In addition to current documentation, we provide [an end-to-end usage manual](https://openpai.readthedocs.io/) for cluster users and administrators to learn how to use OpenPAI.
 
 For more details about this release, please refer to [detailed release note](https://github.com/microsoft/pai/releases/tag/v1.0.0).
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -2,11 +2,12 @@
 
 ## May 2020 (version 1.0.0)
 
-With the v1.0.0 release, OpenPAI is officially switching to pure Kubernetes-based architecture. In addition to this, we had also made efforts on making our component design more modularized by re-organized the code structure to 1 main repo together with 6 standalone key component repos. 
+With the v1.0.0 release, OpenPAI is officially switching to pure Kubernetes-based architecture. In addition to this, we had also made efforts on making our component design more modularized by re-organized the code structure to 1 main repo together with 7 standalone key component repos.
 
-Please refer to the [system architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) documentation for more detailed design thinkings about this change, and review the following list to get a better understanding about the 6 new component repos:
+Please refer to the [system architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) documentation for more detailed design thinkings about this change, and review the following list to get a better understanding about the 7 new component repos:
 
   - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new OpenPAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
+  - [frameworkcontroller](https://github.com/microsoft/frameworkcontroller) is built to orchestrate all kinds of applications on Kubernetes by a single controller.
   - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is the specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.
   - [openpai-runtime](https://github.com/microsoft/openpai-runtime) provides runtime support which is necessary for the OpenPAI protocol. OpenPAI runtime can classify typical runtime error patterns and prevent unnecessay error retries. Therefore cluster resource can be saved.
   - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer more user-friendly experience.
@@ -25,7 +26,8 @@ Other major new features and improvements come with this new release are:
   - Based on [kubespray](https://github.com/microsoft/pai/tree/master/contrib/kubespray), we provided a [quick start script](https://github.com/microsoft/pai/blob/master/contrib/kubespray/doc/quick-start.md) for you to deploy OpenPAI from scratch faster.
   - In addition to basic authentication, [support for Azure Active Directory (AAD)](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md) was added to provide SSO and multi-factor authentication for users.
   - [Built-in storage](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) were refactored to support more storage types with a unified interface.
-  - [WebUI new look&feels and UX improvements](https://github.com/microsoft/pai/issues/4024).
+  - [Storage manager](https://github.com/microsoft/pai/tree/master/src/storage-manager) is provided for users to set up NFS+SMB storage server easily.
+  - [Webportal UX is upgraded to Microsoft Fluent UI 7.0](https://github.com/microsoft/pai/issues/4024). UI component and style elements are optimized to provide more user-friendly experience for both user and admin scenarios.
   - [RESTful API has been refined](https://github.com/microsoft/pai/issues/4337) to be cleaner and more well-organized. [A detailed swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is also provided.
   - In addition to current documentation, we provide [an end-to-end usage manual](https://openpai.readthedocs.io/) for cluster users and administrators to learn how to use OpenPAI.
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -4,11 +4,11 @@
 
 There are **breaking changes** since OpenPAI v1.0.0. Before v1.0.0, OpenPAI was based on Yarn and Kubernetes. Now, OpenPAI has switched to a pure Kubernetes-based architecture. Also, we have created 5 separate repositories for individual OpenPAI components. Some of them are newly-introduced, some are migrated from [OpenPAI main repository](https://github.com/microsoft/pai):
 
-  - [Hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for Multi-Tenant GPU clusters.
-  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) describes specification of OpenPAI jobs.
+  - [Hivedscheduler](https://github.com/microsoft/hivedscheduler) is a Kubernetes Scheduler Extender for multi-tenant GPU clusters.
+  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is a specification of OpenPAI job protocol.
   - [openpai-runtime](https://github.com/microsoft/openpai-runtime) is a module that provides runtime support to job containers.
-  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a The JavaScript SDK is designed to facilitate the developers of OpenPAI to offer user friendly experience.
-  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job.
+  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a The JavaScript SDK designed to facilitate the developers of OpenPAI to offer user friendly experience.
+  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job.
   - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension to connect OpenPAI clusters, submit AI jobs, simulate jobs locally, manage files, and so on.
 
 

--- a/RELEASE_NOTE_zh_CN.md
+++ b/RELEASE_NOTE_zh_CN.md
@@ -1,5 +1,40 @@
 # OpenPAI Release Note
 
+## May 2020 (version 1.0.0)
+
+With the v1.0.0 release, OpenPAI is officially switching to pure Kubernetes-based architecture. In addition to this, we had also made efforts on making our component design more modularized by re-organized the code structure to 1 main repo together with 7 standalone key component repos.
+
+Please refer to the [system architecture](https://github.com/microsoft/pai/blob/master/docs/system_architecture.md) documentation for more detailed design thinkings about this change, and review the following list to get a better understanding about the 7 new component repos:
+
+  - [hivedscheduler](https://github.com/microsoft/hivedscheduler) is a new OpenPAI component providing various advantages over standard k8s scheduler, such as resource isolation for multiple tenants, GPU topology guarantee for virtual clusters, and better topology-aware gang scheduling with no [resource starvation](https://en.wikipedia.org/wiki/Starvation_(computer_science)).
+  - [frameworkcontroller](https://github.com/microsoft/frameworkcontroller) is built to orchestrate all kinds of applications on Kubernetes by a single controller.
+  - [openpai-protocol](https://github.com/microsoft/openpai-protocol) is the specification of OpenPAI job protocol. It facilitates platform interoperability and job portability. A job described by the protocol can run on different clusters managed by OpenPAI. The protocol also enables great flexibility. Any AI workload can be described by it conveniently.
+  - [openpai-runtime](https://github.com/microsoft/openpai-runtime) provides runtime support which is necessary for the OpenPAI protocol. OpenPAI runtime can classify typical runtime error patterns and prevent unnecessay error retries. Therefore cluster resource can be saved.
+  - [openpaisdk](https://github.com/microsoft/openpaisdk) is a JavaScript SDK designed to facilitate the developers of OpenPAI to offer more user-friendly experience.
+  - [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) is a service which stores examples and job templates. Users can use it from webportal plugin to share their jobs or run-and-learn others' sharing job.
+
+    Features:
+
+    1. Provide a way for team collaboration among pai users.
+    2. Provide an easy-to-start and education for new users. Users could refer to shared templates in marketplace and learn how to use pai platform correct.
+    3. Provide admin review process to ensure the quality of templates in marketplace.
+
+  - [openpaivscode](https://github.com/microsoft/openpaivscode) is a VSCode extension, which makes users connect OpenPAI clusters, submit AI jobs, simulate jobs locally and manage files in VSCode easily.
+
+The version of each standalone repo used in OpenPAI `v1.0.0` is hivedscheduler `v0.3.2`, frameworkcontroller `v0.6.0`, openpai-protocol `v2.0.0-alpha`, openpai-runtime `v0.1.0`, openpaisdk `v0.1.0`, openpaimarketplace `v1.2.0` and openpaivscode `v0.3.0`.
+
+Other major new features and improvements come with this new release are:
+
+  - Based on [kubespray](https://github.com/microsoft/pai/tree/master/contrib/kubespray), we provided a [quick start script](https://github.com/microsoft/pai/blob/master/contrib/kubespray/doc/quick-start.md) for you to deploy OpenPAI from scratch faster.
+  - In addition to basic authentication, [support for Azure Active Directory (AAD)](https://github.com/microsoft/pai/blob/master/docs/aad-e2e/aad-e2e.md) was added to provide SSO and multi-factor authentication for users.
+  - [Built-in storage](https://github.com/microsoft/pai/blob/master/docs/setup-persistent-volumes-on-pai.md) were refactored to support more storage types with a unified interface.
+  - [Storage manager](https://github.com/microsoft/pai/tree/master/src/storage-manager) is provided for users to set up NFS+SMB storage server easily.
+  - [Webportal UX is upgraded to Microsoft Fluent UI 7.0](https://github.com/microsoft/pai/issues/4024). UI component and style elements are optimized to provide more user-friendly experience for both user and admin scenarios.
+  - [RESTful API has been refined](https://github.com/microsoft/pai/issues/4337) to be cleaner and more well-organized. [A detailed swagger document](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/microsoft/pai/master/src/rest-server/docs/swagger.yaml) is also provided.
+  - In addition to current documentation, we provide [an end-to-end usage manual](https://openpai.readthedocs.io/) for cluster users and administrators to learn how to use OpenPAI.
+
+For more details about this release, please refer to [detailed release note](https://github.com/microsoft/pai/releases/tag/v1.0.0).
+
 ## July 2019 (version 0.14.0)
 
 Welcome to the July 2019 release of OpenPAI. There are a number of updates in this version that we hope you will like, some of the key highlights include:


### PR DESCRIPTION
# Release v1.0.0

## New Features

- AAD Support
  - mapping between AAD groups and VCs #3275
  - End-to-End AAD test cases #3362 
- Introduce kubespray to deploy clusters #3757
    - Kubernetes Deployment, GPU drivers installation, Nvidia docker runtime #3757 #3842 #3873
    - Add new worker node #3846
    - Clean up cluster environment where OpenPAI is deployed before #3879 #3883
    - Ansible playbooks to uninstall GPU drivers installed by apt #3899 
- Framework Controller 
  - Deployment #3435
  - Foreground stop all frameworks #3664
- [hivedscheduler](https://github.com/microsoft/hivedscheduler) provides a Kubernetes Scheduler Extender for multi-tenant GPU clusters.
    - Hived scheduler deployment #3495, #3579
    - Hived as the default k8s scheduler #3599
    - Job Near FIFO scheduling #3726, #3731
    - Expose LazyPreemptionStatus #3917
    - Disable leader election #3928
    - HiveD intra-vc preemption for restart #3861
    - Check suggested nodes after preemption #3843
    - Update hived config validation #3812
    - HiveD reconfiguration #3768 
- [openpai-runtime](https://github.com/microsoft/openpai-runtime) is a module that provides runtime support to job containers.
  - Port kube runtime #3013
  - Job ssh for kube-runtime #3153, #3729
  - Add PAI env variables in init scripts #3154
  - Generate random ports for scheduling #3224
  - Refine init and runtime script in k8s pods #3245
  - Port conflict check #3259
  - Kubernetes ErrorSpec #3585
  - Add job exit code #3559
  - Add sshbarrier to ssh plugin #3587
  - Clean ```${PAI_WORK_DIR}``` before mv content to this folder #3695
  - Force to flush after user command finished #3794
  - Decompress the framework when the size is large #3820
  - Apt package cache #4226 
- [openpaisdk](https://github.com/microsoft/openpaisdk) provides JavaScript SDK designed to facilitate the developers of OpenPAI to offer user friendly experience.
- [openpaimarketplace](https://github.com/microsoft/openpaimarketplace) provides a webportal plugin, which stores examples and job templates. Users can use `openpaimarketplace` to share their jobs or run-and-learn others' sharing job.
- Enable RBAC
    - RBAC for Prometheus #3716, #3799, #3844, #3865, #3896 
    - RBAC for framework-controller, hived-scheduler, kube-runtime #3709, #3739
    - RBAC for watchdog #3721
    - RBAC for rest-server #3719, #3433, #3750
- Device plugin
    - InfiniBand device plugin in HCA mode for k8s #3732
    - GPU device plugin #3744
    - Host device plugin #3792
- Storage
    - K8S managed NFS + SMB storage #3826
    - Use extras to save team-storage selection #3814
    - Storage Rest API, Refine Storage Data and CLI #3809, #3754
    - Change query storage configs/servers rest-api to GET #3791
    - Refactor storage by leveraging persistent volumes #4157
- Limited internal storage and postgres db #3813
  - Use postgres db to show job history #4164
- TensorBoard integration #3257

## Improvements

- Deployment
  - Support to manage a list of services in paictl #3432
  - Choose services for different cluster type #3528
  - Improve deployment process, reduce the time cost #4022
  - Add deployment pre-check #1893
  - Remove yarn version components in k8s version object model #4027
  - Inform user of pai cluster id, configuration, username, password PR #4267
  - Clean docker image in service-boot.sh PR #4248
  - Disable yarn value in cluster-type #4445 
  - Remove yarn content from deployment doc #4447
- Webportal
  - Quick wizards or templates for users #3430 
  - Enhance data storage functions #3416 
  - Available GPU chart and virtual cluster list #3265
  - User filter #3310
  - Show VC utilization and  alerts notification #3411
  - A confirm dialog for stop actions #3408
  - Add a button in job-detail page to get merged stdout&stderr log #3282
  - Add more information when SSH is disabled #3389
  - Job history UI #3831
  - User profile page #3804, #3853, #3884
  - Add SSH config to webportal for pure-k8s based PAI #3596
  - SSH Generator for webportal #3644
  - Hide pages and links that are not supported in pure k8s version #3574
  - Hide grafana dashboard in k8s webportal #3688
  - Map rest server level job status `completing, retry pending` to `running, waiting` #3636
  - Seperate 'waiting' and 'running' states on task role's statistics #3727
  - Display stopped task count in task role's header #3840
  - Disable utilization charts' animation #3730
  - Render clone job button as a link if possible #3854
  - Add stopping status to task #3868
  - Lazy loading of monaco editor component #3871
  - Render clone job button as a link if possible #3854
  - Static content caching optimization #3852
  - Webportal redirection to the origin page after login #3914
  - Display stopped task count in task role's header #3840
  - Show CPU/Mem usage in home page for normal user #3784
  - new UX design
    - New header, left navigation and command bar #3985 #4057
    - New homepage #3712 #4074
    - WebUI Font Format Adjustment #3877
  - Replace code injection in webportal with new plugin implementation #3823
- Rest-server
  - Cluster info api #3281
  - Update hived config validation #3812 
  - Job history API #3831
  - Token API #3774 #3834 #3835
  - Change to default k8s scheduler #3599
  - Check groups every time restserver start #3458
  - Add pod GPU number for default scheduler #3642
  - Map rest server level job status `completing, retry pending` to `running, waiting` #3636
  - Make -1 compatible in launcher completion policy #3870
  - Update hived resource validation #3867
  - Update restart policy to avoid stuck pending pods #3856
  - Filter pods without nodename and completed pods #3841
  - Reverse encoded framework name #3824
  - Mask secret in framework annotations #3821
  - Update priority class owner references #3808
  - Refine all APIs and documents #4355
  - Change gpuType(s) to skuType(s) #4362
  - Update virtual cluster metrics using scheduler api #4329 
- [openpai-protocol](https://github.com/microsoft/openpai-protocol) provides a specification of OpenPAI job protocol.
  - Remove job name length limit #3935 #4069
- [openpaivscode](https://github.com/microsoft/openpaivscode) provides a VSCode extension to connect OpenPAI clusters, submit AI jobs, simulate jobs locally, manage files, and so on.
  - Support AAD login in VSCode Extension #3647
- Security
  - Enable https for K8S Dashboard #4025
  - Add REST API for checking node/pod status #3892
  - Pass secret field in job config to runtime #3572
- Migrate components to separate repos #4319 #4307 #4311 #4324 
- AMD GPU Support #4127 
  - GPU scheduling for jobs #4093
  - GPU metrics in exporter #4258
  - Rocm job examples on how to use amd gpu #4093
- Others
  - Access Log Manager through Pylon #3600
  - Remove invalid chart in Grafana Dashboard #4020
  - Watchdog auto delete leaked priorityclass #3866
  - Check ACS Docker Image in initContainer #3572
  - For basic authentication mode, prepare document to explain how to create a group and associate users to the group #4130
  - Support to add Pod Creation http error pattern to errorspec #4125
  - Change watchdog default mem limit #4413

## Documentation
- Update job submission doc #3347
- AAD end2end document #3362
- Upgrade document #4238
- Add installation FAQs and troubleshooting PR #4249
- Rest-server API documents refinement #4355
- End-to-end manual for cluster users and administrators #4023
- Remove outdated docs #4446 

## Bug Fixes
  - Docker's data-root will lost on Azure Node restart #3307
  - Fix kubelet.service in add machines #3807
  - Fix missing dependencies during installation #3800
  - Fix VC view link bug #3689
  - Fix job list page's stopping status #3869
  - Fix bug in hived resources calculation #3595
  - Fix grafana can not be accessed behind the gateway #3659
  - Fix job issues on k8s based PAI #3555
  - Remove framework owner reference for priority class & default not to create priority class #4131
  - Job retry link invalid with unknown reason #4008
  - Do not change the semantic meaning of user submitted/cloned job config #3823
  - Storage manager constantly restart #4081
  - Wrong retry log path in job history issue #4237 
  - API server overloaded by job detail page when containers are too many #4270 #4279
  - Job API not return correct appLaunchedTime #4295
  - Fix Azure File issues in storage #4438
  - Fix job retry url #4442
  - Add rate limit for RESTful API #4418 #4422

## Known Issues
  - Weave net cause MPI job hang #4394
  - Hivedscheduler is prone to misconfig due to daemon Pods, such as weave net and nginx proxy #4331
  - Cert expiration will fail the access to the bed #4216
  - Can not access job pod in k8s-dashboard #4181
  - A job (or a pod of a job) may get stuck in a state neither running nor waiting #4141
  - Job config is modified after it is imported/uploaded/cloned #3823
  - Get recursive nested AD Users in AAD Mode #3440






