### PR TITLE
make pai daemon with high priority

### DIFF
--- a/src/cluster-configuration/deploy/priority-class.yaml
+++ b/src/cluster-configuration/deploy/priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: pai-daemon-service-priority
+value: 1000000
+globalDefault: false
+description: "This priority class should be used for PAI daemon service only."

--- a/src/cluster-configuration/deploy/priority-class.yaml
+++ b/src/cluster-configuration/deploy/priority-class.yaml
@@ -1,7 +1,7 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: pai-daemon-service-priority
+  name: pai-daemon-priority
 value: 1000000
 globalDefault: false
-description: "This priority class should be used for PAI daemon service only."
+description: "This priority class should be used for PAI daemon only."

--- a/src/cluster-configuration/deploy/start.sh.template
+++ b/src/cluster-configuration/deploy/start.sh.template
@@ -35,6 +35,9 @@ sed  -i "s/%NAMESPACE%/kube-system/g" secret-system.yaml
 kubectl apply --overwrite=true -f secret-system.yaml || exit $?
 rm -rf secret-system.yaml
 
+# Create priorityClass for PAI daemon service
+kubectl apply --overwrite=true -f priority-class.yaml || exit $?
+
 (
 # Label all the machines
 {% for host in cluster_cfg['layout']['machine-list'] %}

--- a/src/cluster-configuration/deploy/start.sh.template
+++ b/src/cluster-configuration/deploy/start.sh.template
@@ -35,7 +35,7 @@ sed  -i "s/%NAMESPACE%/kube-system/g" secret-system.yaml
 kubectl apply --overwrite=true -f secret-system.yaml || exit $?
 rm -rf secret-system.yaml
 
-# Create priorityClass for PAI daemon service
+# Create priorityClass for PAI daemon
 kubectl apply --overwrite=true -f priority-class.yaml || exit $?
 
 (

--- a/src/cluster-configuration/deploy/stop.sh.template
+++ b/src/cluster-configuration/deploy/stop.sh.template
@@ -47,5 +47,9 @@ if kubectl get secret | grep -q "{{ cluster_cfg['cluster']['docker-registry']['s
     kubectl delete secret {{ cluster_cfg['cluster']['docker-registry']['secret-name'] }} || exit $?
 fi
 
+if kubectl get priorityclass | grep -q "pai-daemon-priority"; then
+    kubectl delete priorityclass pai-daemon-priority || exit $?
+fi
+
 
 popd > /dev/null

--- a/src/job-exporter/deploy/job-exporter.yaml.template
+++ b/src/job-exporter/deploy/job-exporter.yaml.template
@@ -33,7 +33,7 @@ spec:
         prometheus.io/port: "{{ cluster_cfg["job-exporter"]["port"] }}"
       name: job-exporter
     spec:
-      priorityClassName: pai-daemon-service-priority
+      priorityClassName: pai-daemon-priority
       containers:
       - image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}job-exporter:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always

--- a/src/job-exporter/deploy/job-exporter.yaml.template
+++ b/src/job-exporter/deploy/job-exporter.yaml.template
@@ -33,6 +33,7 @@ spec:
         prometheus.io/port: "{{ cluster_cfg["job-exporter"]["port"] }}"
       name: job-exporter
     spec:
+      priorityClassName: pai-daemon-service-priority
       containers:
       - image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}job-exporter:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always

--- a/src/log-manager/deploy/log-manager.yaml.template
+++ b/src/log-manager/deploy/log-manager.yaml.template
@@ -31,6 +31,7 @@ spec:
       annotations:
         port: "{{ cluster_cfg["log-manager"]["port"] }}"
     spec:
+      priorityClassName: pai-daemon-service-priority
       hostNetwork: false
       containers:
       - name: log-manager-logrotate

--- a/src/log-manager/deploy/log-manager.yaml.template
+++ b/src/log-manager/deploy/log-manager.yaml.template
@@ -31,7 +31,7 @@ spec:
       annotations:
         port: "{{ cluster_cfg["log-manager"]["port"] }}"
     spec:
-      priorityClassName: pai-daemon-service-priority
+      priorityClassName: pai-daemon-priority
       hostNetwork: false
       containers:
       - name: log-manager-logrotate

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -33,7 +33,7 @@ spec:
         prometheus.io/port: "{{ cluster_cfg["node-exporter"]["port"] }}"
       name: node-exporter
     spec:
-      priorityClassName: pai-daemon-service-priority
+      priorityClassName: pai-daemon-priority
       containers:
       - image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}node-exporter:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always

--- a/src/node-exporter/deploy/node-exporter.yaml.template
+++ b/src/node-exporter/deploy/node-exporter.yaml.template
@@ -33,6 +33,7 @@ spec:
         prometheus.io/port: "{{ cluster_cfg["node-exporter"]["port"] }}"
       name: node-exporter
     spec:
+      priorityClassName: pai-daemon-service-priority
       containers:
       - image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}node-exporter:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
         imagePullPolicy: Always


### PR DESCRIPTION
Assign PAI daemon with high priority. Make sure PAI service will not be evicted before user pod.
According to: https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/#evicting-end-user-pods
The kubelet ranks Pods for eviction first by resource, then by priority.
We already changed pai daemon service QoS class to Burstable and make sure it will not exceed the limit resource.
 