### PR TITLE
[log-manager] recalculate log-manager resource usage

### DIFF
--- a/src/log-manager/deploy/log-manager.yaml.template
+++ b/src/log-manager/deploy/log-manager.yaml.template
@@ -48,6 +48,9 @@ spec:
           limits:
             cpu: 0.5
             memory: "512Mi"
+          requests:
+            cpu: 0
+            memory: "128Mi"
         {%- endif %}
       - name: log-manager-nginx
         image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}log-manager-nginx:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
@@ -70,6 +73,9 @@ spec:
           limits:
             cpu: 0.5
             memory: "512Mi"
+          requests:
+            cpu: 0
+            memory: "128Mi"
         {%- endif %}
       volumes:
         - name: pai-log


### PR DESCRIPTION
Shrink log-manager requests resources. 
Since it's in idle state in most of time.