### PR TITLE
avoid run multiple log-rotate instances

### DIFF
--- a/src/log-manager/deploy/log-manager.yaml.template
+++ b/src/log-manager/deploy/log-manager.yaml.template
@@ -46,6 +46,7 @@ spec:
         {%- if cluster_cfg['cluster']['common']['qos-switch'] == "true" %}
         resources:
           limits:
+            cpu: 0.5
             memory: "512Mi"
         {%- endif %}
       - name: log-manager-nginx
@@ -67,6 +68,7 @@ spec:
         {%- if cluster_cfg['cluster']['common']['qos-switch'] == "true" %}
         resources:
           limits:
+            cpu: 0.5
             memory: "512Mi"
         {%- endif %}
       volumes:

--- a/src/log-manager/src/logrotate/docker-entrypoint.sh
+++ b/src/log-manager/src/logrotate/docker-entrypoint.sh
@@ -79,7 +79,7 @@ if [ -n "${LOGROTATE_CRONSCHEDULE}" ]; then
   logrotate_croninterval=${LOGROTATE_CRONSCHEDULE}
 fi
 
-logrotate_cron_timetable="/usr/sbin/logrotate ${logrotate_parameters} --state=${logrotate_logstatus} /usr/bin/logrotate.d/logrotate.conf ${logrotate_cronlog}"
+logrotate_cron_timetable="/usr/bin/pgrep -f ^/usr/sbin/logrotate 2>&1 > /dev/null || /usr/sbin/logrotate ${logrotate_parameters} --state=${logrotate_logstatus} /usr/bin/logrotate.d/logrotate.conf ${logrotate_cronlog}"
 
 log_exist_time=30 # 30 day
 if [ -n "${LOG_EXIST_TIME}" ]; then
@@ -87,7 +87,7 @@ if [ -n "${LOG_EXIST_TIME}" ]; then
 fi
 
 # ----- Cron Start ------
-exec /usr/bin/go-cron '@daily' /bin/bash -c "find /usr/local/pai/logs/*/*/*/*/* -mtime +${log_exist_time} -type f -exec rm -fv {} \;"&
+exec /usr/bin/go-cron '@daily' /bin/bash -c "/usr/bin/pgrep -f ^find 2>&1 > /dev/null || find /usr/local/pai/logs/* -mtime +${log_exist_time} -type f -exec rm -fv {} \;"&
 if [ "$1" = 'cron' ]; then
   exec /usr/bin/go-cron "${logrotate_croninterval}" /bin/bash -c "${logrotate_cron_timetable}"
 fi


### PR DESCRIPTION
Currently we use cron job to run log-rotate. There will be multiple log-rotate instances if the log-rotate process takes long time to finish. In this case, many host resource will be consumed. 

Add checker before run log-rotate & limit the cpu