### PR TITLE
Support job archive

### DIFF
--- a/src/database-controller/src/write-merger/app.js
+++ b/src/database-controller/src/write-merger/app.js
@@ -30,9 +30,7 @@ router
 router
   .route('/frameworkRequest/:frameworkName')
   .patch(handler.patchFrameworkRequest);
-router
-  .route('/archiveFramework/:frameworkName')
-  .put(handler.archiveFramework);
+router.route('/archiveFramework/:frameworkName').put(handler.archiveFramework);
 router.route('/watchEvents/:eventType').post(handler.postWatchEvents);
 
 app.use('/api/v1', router);

--- a/src/database-controller/src/write-merger/app.js
+++ b/src/database-controller/src/write-merger/app.js
@@ -30,6 +30,9 @@ router
 router
   .route('/frameworkRequest/:frameworkName')
   .patch(handler.patchFrameworkRequest);
+router
+  .route('/archiveFramework/:frameworkName')
+  .put(handler.archiveFramework);
 router.route('/watchEvents/:eventType').post(handler.postWatchEvents);
 
 app.use('/api/v1', router);

--- a/src/database-controller/src/write-merger/handler.js
+++ b/src/database-controller/src/write-merger/handler.js
@@ -279,7 +279,6 @@ async function putFrameworkRequest(req, res, next) {
   }
 }
 
-
 async function archiveFramework(req, res, next) {
   // The handler to handle framework archive
   // Only completed job can be archived. If job is not a completed job, return 400 Bad Request.
@@ -293,9 +292,7 @@ async function archiveFramework(req, res, next) {
     }
     await lock.acquire(frameworkName, async () => {
       const framework = await databaseModel.Framework.findOne({
-        attributes: [
-          'subState',
-        ],
+        attributes: ['subState'],
         where: { name: frameworkName },
       });
       if (!framework) {
@@ -306,7 +303,7 @@ async function archiveFramework(req, res, next) {
       } else {
         // If the old framework exists and is completed, try to set archived=true
         await databaseModel.Framework.update(
-          {archived: true},
+          { archived: true },
           { where: { name: frameworkName } },
         );
       }

--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1141,6 +1141,11 @@ paths:
           description: 'if withTotalCount is "true", the result will contain a "totalCount" and a "data" field, instead of a job list.'
           schema:
             type: string
+        - name: includeArchive
+          in: query
+          description: 'By default, job list excludes all archived jobs. If includeArchive is "true", the result will contain archived jobs.'
+          schema:
+            type: string
       responses:
         "200":
           description: Succeeded
@@ -1299,6 +1304,37 @@ paths:
                 $ref: "#/components/schemas/Response"
               example:
                 message: execute job {job} successfully
+        "404":
+          $ref: "#/components/responses/NoJobError"
+        "500":
+          $ref: "#/components/responses/UnknownError"
+  "/api/v2/jobs/{user}~{job}/archive":
+    put:
+      tags:
+        - job
+      summary: Archive a job.
+      description: Archive a job. Archived jobs will not be shown in job list by default. Users can only archive completed jobs.
+      operationId: updateJobArchive
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/user"
+        - $ref: "#/components/parameters/job"
+      responses:
+        "202":
+          description: Succeeded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
+              example:
+                message: Archive job {job} successfully
+        "400":
+          description: Archive a non-completed job will raise a 400 error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Response"
         "404":
           $ref: "#/components/responses/NoJobError"
         "500":

--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -105,7 +105,7 @@ const list = asyncHandler(async (req, res) => {
       // include archived jobs
     } else {
       // exclude archived job
-      filters.archived = false
+      filters.archived = false;
     }
   }
   const attributes = [

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -1131,7 +1131,6 @@ const archive = async (frameworkName) => {
   }
 };
 
-
 const getConfig = async (frameworkName) => {
   const framework = await databaseModel.Framework.findOne({
     attributes: ['jobConfig'],

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -1109,6 +1109,29 @@ const execute = async (frameworkName, executionType) => {
   }
 };
 
+const archive = async (frameworkName) => {
+  let response;
+  try {
+    response = await axios({
+      method: 'PUT',
+      url:
+        launcherConfig.writeMergerUrl +
+        '/api/v1/archiveFramework/' +
+        encodeName(frameworkName),
+    });
+  } catch (error) {
+    if (error.response != null) {
+      response = error.response;
+    } else {
+      throw error;
+    }
+  }
+  if (response.status !== status('OK')) {
+    throw createError(response.status, 'UnknownError', response.data.message);
+  }
+};
+
+
 const getConfig = async (frameworkName) => {
   const framework = await databaseModel.Framework.findOne({
     attributes: ['jobConfig'],
@@ -1247,6 +1270,7 @@ module.exports = {
   get,
   put,
   execute,
+  archive,
   getConfig,
   getSshInfo,
 };

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -43,6 +43,11 @@ router
   .put(token.check, controller.execute);
 
 router
+  .route('/:frameworkName/archive')
+  /** PUT /api/v2/jobs/:frameworkName/archive - Archive a completed job */
+  .put(token.check, controller.archive);
+
+router
   .route('/:frameworkName/config')
   /** GET /api/v2/jobs/:frameworkName/config - Get job config */
   .get(token.check, controller.getConfig);


### PR DESCRIPTION
to resolve #4453

Support job archive (only `Completed` jobs can be archived, cannot unarchive job):

- Add rest-server interface:
  - PUT /jobs/{user}~{job}/archive
    - Admin can archive any job; non-admin user can only archive his own job.
    - Only completed job can be archived. If job is not a completed job, return 400 Bad Request.
    - If the job cannot be found, return 404 not found.
    - If job is successfully archived, return 202 Accepted.
    - If other error happens, return 500.
- Add write-merger interface
  - PUT /archiveFramework/:frameworkName
    - Only completed job can be archived. If job is not a completed job, return 400 Bad Request.
    - If the job is not found, return 404 not found. 
    - If job is successfully archived, return 200 OK.
    - If other error happens, return 500.
- Change rest-server list job api: 
    - support to include archived jobs or not. Default is not to include archived jobs