### PR TITLE
A fix for kubespray environment check

### DIFF
--- a/contrib/kubespray/environment-check.yml
+++ b/contrib/kubespray/environment-check.yml
@@ -6,11 +6,6 @@
       setup:
       delegate_to: localhost
 
-    - name: debug
-      debug:
-        var: hostvars[inventory_hostname]
-      delegate_to: 127.0.0.1
-
     - name: set ansible control host IP fact
       set_fact:
         ansible_control_host_address: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"

--- a/contrib/kubespray/environment-check.yml
+++ b/contrib/kubespray/environment-check.yml
@@ -6,6 +6,10 @@
       setup:
       delegate_to: localhost
 
+    - name: debug
+      debug:
+        var: hostvars[inventory_hostname]
+
     - name: set ansible control host IP fact
       set_fact:
         ansible_control_host_address: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"

--- a/contrib/kubespray/environment-check.yml
+++ b/contrib/kubespray/environment-check.yml
@@ -8,7 +8,7 @@
 
     - name: set ansible control host IP fact
       set_fact:
-        ansible_control_host_address: "{{ hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] }}"
+        ansible_control_host_address: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
       delegate_to: 127.0.0.1
 
     - name: "SSH test from dev-box to all machine of infra and worker"

--- a/contrib/kubespray/environment-check.yml
+++ b/contrib/kubespray/environment-check.yml
@@ -9,6 +9,7 @@
     - name: debug
       debug:
         var: hostvars[inventory_hostname]
+      delegate_to: 127.0.0.1
 
     - name: set ansible control host IP fact
       set_fact:

--- a/contrib/kubespray/roles/requirement/devbox/defaults/main.yml
+++ b/contrib/kubespray/roles/requirement/devbox/defaults/main.yml
@@ -1,0 +1,1 @@
+dev_box_registry: docker.io

--- a/contrib/kubespray/roles/requirement/devbox/tasks/ubuntu.yml
+++ b/contrib/kubespray/roles/requirement/devbox/tasks/ubuntu.yml
@@ -37,9 +37,9 @@
   when:
     - dev_box_docker_version_replace is version('1.10.0', '<=')
 
-- name: "Dev-box 3.1 Check whether the vm can access to docker.io"
-  raw: nslookup index.docker.io
-  register: devbox_nslookup_docker_io
+- name: "Dev-box 3.1 Check whether the vm can access to {{dev_box_registry}}"
+  raw: "nslookup {{dev_box_registry}}"
+  register: devbox_nslookup_registry
   failed_when: false
   changed_when: false
   check_mode: false
@@ -47,12 +47,12 @@
 
 - name: "Dev-box 3.2 Check whether the vm can access to docker.io"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + ['Unable to access docker.io'] }}"
+    unmet_requirements: "{{ unmet_requirements + ['Unable to access'+dev_box_registry] }}"
   changed_when: false
   check_mode: false
   environment: {}
   when:
-    - devbox_nslookup_docker_io.rc != 0
+    - devbox_nslookup_registry.rc != 0
 
 
 

--- a/contrib/kubespray/roles/requirement/infra/defaults/main.yml
+++ b/contrib/kubespray/roles/requirement/infra/defaults/main.yml
@@ -1,3 +1,7 @@
 docker_check: true
 
 resource_check: true
+
+openpai_registry: docker.io
+
+gcr_image_repo: gcr.io

--- a/contrib/kubespray/roles/requirement/infra/tasks/ubuntu.yml
+++ b/contrib/kubespray/roles/requirement/infra/tasks/ubuntu.yml
@@ -1,20 +1,20 @@
 ---
-- name: "Infra 1.1 Check whether the vm can access to docker.io"
-  raw: nslookup index.docker.io
-  register: infra_nslookup_docker_io
+- name: "Infra 1.1 Check whether the vm can access to {{openpai_registry}}"
+  raw: "nslookup {{openpai_registry}}"
+  register: infra_nslookup_openpai_registry
   failed_when: false
   changed_when: false
   check_mode: false
   environment: {}
 
-- name: "Infra 1.2 Check whether the vm can access to docker.io"
+- name: "Infra 1.2 Check whether the vm can access to {{openpai_registry}}"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + ['Unable to access docker.io'] }}"
+    unmet_requirements: "{{ unmet_requirements + ['Unable to access'+openpai_registry] }}"
   changed_when: false
   check_mode: false
   environment: {}
   when:
-    - infra_nslookup_docker_io.rc != 0
+    - infra_nslookup_openpai_registry.rc != 0
 
 - name: "Infra 2.1 Check whether the NTP is installed and enabled."
   raw: pgrep ntpd
@@ -39,7 +39,7 @@
   check_mode: false
   environment: {}
   when:
-    - infra_ntpq.rc != 0 or infra_nslookup_docker_io.rc != 0
+    - infra_ntpq.rc != 0 or infra_nslookup_openpai_registry.rc != 0
 
 - name: "Infra 3.1 Ensure dev-box is not an infra machines"
   set_fact:
@@ -47,22 +47,22 @@
   when:
     - ansible_control_host_address == ansible_default_ipv4.address
 
-- name: "Infra 4.1 Check whether the vm can access to gcr.io"
-  raw: ping gcr.io -c 3
-  register: infra_ping_gcr_io
+- name: "Infra 4.1 Check whether the vm can access to {{gcr_image_repo}}"
+  raw: "nslookup {{gcr_image_repo}}"
+  register: infra_nslookup_gcr_image_repo
   failed_when: false
   changed_when: false
   check_mode: false
   environment: {}
 
