### PR TITLE
pgjson: multi-threading, one conneciton for each thread

### DIFF
--- a/src/fluentd/src/fluent-plugin-pgjson/lib/fluent/plugin/out_pgjson.rb
+++ b/src/fluentd/src/fluent-plugin-pgjson/lib/fluent/plugin/out_pgjson.rb
@@ -43,9 +43,16 @@ module Fluent::Plugin
 
     config_param :time_format, :string, default: "%F %T.%N %z"
 
+    config_param :reset_connection_interval, :integer, default: 5
+
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
       config_set_default :chunk_keys, ["tag"]
+    end
+
+    def initialize
+      super
+      @last_reset_ts = 0
     end
 
     def configure(conf)
@@ -64,24 +71,48 @@ module Fluent::Plugin
 
     def init_connection
       # This function is used to create a connection.
+      thread = Thread.current
       begin
         log.debug "[pgjson] [init_connection] Connecting to PostgreSQL server #{@host}:#{@port}, database #{@database}..."
-        conn = PG::Connection.new(dbname: @database, host: @host, port: @port, sslmode: @sslmode, user: @user, password: @password)
+        thread[:conn] = PG::Connection.new(dbname: @database, host: @host, port: @port, sslmode: @sslmode, user: @user, password: @password)
       rescue PG::Error
         log.debug "[pgjson] [init_connection] Failed to initialize a connection."
-        if ! conn.nil?
-          conn.close()
-          conn = nil
+        if ! thread[:conn].nil?
+          thread[:conn].close()
+          thread[:conn] = nil
         end
       rescue => err
         log.debug "#{err}"
       end
-      conn
+    end
+
+    def reset_connection	
+      # This function try to fix the broken connection to database.	
+      # if conn == nil, call init_connection	
+      # if conn != nil, call conn.reset
+      thread = Thread.current
+      begin	
+        if timestamp - @last_reset_ts > @reset_connection_interval	
+          if thread[:conn].nil?	
+            log.debug "[pgjson] [reset_connection] Call init_connection."	
+            init_connection	
+          else	
+            log.debug "[pgjson] [reset_connection] Reset Connection."	
+            thread[:conn].reset	
+          end	
+        else	
+          log.debug "[pgjson] [reset_connection] Skip reset."	
+        end	
+      rescue => err	
+        log.debug "[pgjson] [reset_connection] #{err.class}, #{err.message}"	
+      ensure	
+        @last_reset_ts = timestamp	
+      end
     end
 
     def timestamp
        Time.now.getutc.to_i
-     end
+    end
 
     def formatted_to_msgpack_binary
       true
@@ -98,34 +129,30 @@ module Fluent::Plugin
     def write(chunk)
       log.debug "[pgjson] in write, chunk id #{dump_unique_id_hex chunk.unique_id}"
       thread = Thread.current
-      if thread.key?(:conn)
-        conn = thread[:conn]
-      else
-        conn = init_connection
-        thread[:conn] = conn
+      if ! thread.key?(:conn)
+        init_connection
       end
-      if ! conn.nil?
+      if ! thread[:conn].nil?
         begin
-          conn.exec("COPY #{@table} (#{@tag_col}, #{@time_col}, #{@record_col}) FROM STDIN WITH DELIMITER E'\\x01'")
+          thread[:conn].exec("COPY #{@table} (#{@tag_col}, #{@time_col}, #{@record_col}) FROM STDIN WITH DELIMITER E'\\x01'")
           tag = chunk.metadata.tag
           chunk.msgpack_each do |time, record|
-            conn.put_copy_data "#{tag}\x01#{time}\x01#{record_value(record, conn)}\n"
+            thread[:conn].put_copy_data "#{tag}\x01#{time}\x01#{record_value(record)}\n"
           end
         rescue PG::ConnectionBad, PG::UnableToSend => err
           # connection error
-          conn = init_connection # try to reset broken connection, and wait for next retry
-          thread[:conn] = conn
+          reset_connection # try to reset broken connection, and wait for next retry
           log.debug "%s while copy data: %s" % [ err.class.name, err.message ]
           retry
         rescue PG::Error => err
           log.debug "[pgjson] [write] Error while writing, error is #{err.class}"
           errmsg = "%s while copy data: %s" % [ err.class.name, err.message ]
-          conn.put_copy_end( errmsg )
-          conn.get_result
+          thread[:conn].put_copy_end( errmsg )
+          thread[:conn].get_result
           raise errmsg
         else
-          conn.put_copy_end
-          res = conn.get_result
+          thread[:conn].put_copy_end
+          res = thread[:conn].get_result
           raise res.result_error_message if res.result_status != PG::PGRES_COMMAND_OK
           log.debug "[pgjson] write successfully, chunk id #{dump_unique_id_hex chunk.unique_id}"
         end
@@ -134,9 +161,10 @@ module Fluent::Plugin
       end
     end
 
-    def record_value(record, conn)
+    def record_value(record)
+      thread = Thread.current
       if @msgpack
-        "\\#{conn.escape_bytea(record.to_msgpack)}"
+        "\\#{thread[:conn].escape_bytea(record.to_msgpack)}"
       else
         json = @encoder.dump(record)
         json.gsub!(/\\/){ '\\\\' }

--- a/src/fluentd/src/fluent-plugin-pgjson/lib/fluent/plugin/out_pgjson.rb
+++ b/src/fluentd/src/fluent-plugin-pgjson/lib/fluent/plugin/out_pgjson.rb
@@ -48,11 +48,6 @@ module Fluent::Plugin
       config_set_default :chunk_keys, ["tag"]
     end
 
-    def initialize
-      super
-      @last_reset_ts = 0
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :buffer)
       super


### PR DESCRIPTION
Approach:
- Create one connection for each thread, use thread local variable to store it. 

Exp:
- In comparison to single-thread version, multi-threading can speed up more than 100 times. 