### PR TITLE
[Hotfix] Use status code 307 to redirect http to https (#4714)

### DIFF
--- a/src/pylon/deploy/pylon-config/nginx.conf.template
+++ b/src/pylon/deploy/pylon-config/nginx.conf.template
@@ -72,7 +72,7 @@ http {
     include location.conf;
 
     {% if SSL_ENABLE %}
-    return 301 https://$host$request_uri;
+    return 307 https://$host$request_uri;
     {% endif %}
   }
 


### PR DESCRIPTION
Use status code 307 to redirect http to https to keep request method and body.