### PR TITLE
[log-manager] reconfigure log-manager

### DIFF
--- a/src/log-manager/deploy/log-manager.yaml.template
+++ b/src/log-manager/deploy/log-manager.yaml.template
@@ -37,13 +37,16 @@ spec:
         image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}log-manager-logrotate:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always
         env:
-        - name: LOGROTATE_CRONSCHEDULE
-          value: "daily"
+        - name: LOGROTATE_INTERVAL
+          value: "hourly"
         volumeMounts:
         - name: pai-log
           mountPath: /usr/local/pai/logs
-        - name: pai-log-backup
-          mountPath: /usr/local/pai/logs-backup
+        {%- if cluster_cfg['cluster']['common']['qos-switch'] == "true" %}
+        resources:
+          limits:
+            memory: "512Mi"
+        {%- endif %}
       - name: log-manager-nginx
         image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}log-manager-nginx:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always
@@ -56,19 +59,19 @@ spec:
         volumeMounts:
         - name: pai-log
           mountPath: /usr/local/pai/logs
-        - name: pai-log-backup
-          mountPath: /usr/local/pai/logs-backup
         ports:
         - containerPort: 80
           hostPort: {{ cluster_cfg["log-manager"]["port"] }}
           name: log-manager
+        {%- if cluster_cfg['cluster']['common']['qos-switch'] == "true" %}
+        resources:
+          limits:
+            memory: "512Mi"
+        {%- endif %}
       volumes:
         - name: pai-log
           hostPath:
             path: /var/log/pai
-        - name: pai-log-backup
-          hostPath:
-            path: /var/log/pai-backup
       imagePullSecrets:
       - name: {{ cluster_cfg["cluster"]["docker-registry"]["secret-name"] }}
       tolerations:

--- a/src/log-manager/src/logrotate/logrotate.conf
+++ b/src/log-manager/src/logrotate/logrotate.conf
@@ -1,12 +1,15 @@
-/usr/local/pai/logs/*/*/*/*/*.* {
+/usr/local/pai/logs/*/*/*/*/*.log
+/usr/local/pai/logs/*/*/*/*/*.stdout
+/usr/local/pai/logs/*/*/*/*/*.stderr
+/usr/local/pai/logs/*/*/*/*/*.all
+{
     nomail
-    olddir /usr/local/pai/logs-backup
     weekly
     rotate 4
     compress
-    delaycompress
     missingok
     notifempty
-    create 644 root root
-    nocopytruncate
+    copytruncate
+    maxsize 300M
+    maxage 30
 }


### PR DESCRIPTION
1. Change log-manager QoS class to Burstable
2. Auto rotate the log file which size more than 300M
3. The rotated log will keep no more than 30 days
