### PR TITLE
[pylon] support nginx ssl in basic mode.  

### DIFF
--- a/src/pylon/deploy/pylon-config/nginx.conf.template
+++ b/src/pylon/deploy/pylon-config/nginx.conf.template
@@ -72,7 +72,7 @@ http {
     include location.conf;
   }
 
-  {% if AUTH_MODE %}
+  {% if SSL_ENABLE %}
   # proxy https://x.x.x.x/rest-server/auth/oidc/return to http://x.x.x.x/rest-server/auth/oidc/return
   server {
     listen  443 ssl;

--- a/src/pylon/deploy/pylon-config/run.sh.template
+++ b/src/pylon/deploy/pylon-config/run.sh.template
@@ -21,7 +21,7 @@ python /pylon-config/render.py
 cp /root/nginx.conf /etc/nginx/nginx.conf
 cp /root/location.conf /etc/nginx/location.conf
 
-{% if cluster_cfg['authentication']['OIDC'] %}
+{% if 'ssl' in cluster_cfg['pylon'] %}
 cp /https-config/{{cluster_cfg['pylon']['ssl']['crt_name']}} /root/{{cluster_cfg['pylon']['ssl']['crt_name']}}
 cp /https-config/{{cluster_cfg['pylon']['ssl']['key_name']}} /root/{{cluster_cfg['pylon']['ssl']['key_name']}}
 chmod 664 /root/{{cluster_cfg['pylon']['ssl']['crt_name']}}

--- a/src/pylon/deploy/pylon.yaml.template
+++ b/src/pylon/deploy/pylon.yaml.template
@@ -37,7 +37,7 @@ spec:
           volumeMounts:
             - mountPath: /pylon-config
               name: pylon-configuration
-{% if cluster_cfg['authentication']['OIDC'] %}
+{% if 'ssl' in cluster_cfg['pylon'] %}
             - mountPath: /https-config
               name: https-configuration
 {% endif %}
@@ -51,9 +51,9 @@ spec:
               value: {{ cluster_cfg['layout']['kubernetes']['api-servers-url'] }}
             - name: CLUSTER_TYPE
               value: cluster_cfg["cluster"]["common"]["cluster-type"]
-{% if cluster_cfg['authentication']['OIDC'] %}
-            - name: AUTH_MODE
-              value: OIDC
+{% if 'ssl' in cluster_cfg['pylon'] %}
+            - name: SSL_ENABLE
+              value: true
             - name: CRT_NAME
               value: '{{ cluster_cfg['pylon']['ssl']['crt_name'] }}'
             - name: KEY_NAME
@@ -110,7 +110,7 @@ spec:
         - name: pylon-configuration
           configMap:
             name: pylon-config
-{% if cluster_cfg['authentication']['OIDC'] %}
+{% if 'ssl' in cluster_cfg['pylon'] %}
         - name: https-configuration
           configMap:
             name: https-config

--- a/src/pylon/deploy/pylon.yaml.template
+++ b/src/pylon/deploy/pylon.yaml.template
@@ -53,7 +53,7 @@ spec:
               value: cluster_cfg["cluster"]["common"]["cluster-type"]
 {% if 'ssl' in cluster_cfg['pylon'] %}
             - name: SSL_ENABLE
-              value: true
+              value: 'true'
             - name: CRT_NAME
               value: '{{ cluster_cfg['pylon']['ssl']['crt_name'] }}'
             - name: KEY_NAME

--- a/src/pylon/deploy/start.sh.template
+++ b/src/pylon/deploy/start.sh.template
@@ -19,7 +19,7 @@
 
 pushd $(dirname "$0") > /dev/null
 
-{% if cluster_cfg['authentication']['OIDC'] %}
+{% if 'ssl' in cluster_cfg['pylon'] %}
 
 mkdir -p https-config/
 cp {{ cluster_cfg["pylon"]["ssl"]["crt_path"] }} https-config/


### PR DESCRIPTION
 When ssl is configured in pylon configuration, ssl server in nginx will be enabled. After this PR, pylon will support ssl in basic mode.