### PR TITLE
Update PAI service metrics

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
@@ -377,8 +377,8 @@
         "allValue": null,
         "current": {
           "tags": [],
-          "text": "hadoop-resource-manager",
-          "value": "hadoop-resource-manager"
+          "text": "rest-server",
+          "value": "rest-server"
         },
         "datasource": "PM",
         "hide": 0,
@@ -394,38 +394,8 @@
           },
           {
             "selected": false,
-            "text": "end-to-end-test",
-            "value": "end-to-end-test"
-          },
-          {
-            "selected": false,
             "text": "grafana",
             "value": "grafana"
-          },
-          {
-            "selected": false,
-            "text": "hadoop-data-node",
-            "value": "hadoop-data-node"
-          },
-          {
-            "selected": false,
-            "text": "hadoop-jobhistory-service",
-            "value": "hadoop-jobhistory-service"
-          },
-          {
-            "selected": false,
-            "text": "hadoop-name-node",
-            "value": "hadoop-name-node"
-          },
-          {
-            "selected": false,
-            "text": "hadoop-node-manager",
-            "value": "hadoop-node-manager"
-          },
-          {
-            "selected": true,
-            "text": "hadoop-resource-manager",
-            "value": "hadoop-resource-manager"
           },
           {
             "selected": false,
@@ -439,11 +409,6 @@
           },
           {
             "selected": false,
-            "text": "nvidia-drivers",
-            "value": "nvidia-drivers"
-          },
-          {
-            "selected": false,
             "text": "prometheus",
             "value": "prometheus"
           },
@@ -451,11 +416,6 @@
             "selected": false,
             "text": "pylon",
             "value": "pylon"
-          },
-          {
-            "selected": false,
-            "text": "rest-server",
-            "value": "rest-server"
           },
           {
             "selected": false,
@@ -469,18 +429,58 @@
           },
           {
             "selected": false,
-            "text": "yarn-exporter",
-            "value": "yarn-exporter"
+            "text": "frameworkcontroller",
+            "value": "frameworkcontroller"
           },
           {
             "selected": false,
-            "text": "yarn-frameworklauncher",
-            "value": "yarn-frameworklauncher"
+            "text": "framework-watcher_database-controller",
+            "value": "framework-watcher_database-controller"
           },
           {
             "selected": false,
-            "text": "zookeeper",
-            "value": "zookeeper"
+            "text": "write-merger_database-controller",
+            "value": "write-merger_database-controller"
+          },
+          {
+            "selected": false,
+            "text": "poller_database-controller",
+            "value": "poller_database-controller"
+          },
+          {
+            "selected": false,
+            "text": "log-manager-nginx",
+            "value": "log-manager-nginx"
+          },
+          {
+            "selected": false,
+            "text": "log-manager-logrotate",
+            "value": "log-manager-logrotate"
+          },
+          {
+            "selected": false,
+            "text": "dshuttle-master",
+            "value": "dshuttle-master"
+          },
+          {
+            "selected": false,
+            "text": "dshuttle-worker",
+            "value": "dshuttle-worker"
+          },
+          {
+            "selected": false,
+            "text": "dshuttle-csi-daemon",
+            "value": "dshuttle-csi-daemon"
+          },
+          {
+            "selected": false,
+            "text": "dshuttle-job-worker",
+            "value": "dshuttle-job-worker"
+          },
+          {
+            "selected": false,
+            "text": "dshuttle-job-master",
+            "value": "dshuttle-job-master"
           }
         ],
         "query": "label_values(service_cpu_percent, name)",

--- a/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
@@ -454,6 +454,16 @@
           },
           {
             "selected": false,
+            "text": "fluentd",
+            "value": "fluentd"
+          },
+          {
+            "selected": false,
+            "text": "postgresql",
+            "value": "postgresql_postgresql"
+          },
+          {
+            "selected": false,
             "text": "log-manager-nginx",
             "value": "log-manager-nginx"
           },

--- a/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
@@ -434,6 +434,11 @@
           },
           {
             "selected": false,
+            "text": "hivedscheduler",
+            "value": "hivedscheduler"
+          },
+          {
+            "selected": false,
             "text": "framework-watcher_database-controller",
             "value": "framework-watcher_database-controller"
           },

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -544,6 +544,8 @@ class ContainerCollector(Collector):
         "poller_database-controller",
         "dshuttle-master",
         "dshuttle-job-master",
+        "fluentd",
+        "postgresql_postgresql",
 
         # Run as daemon set
         "node-exporter",
@@ -553,15 +555,9 @@ class ContainerCollector(Collector):
         "dshuttle-worker",
         "dshuttle-job-worker",
         "dshuttle-csi-daemon",
-
-        # Below are DLTS services
-        "nginx",
-        "restfulapi",
         "weave",
         "weave-npc",
         "nvidia-device-plugin-ctr",
-        "mysql",
-        "jobmanager",
         ]))
 
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter, gpu_info_ref,

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -538,6 +538,7 @@ class ContainerCollector(Collector):
         "alertmanager",
         "watchdog",
         "frameworkcontroller",
+        "hivedscheduler",
         "framework-watcher_database-controller",
         "write-merger_database-controller",
         "poller_database-controller",

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -529,6 +529,7 @@ class ContainerCollector(Collector):
     lsof_timeout = 2 # 99th latency is 0.5s
 
     pai_services = list(map(lambda s: "k8s_" + s, [
+        # Run in master node
         "rest-server",
         "pylon",
         "webportal",
@@ -536,19 +537,21 @@ class ContainerCollector(Collector):
         "prometheus",
         "alertmanager",
         "watchdog",
-        "end-to-end-test",
-        "yarn-frameworklauncher",
-        "hadoop-jobhistory-service",
-        "hadoop-name-node",
-        "hadoop-node-manager",
-        "hadoop-resource-manager",
-        "hadoop-data-node",
-        "zookeeper",
+        "frameworkcontroller",
+        "framework-watcher_database-controller",
+        "write-merger_database-controller",
+        "poller_database-controller",
+        "dshuttle-master",
+        "dshuttle-job-master",
+
+        # Run in as daemon set
         "node-exporter",
         "job-exporter",
-        "yarn-exporter",
-        "nvidia-drivers",
-        "docker-cleaner",
+        "log-manager-nginx",
+        "log-manager-logrotate",
+        "dshuttle-worker",
+        "dshuttle-job-worker",
+        "dshuttle-csi-daemon",
 
         # Below are DLTS services
         "nginx",

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -558,6 +558,8 @@ class ContainerCollector(Collector):
         "weave",
         "weave-npc",
         "nvidia-device-plugin-ctr",
+        "k8s-host-device",
+        "amdgpu",
         ]))
 
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter, gpu_info_ref,

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -544,7 +544,7 @@ class ContainerCollector(Collector):
         "dshuttle-master",
         "dshuttle-job-master",
 
-        # Run in as daemon set
+        # Run as daemon set
         "node-exporter",
         "job-exporter",
         "log-manager-nginx",

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -560,6 +560,7 @@ class ContainerCollector(Collector):
         "nvidia-device-plugin-ctr",
         "k8s-host-device",
         "amdgpu",
+        "k8s-rdma",
         ]))
 
     def __init__(self, name, sleep_time, atomic_ref, iteration_counter, gpu_info_ref,


### PR DESCRIPTION
- Remove deprecated service from grafana
- Add new services to monitor, include (FC, db-controller, hived, DShuttle, log-manager)