### PR TITLE
Remove default webportal plugins in quick start

### DIFF
--- a/contrib/kubespray/quick-start/services-configuration.yaml.template
+++ b/contrib/kubespray/quick-start/services-configuration.yaml.template
@@ -46,13 +46,6 @@ rest-server:
 
 
 webportal:
-  plugins:
-  - id: submit-job-v2
-    title: Submit Job v2
-    uri: https://gerhut.github.io/store/submit-job-v2/plugin.js
-  - id: marketplace
-    title: Marketplace
-    uri: https://gerhut.github.io/store/marketplace/plugin.js
   server-port: 9286
 
 internal-storage:


### PR DESCRIPTION
Remove default webportal plugins in quick start.
`gerhut.github.io/store` is retired now. /cc @gerhut

Closes #4579.