### PR TITLE
[Docs] Fix incorrect query in api docs

### DIFF
--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1014,7 +1014,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - name: user
+        - name: username
           in: query
           description: filter jobs with username
           schema:


### PR DESCRIPTION
Fix incorrect query for `/api/v2/jobs` in api docs.