### PR TITLE
add validate body middleware in put/delete tag api & executionType api

### DIFF
--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1376,6 +1376,8 @@ paths:
                 $ref: "#/components/schemas/Response"
               example:
                 message: execute job {job} successfully
+        "400":
+          $ref: "#/components/responses/InvalidProtocolError"
         "404":
           $ref: "#/components/responses/NoJobError"
         "500":
@@ -1413,6 +1415,8 @@ paths:
                 $ref: "#/components/schemas/Response"
               example:
                 message: "Add tag {tag} for job {job} successfully."
+        "400":
+          $ref: "#/components/responses/InvalidProtocolError"
         "404":
           $ref: "#/components/responses/NoJobError"
         "500":
@@ -1449,6 +1453,8 @@ paths:
                 $ref: "#/components/schemas/Response"
               example:
                 message: "Delete tag {tag} from job {job} successfully."
+        "400":
+          $ref: "#/components/responses/InvalidProtocolError"
         "404":
           description: NoJobError or NoTagError
           content:
@@ -3055,6 +3061,17 @@ components:
         - email
         - extension
   responses:
+    InvalidProtocolError:
+      description: InvalidProtocolError
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Response"
+          examples:
+            InvalidProtocolError:
+              value:
+                code: InvalidProtocolError
+                message: Invalid request.
     IncorrectPasswordError:
       description: IncorrectPasswordError
       content:

--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1377,7 +1377,7 @@ paths:
               example:
                 message: execute job {job} successfully
         "400":
-          $ref: "#/components/responses/InvalidProtocolError"
+          $ref: "#/components/responses/InvalidParametersError"
         "404":
           $ref: "#/components/responses/NoJobError"
         "500":
@@ -1416,7 +1416,7 @@ paths:
               example:
                 message: "Add tag {tag} for job {job} successfully."
         "400":
-          $ref: "#/components/responses/InvalidProtocolError"
+          $ref: "#/components/responses/InvalidParametersError"
         "404":
           $ref: "#/components/responses/NoJobError"
         "500":
@@ -1454,7 +1454,7 @@ paths:
               example:
                 message: "Delete tag {tag} from job {job} successfully."
         "400":
-          $ref: "#/components/responses/InvalidProtocolError"
+          $ref: "#/components/responses/InvalidParametersError"
         "404":
           description: NoJobError or NoTagError
           content:
@@ -3061,17 +3061,17 @@ components:
         - email
         - extension
   responses:
-    InvalidProtocolError:
-      description: InvalidProtocolError
+    InvalidParametersError:
+      description: InvalidParametersError
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/Response"
           examples:
-            InvalidProtocolError:
+            InvalidParametersError:
               value:
-                code: InvalidProtocolError
-                message: Invalid request.
+                code: InvalidParametersError
+                message: Invalid request parameters.
     IncorrectPasswordError:
       description: IncorrectPasswordError
       content:

--- a/src/rest-server/src/config/v2/execution-type.js
+++ b/src/rest-server/src/config/v2/execution-type.js
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// module dependencies
+const Joi = require('joi');
+
+// define the input schema for the 'update group extension' api
+const executionTypeInputSchema = Joi.object().keys({
+  // executionType should be 'STOP' or 'START'
+  value: Joi.string().valid('STOP', 'START').required(),
+});
+
+// module exports
+module.exports = {
+  executionTypeInputSchema,
+};

--- a/src/rest-server/src/config/v2/tag.js
+++ b/src/rest-server/src/config/v2/tag.js
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// module dependencies
+const Joi = require('joi');
+
+// define the input schema for the 'update group extension' api
+const tagInputSchema = Joi.object().keys({
+  value: Joi.string()
+    // tag should not include ','
+    .regex(/^[^,]+$/, 'value')
+    .required(),
+});
+
+// module exports
+module.exports = {
+  tagInputSchema,
+};

--- a/src/rest-server/src/middlewares/v2/protocol.js
+++ b/src/rest-server/src/middlewares/v2/protocol.js
@@ -211,63 +211,9 @@ const protocolSubmitMiddleware = [
   }),
 ];
 
-const validateExecutionTypeMiddleware = async (req, _, next) => {
-  if (req.headers['content-type'] !== 'application/json') {
-    return next(
-      createError(
-        'Bad Request',
-        'InvalidProtocolError',
-        'Invalid content-type',
-      ),
-    );
-  }
-  if (!('value' in req.body && req.body.value)) {
-    return next(
-      createError('Bad Request', 'InvalidProtocolError', 'Invalid format'),
-    );
-  }
-  // executionType should be 'stop' or 'start'
-  if (!['START', 'STOP'].includes(req.body.value.toUpperCase())) {
-    return next(
-      createError('Bad Request', 'InvalidProtocolError', 'Invalid value'),
-    );
-  }
-  next();
-};
-
-const validateTagMiddleware = async (req, _, next) => {
-  if (req.headers['content-type'] !== 'application/json') {
-    return next(
-      createError(
-        'Bad Request',
-        'InvalidProtocolError',
-        'Invalid content-type',
-      ),
-    );
-  }
-  if (!('value' in req.body && req.body.value)) {
-    return next(
-      createError('Bad Request', 'InvalidProtocolError', 'Invalid format'),
-    );
-  }
-  // tag should not include ','
-  if (req.body.value.includes(',')) {
-    return next(
-      createError(
-        'Bad Request',
-        'InvalidProtocolError',
-        "tag should not include ','",
-      ),
-    );
-  }
-  next();
-};
-
 // module exports
 module.exports = {
   validate: protocolValidate,
   render: protocolRender,
   submit: protocolSubmitMiddleware,
-  validateTag: validateTagMiddleware,
-  validateExecutionType: validateExecutionTypeMiddleware,
 };

