### PR TITLE
update users's own profile: support AAD mode; update extension

### DIFF
--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -441,7 +441,6 @@ paths:
       summary: Update user's own profile.
       description: >-
         Update user's own profile in the system.
-        Only allowed in basic mode
       operationId: updateUserSelf
       security:
         - bearerAuth: []
@@ -478,6 +477,13 @@ paths:
                         Old password.
                         When newPassword exists, it's required.
                         When newPassword doesn't exists, it's useless.
+                    extension:
+                      type: object
+                      description: >-
+                        Extension fields.
+                        Be allowed in both oidc and basic mode.
+                        When patch is false, it's required.
+                        When patch is true, it's optional.
                 patch:
                   type: boolean
                   default: false

--- a/src/rest-server/src/config/v2/user.js
+++ b/src/rest-server/src/config/v2/user.js
@@ -117,6 +117,7 @@ const basicUserUpdateInputSchema = Joi.object().keys({
         is: Joi.exist(),
         then: Joi.required(),
       }),
+      extension: Joi.object().pattern(/\w+/, Joi.required()),
     })
     .when('patch', {
       is: true,
@@ -131,8 +132,8 @@ const basicUserUpdateInputSchema = Joi.object().keys({
     }),
 });
 
-// define the input schema for the 'update user' api in oidc mode
-const oidcAdminUserUpdateInputSchema = Joi.object().keys({
+// define the input schema for the 'update user' api in oidc mode for admin and other users
+const oidcUserUpdateInputSchema = Joi.object().keys({
   data: Joi.object().keys({
     username: Joi.string()
       .regex(/^[\w.-]+$/, 'username')
@@ -147,7 +148,7 @@ module.exports = {
   userCreateInputSchema,
   basicAdminUserUpdateInputSchema,
   basicUserUpdateInputSchema,
-  oidcAdminUserUpdateInputSchema,
+  oidcUserUpdateInputSchema,
   userExtensionUpdateInputSchema,
   userVirtualClusterUpdateInputSchema,
   userGrouplistUpdateInputSchema,

--- a/src/rest-server/src/config/v2/user.js
+++ b/src/rest-server/src/config/v2/user.js
@@ -132,7 +132,8 @@ const basicUserUpdateInputSchema = Joi.object().keys({
     }),
 });
 
-// define the input schema for the 'update user' api in oidc mode for admin and other users
+// define the input schema for the 'update user' api in OIDC mode
+// admin and other user share the same update schema in OIDC mode
 const oidcUserUpdateInputSchema = Joi.object().keys({
   data: Joi.object().keys({
     username: Joi.string()

--- a/src/rest-server/src/controllers/v2/user.js
+++ b/src/rest-server/src/controllers/v2/user.js
@@ -635,17 +635,21 @@ const updateUserAdminPermission = async (req, res, next) => {
   }
 };
 
-const basicAdminUserUpdate = async (req, res, next) => {
-  const username = req.body.data.username;
-  if (!req.user.admin) {
-    next(
+const checkSelf = async (req, _, next) => {
+  if (req.user.username !== req.body.data.username) {
+    return next(
       createError(
         'Forbidden',
         'ForbiddenUserError',
-        `Non-admin is not allow to do this operation.`,
+        `Can't update other user's data`,
       ),
     );
   }
+  next();
+};
+
+const basicAdminUserUpdate = async (req, res, next) => {
+  const username = req.body.data.username;
   let userInfo;
   try {
     userInfo = await userModel.getUser(username);
@@ -713,15 +717,6 @@ const basicAdminUserUpdate = async (req, res, next) => {
 
 const basicUserUpdate = async (req, res, next) => {
   const username = req.user.username;
-  if (username !== req.body.data.username) {
-    return next(
-      createError(
-        'Forbidden',
-        'ForbiddenUserError',
-        `Can't update other user's data`,
-      ),
-    );
-  }
   let userInfo;
   try {
     userInfo = await userModel.getUser(username);
@@ -774,17 +769,9 @@ const basicUserUpdate = async (req, res, next) => {
   }
 };
 
+// OIDC
 const oidcUserUpdate = async (req, res, next) => {
-  const username = req.body.data.username;
-  if (!req.user.admin) {
-    next(
-      createError(
-        'Forbidden',
-        'ForbiddenUserError',
-        `Non-admin is not allow to do this operation.`,
-      ),
-    );
-  }
+  const username = req.user.username;
   let userInfo;
   try {
     userInfo = await userModel.getUser(username);
@@ -854,6 +841,7 @@ const deleteUser = async (req, res, next) => {
 
 // module exports
 module.exports = {
+  checkSelf,
   getUser,
   getAllUser,
   createUserIfUserNotExist,

--- a/src/rest-server/src/controllers/v2/user.js
+++ b/src/rest-server/src/controllers/v2/user.js
@@ -160,15 +160,6 @@ const updateUserGroupListFromExternal = async (req, res, next) => {
 };
 
 const createUser = async (req, res, next) => {
-  if (!req.user.admin) {
-    next(
-      createError(
-        'Forbidden',
-        'ForbiddenUserError',
-        `Non-admin is not allow to do this operation.`,
-      ),
-    );
-  }
   let grouplist;
   try {
     grouplist = await groupModel.virtualCluster2GroupList(
@@ -368,15 +359,6 @@ const updateGroupListInternal = async (groupList) => {
 };
 
 const updateUserGroupList = async (req, res, next) => {
-  if (!req.user.admin) {
-    next(
-      createError(
-        'Forbidden',
-        'ForbiddenUserError',
-        `Non-admin is not allow to do this operation.`,
-      ),
-    );
-  }
   const username = req.params.username;
   let userValue;
   try {
@@ -404,15 +386,6 @@ const updateUserGroupList = async (req, res, next) => {
 };
 
 const addGroupIntoUserGrouplist = async (req, res, next) => {
-  if (!req.user.admin) {
-    next(
-      createError(
-        'Forbidden',
-        'ForbiddenUserError',
-        `Non-admin is not allow to do this operation.`,
-      ),
-    );
-  }
   const existGrouplist = await groupModel.filterExistGroups([
     req.body.groupname,
   ]);
@@ -453,15 +426,6 @@ const addGroupIntoUserGrouplist = async (req, res, next) => {
 
 const removeGroupFromUserGrouplist = async (req, res, next) => {
   try {
-    if (!req.user.admin) {
-      next(
-        createError(
-          'Forbidden',
-          'ForbiddenUserError',
-          `Non-admin is not allow to do this operation.`,
-        ),
-      );
-    }
     const username = req.params.username;
     const groupname = req.body.groupname;
     const userInfo = await userModel.getUser(username);
@@ -600,36 +564,26 @@ const updateUserAdminPermission = async (req, res, next) => {
   try {
     const username = req.params.username;
     const admin = req.body.admin;
-    if (!req.user.admin) {
-      next(
-        createError(
-          'Forbidden',
-          'ForbiddenUserError',
-          `Non-admin is not allow to do this operation.`,
-        ),
-      );
-    } else {
-      let userInfo;
-      try {
-        userInfo = await userModel.getUser(username);
-      } catch (error) {
-        if (error.status === 404) {
-          return next(
-            createError(
-              'Not Found',
-              'NoUserError',
-              `User ${req.params.username} not found.`,
-            ),
-          );
-        }
-        return next(createError.unknown(error));
+    let userInfo;
+    try {
+      userInfo = await userModel.getUser(username);
+    } catch (error) {
+      if (error.status === 404) {
+        return next(
+          createError(
+            'Not Found',
+            'NoUserError',
+            `User ${req.params.username} not found.`,
+          ),
+        );
       }
-      userInfo.grouplist = await updateAdminPermissionInternal(userInfo, admin);
-      await userModel.updateUser(username, userInfo);
-      return res.status(201).json({
-        message: 'Update user admin permission successfully.',
-      });
+      return next(createError.unknown(error));
     }
+    userInfo.grouplist = await updateAdminPermissionInternal(userInfo, admin);
+    await userModel.updateUser(username, userInfo);
+    return res.status(201).json({
+      message: 'Update user admin permission successfully.',
+    });
   } catch (error) {
     return next(createError.unknown(error));
   }
@@ -770,6 +724,7 @@ const basicUserUpdate = async (req, res, next) => {
 };
 
 // OIDC
+// admin and other user share the same update schema in OIDC mode
 const oidcUserUpdate = async (req, res, next) => {
   const username = req.user.username;
   let userInfo;
@@ -848,10 +803,10 @@ module.exports = {
   basicAdminUserUpdate,
   basicUserUpdate,
   oidcUserUpdate,
+  updateUserGroupList,
   updateUserGroupListFromExternal,
   updateUserExtension,
   updateUserVirtualCluster,
-  updateUserGroupList,
   updateUserEmail,
   updateUserAdminPermission,
   addGroupIntoUserGrouplist,

--- a/src/rest-server/src/controllers/v2/user.js
+++ b/src/rest-server/src/controllers/v2/user.js
@@ -178,7 +178,7 @@ const createUser = async (req, res, next) => {
     return next(createError.unknown(error));
   }
   if (grouplist.length !== req.body.virtualCluster.length) {
-    next(
+    return next(
       createError(
         'Bad Request',
         'NoVirtualClusterError',

--- a/src/rest-server/src/middlewares/token.js
+++ b/src/rest-server/src/middlewares/token.js
@@ -83,7 +83,21 @@ const notApplication = async (req, _, next) => {
   }
 };
 
+const checkAdmin = async (req, _, next) => {
+  if (!req.user.admin) {
+    return next(
+      createError(
+        'Forbidden',
+        'ForbiddenUserError',
+        `Non-admin is not allow to do this operation.`,
+      ),
+    );
+  }
+  next();
+};
+
 module.exports = {
   check,
   checkNotApplication: [check, notApplication],
+  checkAdmin,
 };

--- a/src/rest-server/src/routes/v2/user.js
+++ b/src/rest-server/src/routes/v2/user.js
@@ -56,6 +56,7 @@ if (authnConfig.authnMethod === 'basic') {
     /** Create /api/v2/users */
     .post(
       token.checkNotApplication,
+      token.checkAdmin,
       param.validate(userInputSchema.userCreateInputSchema),
       userController.createUser,
     );
@@ -85,6 +86,7 @@ if (authnConfig.authnMethod === 'basic') {
     /** put /api/v2/users/:username/grouplist */
     .put(
       token.checkNotApplication,
+      token.checkAdmin,
       param.validate(userInputSchema.userGrouplistUpdateInputSchema),
       userController.updateUserGroupList,
     );
@@ -94,6 +96,7 @@ if (authnConfig.authnMethod === 'basic') {
     /** put /api/v2/users/:username/group */
     .put(
       token.checkNotApplication,
+      token.checkAdmin,
       param.validate(userInputSchema.addOrRemoveGroupInputSchema),
       userController.addGroupIntoUserGrouplist,
     );
@@ -103,6 +106,7 @@ if (authnConfig.authnMethod === 'basic') {
     /** delete /api/v2/users/:username/group */
     .delete(
       token.checkNotApplication,
+      token.checkAdmin,
       param.validate(userInputSchema.addOrRemoveGroupInputSchema),
       userController.removeGroupFromUserGrouplist,
     );
@@ -143,6 +147,7 @@ if (authnConfig.authnMethod === 'basic') {
     /** Update /api/v2/users/:username/admin */
     .put(
       token.checkNotApplication,
+      token.checkAdmin,
       param.validate(userInputSchema.userAdminPermissionUpdateInputSchema),
       userController.updateUserAdminPermission,
     );
@@ -159,7 +164,7 @@ if (authnConfig.authnMethod === 'basic') {
 
   router
     .route('/me')
-    /** Put /api/v2/users */
+    /** Put /api/v2/users/me */
     .put(
       token.checkNotApplication,
       param.validate(userInputSchema.oidcUserUpdateInputSchema),

--- a/src/rest-server/src/routes/v2/user.js
+++ b/src/rest-server/src/routes/v2/user.js
@@ -65,16 +65,18 @@ if (authnConfig.authnMethod === 'basic') {
     /** Put /api/v2/users */
     .put(
       token.checkNotApplication,
+      token.checkAdmin,
       param.validate(userInputSchema.basicAdminUserUpdateInputSchema),
       userController.basicAdminUserUpdate,
     );
 
   router
     .route('/me')
-    /** Put /api/v2/users */
+    /** Put /api/v2/users/me */
     .put(
       token.checkNotApplication,
       param.validate(userInputSchema.basicUserUpdateInputSchema),
+      userController.checkSelf,
       userController.basicUserUpdate,
     );
 
@@ -150,7 +152,18 @@ if (authnConfig.authnMethod === 'basic') {
     /** Put /api/v2/users */
     .put(
       token.checkNotApplication,
-      param.validate(userInputSchema.oidcAdminUserUpdateInputSchema),
+      token.checkAdmin,
+      param.validate(userInputSchema.oidcUserUpdateInputSchema),
+      userController.oidcUserUpdate,
+    );
+
+  router
+    .route('/me')
+    /** Put /api/v2/users */
+    .put(
+      token.checkNotApplication,
+      param.validate(userInputSchema.oidcUserUpdateInputSchema),
+      userController.checkSelf,
       userController.oidcUserUpdate,
     );
 }

--- a/src/rest-server/src/routes/v2/user.js
+++ b/src/rest-server/src/routes/v2/user.js
@@ -56,8 +56,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** Create /api/v2/users */
     .post(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.userCreateInputSchema),
+      token.checkAdmin,
       userController.createUser,
     );
 
@@ -66,8 +66,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** Put /api/v2/users */
     .put(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.basicAdminUserUpdateInputSchema),
+      token.checkAdmin,
       userController.basicAdminUserUpdate,
     );
 
@@ -86,8 +86,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** put /api/v2/users/:username/grouplist */
     .put(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.userGrouplistUpdateInputSchema),
+      token.checkAdmin,
       userController.updateUserGroupList,
     );
 
@@ -96,8 +96,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** put /api/v2/users/:username/group */
     .put(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.addOrRemoveGroupInputSchema),
+      token.checkAdmin,
       userController.addGroupIntoUserGrouplist,
     );
 
@@ -106,8 +106,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** delete /api/v2/users/:username/group */
     .delete(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.addOrRemoveGroupInputSchema),
+      token.checkAdmin,
       userController.removeGroupFromUserGrouplist,
     );
 
@@ -147,8 +147,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** Update /api/v2/users/:username/admin */
     .put(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.userAdminPermissionUpdateInputSchema),
+      token.checkAdmin,
       userController.updateUserAdminPermission,
     );
 } else {
@@ -157,8 +157,8 @@ if (authnConfig.authnMethod === 'basic') {
     /** Put /api/v2/users */
     .put(
       token.checkNotApplication,
-      token.checkAdmin,
       param.validate(userInputSchema.oidcUserUpdateInputSchema),
+      token.checkAdmin,
       userController.oidcUserUpdate,
     );
 

--- a/src/rest-server/test/userManagement.js
+++ b/src/rest-server/test/userManagement.js
@@ -151,7 +151,6 @@ describe('Add new user: post /api/v2/user', () => {
 
   before(() => {
     // mock for case1 username=newuser
-
     nock(apiServerRootUri)
       .post('/api/v1/namespaces/pai-user-v2/secrets', {
         'metadata': {'name': '6e657775736572'},
@@ -185,7 +184,6 @@ describe('Add new user: post /api/v2/user', () => {
       });
 
     // mock for case2 add non-admin user
-
     nock(apiServerRootUri)
       .post('/api/v1/namespaces/pai-user-v2/secrets', {
         'metadata': {'name': '6e6f6e5f61646d696e'},
@@ -247,13 +245,13 @@ describe('Add new user: post /api/v2/user', () => {
 
     nock(apiServerRootUri)
       .get('/api/v1/namespaces/pai-group/secrets/64656661756c74')
-      .times(4)
+      .times(3)
       .reply(200, defaultGroupSchema)
       .get('/api/v1/namespaces/pai-group/secrets/766331')
-      .times(4)
+      .times(3)
       .reply(200, vc1GroupSchema)
       .get('/api/v1/namespaces/pai-group/secrets/766332')
-      .times(4)
+      .times(3)
       .reply(200, vc2GroupSchema)
       .get('/api/v1/namespaces/pai-group/secrets/61646d696e47726f7570');
 });


### PR DESCRIPTION
This PR is for release v1.4. Needed for multi-cluster feature.

update users own profile API:
- support AAD mode
- suppport `extension` update
- Some code is refactored: `checkAdmin` should be a common logic in token check, while `checkSelf` should be controller specific since it relies on the request body.