### PR TITLE
[Webportal] Use GPU number as SKU number when import config

### DIFF
--- a/src/webportal/src/app/job-submission/models/job-task-role.js
+++ b/src/webportal/src/app/job-submission/models/job-task-role.js
@@ -110,7 +110,7 @@ export class JobTaskRole {
       hivedSku.skuNum = get(
         extras,
         `hivedScheduler.taskRoles.${name}.skuNum`,
-        1,
+        Math.max(get(resourcePerInstance, 'gpu', 1), 1),
       );
       hivedSku.skuType = get(
         extras,


### PR DESCRIPTION
Use GPU number as SKU number when import config.
Workaround for #4881.