### PR TITLE
Freeze dnspython version in dev-box

### DIFF
--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -56,7 +56,7 @@ RUN apt-get -y update && \
       net-tools && \
     mkdir -p /cluster-configuration &&\
     git clone https://github.com/Microsoft/pai.git &&\
-    pip install python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
+    pip install dnspython==1.16.0 python-etcd docker kubernetes paramiko==2.6.0 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
     pip3 install kubernetes
 


### PR DESCRIPTION
In dev-box, `dnspython` package is needed by `etcd`. According to https://www.dnspython.org/, dnspython released a 2.0.0 version which doesn't support python2. We should freeze its version to `v1.16.0`, otherwise `paictl` will fail with the following error:

![image](https://user-images.githubusercontent.com/7499023/88650176-12dc0800-d0fb-11ea-801e-baa68de67e74.png)
