### PR TITLE
[Webportal] Fix loading in job list

### DIFF
--- a/src/webportal/src/app/job/job-view/fabric/JobList/Table.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/JobList/Table.jsx
@@ -48,6 +48,7 @@ export default function Table() {
     setOrdering,
     pagination,
     setFilter,
+    loading,
   } = useContext(Context);
   const [hideDialog, setHideDialog] = useState(true);
   const [currentJob, setCurrentJob] = useState(null);
@@ -304,7 +305,7 @@ export default function Table() {
     return (
       <div>
         <ShimmeredDetailsList
-          items={filteredJobsInfo.data || []}
+          items={loading ? [] : filteredJobsInfo.data || []}
           setKey='key'
           columns={columns}
           enableShimmer={isNil(filteredJobsInfo)}

--- a/src/webportal/src/app/job/job-view/fabric/JobList/index.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/JobList/index.jsx
@@ -122,6 +122,7 @@ export default function JobList() {
         })
         .catch(err => {
           alert(err.data.message || err.message);
+          setLoading(false);
           throw Error(err.data.message || err.message);
         });
     }
@@ -242,6 +243,7 @@ export default function JobList() {
         })
         .catch(err => {
           alert(err.data.message || err.message);
+          setLoading(false);
           throw Error(err.data.message || err.message);
         });
     }

--- a/src/webportal/src/app/job/job-view/fabric/JobList/index.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/JobList/index.jsx
@@ -265,6 +265,7 @@ export default function JobList() {
     setOrdering,
     pagination,
     setPagination,
+    loading,
   };
 
   const { spacing } = getTheme();


### PR DESCRIPTION
PR: #4854 Add table to job-list page during loading to show the columns.
But forgot to clear the old jobs, so the `loading` label will be place outside of the page.
This PR fix this bug:
1. Empty the items in the table during loading.
2. Set loading to false after catch error, to end the loading.