### PR TITLE
[Webportal] Add admin groups to vc's granted groups (Admin's user profile page)

### DIFF
--- a/src/webportal/src/app/home/home/virtual-cluster-statistics.jsx
+++ b/src/webportal/src/app/home/home/virtual-cluster-statistics.jsx
@@ -172,7 +172,10 @@ const vcListColumns = colProps => {
         const groups = [];
         colProps.groups.forEach(group => {
           const virtualClusters = group.extension.acls.virtualClusters;
-          if (virtualClusters && virtualClusters.includes(vc.name)) {
+          if (
+            virtualClusters &&
+            (virtualClusters.includes(vc.name) || group.extension.acls.admin)
+          ) {
             groups.push(group);
           }
         });


### PR DESCRIPTION
Current version, the "granted group" in Admin's VC view didn't include the admin groups.
This PR will add all groups with the admin privilege to the "granted group" view.
Before:

![grantedGroup1](https://user-images.githubusercontent.com/17357108/96234520-22693f80-0fcc-11eb-80d2-7574ae079790.png)

After:
![grantedGroup2](https://user-images.githubusercontent.com/17357108/96234925-b0ddc100-0fcc-11eb-91bd-a79464e17400.png)

