### PR TITLE
[Rest Server] Fix default parameter of list storages API

### DIFF
--- a/src/rest-server/src/controllers/v2/storage.js
+++ b/src/rest-server/src/controllers/v2/storage.js
@@ -1,19 +1,5 @@
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-//
-// MIT License
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 // module dependencies
 const asyncHandler = require('@pai/middlewares/v2/asyncHandler');
@@ -22,7 +8,7 @@ const storage = require('@pai/models/v2/storage');
 
 const list = asyncHandler(async (req, res) => {
   const userName = req.user.username;
-  const filterDefault = Boolean(req.query.default);
+  const filterDefault = (req.query.default === 'true');
   const data = await storage.list(userName, filterDefault);
   res.json(data);
 });


### PR DESCRIPTION
Fix call `/api/v2/storages?default=false` will even only get default storages.