### PR TITLE
Restore job detail title font

### DIFF
--- a/src/webportal/src/app/job/job-view/fabric/job-detail/components/summary.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/components/summary.jsx
@@ -276,9 +276,8 @@ export default class Summary extends React.Component {
               style={{ flexShrink: 1, minWidth: 0 }}
             >
               <div
-                className={c(t.truncate)}
+                className={c(t.truncate, FontClassNames.xxLarge)}
                 style={{
-                  fontSize: FontSizes.xxLarge,
                   fontWeight: FontWeights.regular,
                 }}
               >

--- a/src/webportal/src/app/job/job-view/fabric/job-detail/components/summary.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/components/summary.jsx
@@ -18,7 +18,6 @@
 import {
   FontClassNames,
   FontWeights,
-  FontSizes,
   ColorClassNames,
   IconFontSizes,
 } from '@uifabric/styling';


### PR DESCRIPTION
Webportal Font Solution:

1. FontClassNames (Use to custom text)
    Different classname has [different default styles](https://github.com/microsoft/fluentui/blob/5158b5e405/packages/theme/src/fonts/createFontStyles.ts#L75). Incudes:
- [FontSize](https://github.com/microsoft/fluentui/blob/5158b5e405/packages/theme/src/fonts/FluentFonts.ts#L38)
- [FontWeight](https://github.com/microsoft/fluentui/blob/5158b5e405/packages/theme/src/fonts/FluentFonts.ts#L69)
- FontFamily: [A font map](https://github.com/microsoft/fluentui/blob/5158b5e405/packages/theme/src/fonts/createFontStyles.ts#L13) for different language with a fallback ```const FontFamilyFallbacks = `'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif`;```

2. [Text component](https://github.com/microsoft/fluentui/blob/5158b5e405/packages/react-text/README.md) (Recommended to use as default text)
    Has a parameter variant to control the font styles. 

3. Tachyons. The tachyons css module is not recommended right now. However the history code still has tachyons styles. Will be removed step by step.