-- name: "Infra 4.2 Check whether the vm can access to gcr.io"
+- name: "Infra 4.2 Check whether the vm can access to {{gcr_image_repo}}"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + ['Unable to access gcr.io'] }}"
+    unmet_requirements: "{{ unmet_requirements + ['Unable to access' + gcr_image_repo] }}"
   changed_when: false
   check_mode: false
   environment: {}
   when:
-    - infra_ping_gcr_io.rc != 0
+    - infra_nslookup_gcr_image_repo.rc != 0
 
 - name: "Infra 5.1 Check whether the vm can access to quay.io"
   raw: nslookup quay.io

--- a/contrib/kubespray/roles/requirement/worker/defaults/main.yml
+++ b/contrib/kubespray/roles/requirement/worker/defaults/main.yml
@@ -4,3 +4,7 @@ worker_default_docker_runtime: nvidia
 resource_check: true
 
 gpu_type: nvidia
+
+openpai_registry: docker.io
+
+gcr_image_repo: gcr.io

--- a/contrib/kubespray/roles/requirement/worker/tasks/ubuntu-docker.yml
+++ b/contrib/kubespray/roles/requirement/worker/tasks/ubuntu-docker.yml
@@ -38,7 +38,7 @@
   set_fact:
     default_runtime_fin: item
   when: item == worker_default_docker_runtime
-
+  loop: "{{default_runtime_processed}}"
 
 - name: "Check the default runtime is set correctly"
   set_fact:

--- a/contrib/kubespray/roles/requirement/worker/tasks/ubuntu-docker.yml
+++ b/contrib/kubespray/roles/requirement/worker/tasks/ubuntu-docker.yml
@@ -24,6 +24,10 @@
   check_mode: false
   environment: {}
 
+- name: "Init array"
+  set_fact:
+    default_runtime_processed: []
+
 - name: "Remove unnecessary char in the end of the output"
   set_fact:
     default_runtime_processed: "{{ default_runtime_processed + [ item | replace('\"','') ] }}"

--- a/contrib/kubespray/roles/requirement/worker/tasks/ubuntu-docker.yml
+++ b/contrib/kubespray/roles/requirement/worker/tasks/ubuntu-docker.yml
@@ -26,7 +26,15 @@
 
 - name: "Remove unnecessary char in the end of the output"
   set_fact:
-    default_runtime_processed: "{{ default_runtime.stdout_lines[0] | replace('\"','') }}"
+    default_runtime_processed: "{{ default_runtime_processed + [ item | replace('\"','') ] }}"
+  loop: "{{ default_runtime.stdout_lines }}"
+
+
+- name: "Get Default Runtime"
+  set_fact:
+    default_runtime_fin: item
+  when: item == worker_default_docker_runtime
+
 
 - name: "Check the default runtime is set correctly"
   set_fact:
@@ -35,4 +43,4 @@
   check_mode: false
   environment: {}
   when:
-    - default_runtime_processed != worker_default_docker_runtime
+    - default_runtime_fin is defined

--- a/contrib/kubespray/roles/requirement/worker/tasks/ubuntu.yml
+++ b/contrib/kubespray/roles/requirement/worker/tasks/ubuntu.yml
@@ -1,20 +1,20 @@
 ---
-- name: "Worker 1.1 Check whether the vm can access to docker.io"
-  raw: nslookup index.docker.io
-  register: worker_nslookup_docker_io
+- name: "Worker 1.1 Check whether the vm can access to {{openpai_registry}}"
+  raw: "nslookup {{openpai_registry}}"
+  register: worker_nslookup_openpai_registry
   failed_when: false
   changed_when: false
   check_mode: false
   environment: {}
 
-- name: "Worker 1.2 Check whether the vm can access to docker.io"
+- name: "Worker 1.2 Check whether the vm can access to {{openpai_registry}}"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + ['Unable to access docker.io'] }}"
+    unmet_requirements: "{{ unmet_requirements + ['Unable to access' + openpai_registry] }}"
   changed_when: false
   check_mode: false
   environment: {}
   when:
-    - worker_nslookup_docker_io.rc != 0
+    - worker_nslookup_openpai_registry.rc != 0
 
 - name: "Worker 2.1 Ensure dev-box is not an worker machines"
   set_fact:
@@ -22,22 +22,22 @@
   when:
     - ansible_control_host_address == ansible_default_ipv4.address
 
-- name: "Worker 3.1 Check whether the vm can access to gcr.io"
-  raw: ping gcr.io -c 3
-  register: worker_ping_gcr_io
+- name: "Worker 3.1 Check whether the vm can access to {{gcr_image_repo}}"
+  raw: "nslookup {{gcr_image_repo}}"
+  register: worker_nslookup_gcr_image_repo
   failed_when: false
   changed_when: false
   check_mode: false
   environment: {}
 
-- name: "Worker 3.2 Check whether the vm can access to gcr.io"
+- name: "Worker 3.2 Check whether the vm can access to {{gcr_image_repo}}"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + ['Unable to access gcr.io'] }}"
+    unmet_requirements: "{{ unmet_requirements + ['Unable to access' + gcr_image_repo] }}"
   changed_when: false
   check_mode: false
   environment: {}
   when:
-    - worker_ping_gcr_io.rc != 0
+    - worker_nslookup_gcr_image_repo.rc != 0
 
 - name: "Worker 4.1 Check whether the vm can access to quay.io"
   raw: nslookup quay.io


### PR DESCRIPTION
- Fix default runtime check issue:  https://github.com/microsoft/pai/issues/4564
- When user replace docker.io or fcr.io, check the corresponding repo instead of the original. https://github.com/microsoft/pai/issues/4675
- Get devbox ip from hostvars[inventory_hostname]['ansible_default_ipv4']['address'] instead of eth0 https://github.com/microsoft/pai/issues/4675

