### PR TITLE
Fix setuptools version in dev-box

### DIFF
--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -y update && \
       net-tools && \
     mkdir -p /cluster-configuration &&\
     git clone https://github.com/Microsoft/pai.git &&\
-    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future &&\
+    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools\<45 &&\
     python -m easy_install --upgrade pyOpenSSL && \
     pip3 install kubernetes
 

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -y update && \
       net-tools && \
     mkdir -p /cluster-configuration &&\
     git clone https://github.com/Microsoft/pai.git &&\
-    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools\<45 &&\
+    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
     pip3 install kubernetes
 


### PR DESCRIPTION
According to https://setuptools.readthedocs.io/en/latest/python%202%20sunset.html, Python2 is not supported by setuptools. This PR pins setuptools version to lower than 45.