### PR TITLE
refine exit spec

### DIFF
--- a/src/k8s-job-exit-spec/config/k8s-job-exit-spec.yaml
+++ b/src/k8s-job-exit-spec/config/k8s-job-exit-spec.yaml
@@ -567,7 +567,7 @@ spec:
       - reasonRegex: '(?i)^ContainerCannotRun$'
         exitCode: 128
         nameRegex: '(?ms).*'
-        messageRegex: '(?msi).*(not found|cannot find|no such).*'
+        messageRegex: '(?mi).*(not found|cannot find|no such).*'
 
 - code: -1204
   phrase: ContainerDockerStartUnknownError
@@ -612,7 +612,7 @@ spec:
       - reasonRegex: '(?i)^ContainerCannotRun$'
         exitCode: 128
         nameRegex: '(?ms).*'
-        messageRegex: '(?msi).*(nvidia-container-cli: device error: unknown device id).*'
+        messageRegex: '(?mi).*(nvidia-container-cli: device error: unknown device id).*'
 
 
 ###########################################################################
@@ -1001,11 +1001,11 @@ spec:
     - userLogRegex: "(?i)exception: unknown text header name"
     - userLogRegex: "(?i)exception: unknown label header name"
     - userLogRegex: "(?i)eoferror: ran out of input"
-    - userLogRegex: "(?msi)utils.lua:.*input/output error"
-    - userLogRegex: "(?msi)tensorflow.python.framework.errors.unknownerror:.*input/output error"
-    - userLogRegex: "(?msi)oserror:.*input/output error"
-    - userLogRegex: "(?msi)cp: failed to close.*input/output error"
-    - userLogRegex: "(?msi)exception occurred:.* Input/output error"
+    - userLogRegex: "(?mi)utils.lua:.*input/output error"
+    - userLogRegex: "(?mi)tensorflow.python.framework.errors.unknownerror:.*input/output error"
+    - userLogRegex: "(?mi)oserror:.*input/output error"
+    - userLogRegex: "(?mi)cp: failed to close.*input/output error"
+    - userLogRegex: "(?mi)exception occurred:.* Input/output error"
 
 - code: 230
   phrase: ContainerInvalidSavePath
@@ -1042,9 +1042,9 @@ spec:
     - userLogRegex: "(?i)syntaxerror: invalid syntax"
     - userLogRegex: "(?i)unpicklingerror"
     - userLogRegex: "(?i)assign requires shapes of both tensors to match"
-    - userLogRegex: "(?msi)torch/install/share/lua.*c.* exception"
-    - userLogRegex: "(?msi)attributeerror:.*has no attribute"
-    - userLogRegex: "(?msi)nameerror: name.* is not defined"
+    - userLogRegex: "(?mi)torch/install/share/lua.*c.* exception"
+    - userLogRegex: "(?mi)attributeerror:.*has no attribute"
+    - userLogRegex: "(?mi)nameerror: name.* is not defined"
 
 - code: 232
   phrase: ContainerImportError
@@ -1078,7 +1078,7 @@ spec:
   - "Check the source code and correct it"
   pattern:
     runtimeContainerPatterns:
-    - userLogRegex: "(?msi)indexerror:.*index out of range"
+    - userLogRegex: "(?mi)indexerror:.*index out of range"
 
 
 - code: 234

--- a/src/k8s-job-exit-spec/config/k8s-job-exit-spec.yaml
+++ b/src/k8s-job-exit-spec/config/k8s-job-exit-spec.yaml
@@ -846,7 +846,7 @@ spec:
   - "Tuning the tensorflow program"
   pattern:
     runtimeContainerPatterns:
-    - userLogRegex: "(?msi)tensorflow.*ResourceExhaustedError.*OOM.*"
+    - userLogRegex: "(?mi)tensorflow.*ResourceExhaustedError.*OOM.*"
     - userLogRegex: "(?i)ran out of memory trying to allocate"
 
 - code: 222
@@ -864,7 +864,7 @@ spec:
   - "Check container log and fix your program bug"
   pattern:
     runtimeContainerPatterns:
-    - userLogRegex: "(?msi)Signal code: Address not mapped.*"
+    - userLogRegex: "(?mi)Signal code: Address not mapped.*"
 
 - code: 223
   phrase: ContainerCudaUncorrectableECCError
@@ -882,7 +882,7 @@ spec:
   - "Contact Cluster Admin"
   pattern:
     runtimeContainerPatterns:
-    - userLogRegex: "(?msi)CUDA_ERROR_ECC_UNCORRECTABLE.*"
+    - userLogRegex: "(?mi)CUDA_ERROR_ECC_UNCORRECTABLE.*"
 
 - code: 224
   phrase: ContainerCudaVersionMismatch
@@ -973,7 +973,7 @@ spec:
     runtimeContainerPatterns:
     - userLogRegex: "(?i)unknown option"
     - userLogRegex: "(?i)typeerror: dynamic_rnn() got multiple values for keyword argument"
-    - userLogRegex: "(?msi)bad argument #2 to .*"
+    - userLogRegex: "(?mi)bad argument #2 to .*"
     - userLogRegex: "(?i)invalid argument:"
     - userLogRegex: "(?i)option -start_symbol has no default value"
 

--- a/src/k8s-job-exit-spec/config/k8s-job-exit-spec.yaml
+++ b/src/k8s-job-exit-spec/config/k8s-job-exit-spec.yaml
@@ -1061,7 +1061,7 @@ spec:
   - "Check the source code and correct it"
   pattern:
     runtimeContainerPatterns:
-    - userLogRegex: "(?msi)importerror:.*"
+    - userLogRegex: "(?mi)importerror:.*"
 
 - code: 233
   phrase: ContainerIndexOutOfRange


### PR DESCRIPTION
For regex, `s` means `single line mode` which will treat all logs as a single line.
So if pattern contains `.*` at the end of pattern, it will match all logs to the end of log file.
This will cause matching string in exitInfo contains too much logs and confuse end user.

Change to only use multi-line mode in this case