### PR TITLE
change storage manager QOS class from BestEffort to Burstable

### DIFF
--- a/src/storage-manager/deploy/storage-manager.yaml.template
+++ b/src/storage-manager/deploy/storage-manager.yaml.template
@@ -77,6 +77,11 @@ spec:
         - containerPort: 2049
           hostPort: 2049
           name: sm-nfsport
+        {%- if cluster_cfg['cluster']['common']['qos-switch'] == "true" %}
+        resources:
+          limits:
+            memory: "4Gi"
+        {%- endif %}
       volumes:
         - name: pai-storage
           hostPath:


### PR DESCRIPTION
Before this change. The storage manager QOS class is BestEffort. When the node occur some condition, such as memory pressure/disk pressure.  This pod will be evicted first.

Change to Burstable QOS class to avoid such evict.