--- a/src/rest-server/src/middlewares/v2/protocol.js
+++ b/src/rest-server/src/middlewares/v2/protocol.js
@@ -211,7 +211,45 @@ const protocolSubmitMiddleware = [
   }),
 ];
 
+const validateExecutionTypeMiddleware = async (req, _, next) => {
+  if (req.headers['content-type'] !== 'application/json') {
+    return next(
+      createError(
+        'Bad Request',
+        'InvalidProtocolError',
+        'Invalid content-type',
+      ),
+    );
+  }
+  if (!('value' in req.body && req.body.value)) {
+    return next(
+      createError('Bad Request', 'InvalidProtocolError', 'Invalid format'),
+    );
+  }
+  // executionType should be 'stop' or 'start'
+  if (!['START', 'STOP'].includes(req.body.value.toUpperCase())) {
+    return next(
+      createError('Bad Request', 'InvalidProtocolError', 'Invalid value'),
+    );
+  }
+  next();
+};
+
 const validateTagMiddleware = async (req, _, next) => {
+  if (req.headers['content-type'] !== 'application/json') {
+    return next(
+      createError(
+        'Bad Request',
+        'InvalidProtocolError',
+        'Invalid content-type',
+      ),
+    );
+  }
+  if (!('value' in req.body && req.body.value)) {
+    return next(
+      createError('Bad Request', 'InvalidProtocolError', 'Invalid format'),
+    );
+  }
   // tag should not include ','
   if (req.body.value.includes(',')) {
     return next(
@@ -231,4 +269,5 @@ module.exports = {
   render: protocolRender,
   submit: protocolSubmitMiddleware,
   validateTag: validateTagMiddleware,
+  validateExecutionType: validateExecutionTypeMiddleware,
 };

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -53,7 +53,7 @@ router
 router
   .route('/:frameworkName/executionType')
   /** PUT /api/v2/jobs/:frameworkName/executionType - Start or stop job */
-  .put(token.check, controller.execute);
+  .put(token.check, protocol.validateExecutionType, controller.execute);
 
 router
   .route('/:frameworkName/config')
@@ -75,7 +75,7 @@ router
 router
   .route('/:frameworkName/tag')
   /** DELETE /api/v2/jobs/:frameworkName/tag - Delete a framework tag */
-  .delete(token.check, controller.deleteTag);
+  .delete(token.check, protocol.validateTag, controller.deleteTag);
 
 router
   .route('/:frameworkName/events')

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -23,6 +23,9 @@ const controller = require('@pai/controllers/v2/job');
 const taskController = require('@pai/controllers/v2/task');
 const protocol = require('@pai/middlewares/v2/protocol');
 const jobAttemptRouter = require('@pai/routes/v2/job-attempt.js');
+const param = require('@pai/middlewares/parameter');
+const tagInputSchema = require('@pai/config/v2/tag');
+const executionTypeInputSchema = require('@pai/config/v2/execution-type');
 
 const router = new express.Router();
 
@@ -53,7 +56,11 @@ router
 router
   .route('/:frameworkName/executionType')
   /** PUT /api/v2/jobs/:frameworkName/executionType - Start or stop job */
-  .put(token.check, protocol.validateExecutionType, controller.execute);
+  .put(
+    token.check,
+    param.validate(executionTypeInputSchema.executionTypeInputSchema),
+    controller.execute,
+  );
 
 router
   .route('/:frameworkName/config')
@@ -70,12 +77,20 @@ router.use('/:frameworkName/job-attempts', jobAttemptRouter);
 router
   .route('/:frameworkName/tag')
   /** PUT /api/v2/jobs/:frameworkName/tag - Add a framework tag */
-  .put(token.check, protocol.validateTag, controller.addTag);
+  .put(
+    token.check,
+    param.validate(tagInputSchema.tagInputSchema),
+    controller.addTag,
+  );
 
 router
   .route('/:frameworkName/tag')
   /** DELETE /api/v2/jobs/:frameworkName/tag - Delete a framework tag */
-  .delete(token.check, protocol.validateTag, controller.deleteTag);
+  .delete(
+    token.check,
+    param.validate(tagInputSchema.tagInputSchema),
+    controller.deleteTag,
+  );
 
 router
   .route('/:frameworkName/events')


### PR DESCRIPTION
Refine APIs `put/delete tag` , `put job/executionType`: 
-  return error when the request has content-type issue or body format issue