### PR TITLE
Fail the script in cluster-configuration service if node is not correctly labeled

### DIFF
--- a/src/cluster-configuration/deploy/start.sh.template
+++ b/src/cluster-configuration/deploy/start.sh.template
@@ -48,6 +48,6 @@ echo kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list
 echo kubectl label --overwrite=true nodes {{ cluster_cfg['layout']['machine-list'][host]['nodename'] }} pai-storage=true || exit $?
     {% endif %}
 {% endfor %}
-) | parallel
+) | parallel || exit $?
 
 popd > /dev/null


### PR DESCRIPTION
Currently, if the node labeling fails, the cluster-configuration will still be considered as a successful deployment. It will cause some problem in the future e.g. the storage manger will hang forever waiting for a node with `pai-storage` label.