### PR TITLE
use checkAdmin middleware

### DIFF
--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -222,14 +222,6 @@ const getSshInfo = asyncHandler(async (req, res) => {
 });
 
 const addTag = asyncHandler(async (req, res) => {
-  // only admin users can add tags
-  if (!req.user.admin) {
-    throw createError(
-      'Unauthorized',
-      'UnauthorizedUserError',
-      'Only admin users are allowed to do this operation.',
-    );
-  }
   await job.addTag(req.params.frameworkName, req.body.value);
   res.status(status('OK')).json({
     status: status('OK'),
@@ -238,14 +230,6 @@ const addTag = asyncHandler(async (req, res) => {
 });
 
 const deleteTag = asyncHandler(async (req, res) => {
-  // only admin users can delete tags
-  if (!req.user.admin) {
-    throw createError(
-      'Unauthorized',
-      'UnauthorizedUserError',
-      'Only admin users are allowed to do this operation.',
-    );
-  }
   await job.deleteTag(req.params.frameworkName, req.body.value);
   res.status(status('OK')).json({
     status: status('OK'),

--- a/src/rest-server/src/controllers/v2/virtual-cluster.js
+++ b/src/rest-server/src/controllers/v2/virtual-cluster.js
@@ -58,13 +58,6 @@ const get = asyncHandler(async (req, res) => {
 
 const update = asyncHandler(async (req, res) => {
   const virtualClusterName = req.params.virtualClusterName;
-  if (!req.user.admin) {
-    throw createError(
-      'Forbidden',
-      'ForbiddenUserError',
-      `Non-admin is not allowed to do this operation.`,
-    );
-  }
   if (virtualClusterName === authConfig.groupConfig.defaultGroup.groupname) {
     throw createError(
       'Forbidden',
@@ -130,44 +123,29 @@ const update = asyncHandler(async (req, res) => {
 const updateStatus = asyncHandler(async (req, res) => {
   const virtualClusterName = req.params.virtualClusterName;
   const vcStatus = req.body.vcStatus;
-  if (req.user.admin) {
-    if (vcStatus === 'stopped') {
-      await virtualCluster.stop(virtualClusterName);
-      res.status(status('Created')).json({
-        status: status('Created'),
-        message: `Stop virtual cluster ${virtualClusterName} successfully.`,
-      });
-    } else if (vcStatus === 'running') {
-      await virtualCluster.activate(virtualClusterName);
-      res.status(status('Created')).json({
-        status: status('Created'),
-        message: `Activate virtual cluster ${virtualClusterName} successfully.`,
-      });
-    } else {
-      throw createError(
-        'Bad Request',
-        'BadConfigurationError',
-        `Unknown vc status: ${vcStatus}`,
-      );
-    }
+  if (vcStatus === 'stopped') {
+    await virtualCluster.stop(virtualClusterName);
+    res.status(status('Created')).json({
+      status: status('Created'),
+      message: `Stop virtual cluster ${virtualClusterName} successfully.`,
+    });
+  } else if (vcStatus === 'running') {
+    await virtualCluster.activate(virtualClusterName);
+    res.status(status('Created')).json({
+      status: status('Created'),
+      message: `Activate virtual cluster ${virtualClusterName} successfully.`,
+    });
   } else {
     throw createError(
-      'Forbidden',
-      'ForbiddenUserError',
-      'Non-admin is not allowed to do this operation.',
+      'Bad Request',
+      'BadConfigurationError',
+      `Unknown vc status: ${vcStatus}`,
     );
   }
 });
 
 const remove = asyncHandler(async (req, res) => {
   const virtualClusterName = req.params.virtualClusterName;
-  if (!req.user.admin) {
-    throw createError(
-      'Forbidden',
-      'ForbiddenUserError',
-      `Non-admin is not allowed to do this operation.`,
-    );
-  }
   if (virtualClusterName === authConfig.groupConfig.adminGroup.groupname) {
     throw createError(
       'Forbidden',

--- a/src/rest-server/src/middlewares/token.js
+++ b/src/rest-server/src/middlewares/token.js
@@ -83,7 +83,8 @@ const notApplication = async (req, _, next) => {
   }
 };
 
-const checkAdmin = async (req, _, next) => {
+// this middleware should be used after `check` to ensure `req.user` contains `admin` as a key
+const checkAdmin = (req, _, next) => {
   if (!req.user.admin) {
     return next(
       createError(

--- a/src/rest-server/src/routes/kubernetes.js
+++ b/src/rest-server/src/routes/kubernetes.js
@@ -4,23 +4,13 @@
 const express = require('express');
 const token = require('@pai/middlewares/token');
 const kubernetes = require('@pai/models/kubernetes/kubernetes');
-const createError = require('@pai/utils/error');
 
 const router = new express.Router();
 
 router
   .route('/nodes')
   /** GET /api/v1/kubernetes/nodes - Return k8s nodes info */
-  .get(token.check, async (req, res, next) => {
-    if (!req.user.admin) {
-      return next(
-        createError(
-          'Forbidden',
-          'ForbiddenUserError',
-          `Non-admin is not allow to do this operation.`,
-        ),
-      );
-    }
+  .get(token.check, token.checkAdmin, async (req, res, next) => {
     try {
       const nodes = await kubernetes.getNodes();
       res.status(200).json(nodes);
@@ -32,16 +22,7 @@ router
 router
   .route('/pods')
   /** GET /api/v1/kubernetes/pods - Return k8s pods info */
-  .get(token.check, async (req, res, next) => {
-    if (!req.user.admin) {
-      return next(
-        createError(
-          'Forbidden',
-          'ForbiddenUserError',
-          `Non-admin is not allow to do this operation.`,
-        ),
-      );
-    }
+  .get(token.check, token.checkAdmin, async (req, res, next) => {
     try {
       const pods = await kubernetes.getPods(req.query);
       res.status(200).json(pods);

--- a/src/rest-server/src/routes/v2/group.js
+++ b/src/rest-server/src/routes/v2/group.js
@@ -37,7 +37,11 @@ router
 router
   .route('/:groupname')
   /** Post /api/v2/group/:groupname */
-  .delete(token.checkNotApplication, groupController.deleteGroup);
+  .delete(
+    token.checkNotApplication,
+    token.checkAdmin,
+    groupController.deleteGroup,
+  );
 
 router
   .route('/')
@@ -45,6 +49,7 @@ router
   .post(
     token.checkNotApplication,
     param.validate(groupInputSchema.groupCreateInputSchema),
+    token.checkAdmin,
     groupController.createGroup,
   );
 
@@ -54,6 +59,7 @@ router
   .put(
     token.checkNotApplication,
     param.validate(groupInputSchema.groupUpdateInputSchema),
+    token.checkAdmin,
     groupController.updateGroup,
   );
 
@@ -63,13 +69,14 @@ router
   .put(
     token.checkNotApplication,
     param.validate(groupInputSchema.groupExtensionAttrUpdateInputSchema),
+    token.checkAdmin,
     groupController.updateGroupExtensionAttr,
   );
 
 router
   .route('/:groupname/userlist')
   /** get /api/v2/group/:groupname/userlist */
-  .get(token.check, groupController.getGroupUserList);
+  .get(token.check, token.checkAdmin, groupController.getGroupUserList);
 
 /** Legacy API and will be deprecated in the future. Please use put /api/v2/group */
 router
@@ -77,6 +84,7 @@ router
   .put(
     token.checkNotApplication,
     param.validate(groupInputSchema.groupExtensionUpdateInputSchema),
+    token.checkAdmin,
     groupController.updateGroupExtension,
   );
 
@@ -86,6 +94,7 @@ router
   .put(
     token.checkNotApplication,
     param.validate(groupInputSchema.groupDescriptionUpdateInputSchema),
+    token.checkAdmin,
     groupController.updateGroupDescription,
   );
 
@@ -95,6 +104,7 @@ router
   .put(
     token.checkNotApplication,
     param.validate(groupInputSchema.groupExternalNameUpdateInputSchema),
+    token.checkAdmin,
     groupController.updateGroupExternalName,
   );
 

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -80,6 +80,7 @@ router
   .put(
     token.check,
     param.validate(tagInputSchema.tagInputSchema),
+    token.checkAdmin,
     controller.addTag,
   );
 
@@ -89,6 +90,7 @@ router
   .delete(
     token.check,
     param.validate(tagInputSchema.tagInputSchema),
+    token.checkAdmin,
     controller.deleteTag,
   );
 

--- a/src/rest-server/src/routes/v2/user.js
+++ b/src/rest-server/src/routes/v2/user.js
@@ -49,7 +49,11 @@ if (authnConfig.authnMethod === 'basic') {
   router
     .route('/:username')
     /** Delete /api/v2/users/:username */
-    .delete(token.checkNotApplication, userController.deleteUser);
+    .delete(
+      token.checkNotApplication,
+      token.checkAdmin,
+      userController.deleteUser,
+    );
 
   router
     .route('/')
@@ -118,6 +122,7 @@ if (authnConfig.authnMethod === 'basic') {
     .put(
       token.checkNotApplication,
       param.validate(userInputSchema.userVirtualClusterUpdateInputSchema),
+      token.checkAdmin,
       userController.updateUserVirtualCluster,
     );
 

--- a/src/rest-server/src/routes/v2/virtual-cluster.js
+++ b/src/rest-server/src/routes/v2/virtual-cluster.js
@@ -37,10 +37,11 @@ router
   .put(
     token.checkNotApplication,
     param.validate(vcConfig.vcCreateInputSchema),
+    token.checkAdmin,
     controller.update,
   )
   /** DELETE /api/v2/virtual-clusters/:virtualClusterName - Remove a virtual cluster */
-  .delete(token.checkNotApplication, controller.remove);
+  .delete(token.checkNotApplication, token.checkAdmin, controller.remove);
 
 router
   .route('/:virtualClusterName/status')
@@ -48,6 +49,7 @@ router
   .put(
     token.checkNotApplication,
     param.validate(vcConfig.vcStatusPutInputSchema),
+    token.checkAdmin,
     controller.updateStatus,
   );
 


### PR DESCRIPTION
- refactor with common middleware to avoid code duplication
- fix issues in `getGroupUserList` and `createGroup` function. The created error was not thrown immediately so the following code will be executed even when the auth check doesn't pass.