### PR TITLE
Handle node label with parallel

### DIFF
--- a/src/cluster-configuration/deploy/start.sh.template
+++ b/src/cluster-configuration/deploy/start.sh.template
@@ -35,17 +35,19 @@ sed  -i "s/%NAMESPACE%/kube-system/g" secret-system.yaml
 kubectl apply --overwrite=true -f secret-system.yaml || exit $?
 rm -rf secret-system.yaml
 
+(
 # Label all the machines
 {% for host in cluster_cfg['layout']['machine-list'] %}
     {% if 'pai-master' in cluster_cfg['layout']['machine-list'][host] and cluster_cfg['layout']['machine-list'][host]['pai-master'] == 'true' %}
-kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-master=true || exit $?
+echo kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-master=true || exit $?
     {% endif %}
     {% if 'pai-worker' in cluster_cfg['layout']['machine-list'][host] and cluster_cfg['layout']['machine-list'][host]['pai-worker'] == 'true' %}
-kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-worker=true || exit $?
+echo kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-worker=true || exit $?
     {% endif %}
     {% if 'pai-storage' in cluster_cfg['layout']['machine-list'][host] and cluster_cfg['layout']['machine-list'][host]['pai-storage'] == 'true' %}
-kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-storage=true || exit $?
+echo kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-storage=true || exit $?
     {% endif %}
 {% endfor %}
+) | parallel
 
 popd > /dev/null

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -46,6 +46,7 @@ RUN apt-get -y update && \
       openssh-server \
       openssh-client \
       git \
+      paralle \
       subversion \
       bash-completion \
       inotify-tools \

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -46,7 +46,7 @@ RUN apt-get -y update && \
       openssh-server \
       openssh-client \
       git \
-      paralle \
+      parallel \
       subversion \
       bash-completion \
       inotify-tools \


### PR DESCRIPTION
If the node number reach to thousands, label node one by one cost too much time. Handling it with parallel will save a lot of time.

Ref: https://stackoverflow.com/a/24961201/8589683

Tested it with 1000 node.