### PR TITLE
deployment process refine

### DIFF
--- a/contrib/kubespray/quick-start-kubespray.sh
+++ b/contrib/kubespray/quick-start-kubespray.sh
@@ -57,7 +57,7 @@ if [ $ret_code_check -ne 0 ]; then
 fi
 
 # prepare cluster-cfg folder
-/bin/bash script/configuration-kubescpray.sh -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} || exit $?
+/bin/bash script/configuration-kubespray.sh -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} || exit $?
 
 echo "Ping Test"
 ansible all -i ${HOME}/pai-deploy/cluster-cfg/hosts.yml -m ping || exit $?

--- a/contrib/kubespray/quick-start-kubespray.sh
+++ b/contrib/kubespray/quick-start-kubespray.sh
@@ -40,14 +40,10 @@ then
   exit 1
 fi
 
+# environment set up
 /bin/bash script/environment.sh -c ${CLUSTER_CONFIG} || exit $?
 
-/bin/bash script/configuration.sh -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} || exit $?
-
-echo "Ping Test"
-
-ansible all -i ${HOME}/pai-deploy/cluster-cfg/hosts.yml -m ping || exit $?
-
+# check requirements
 /bin/bash requirement.sh -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG}
 ret_code_check=$?
 if [ $ret_code_check -ne 0 ]; then
@@ -60,8 +56,13 @@ if [ $ret_code_check -ne 0 ]; then
   fi
 fi
 
+# prepare cluster-cfg folder
+/bin/bash script/configuration-kubescpray.sh -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} || exit $?
+
+echo "Ping Test"
+ansible all -i ${HOME}/pai-deploy/cluster-cfg/hosts.yml -m ping || exit $?
+
 /bin/bash preinstall.sh -c ${CLUSTER_CONFIG} || exit $?
 
+# setup k8s cluster
 /bin/bash script/kubernetes-boot.sh || exit $?
-
-

--- a/contrib/kubespray/quick-start-service.sh
+++ b/contrib/kubespray/quick-start-service.sh
@@ -40,4 +40,7 @@ then
   exit 1
 fi
 
+# prepare quick-start-config folder
+/bin/bash script/configuration-services.sh -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} || exit $?
+
 /bin/bash script/service-boot.sh -c ${CLUSTER_CONFIG}

--- a/contrib/kubespray/script/configuration-kubespray.sh
+++ b/contrib/kubespray/script/configuration-kubespray.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+while getopts "w:m:c:" opt; do
+  case $opt in
+    w)
+      WORKER_LIST=$OPTARG
+      ;;
+    m)
+      MASTER_LIST=$OPTARG
+      ;;
+    c)
+      CLUSTER_CONFIG=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG"
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p ${HOME}/pai-deploy/cluster-cfg
+python3 ${HOME}/pai-deploy/pai/contrib/kubespray/script/k8s-generator.py -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} -o ${HOME}/pai-deploy/cluster-cfg || exit $?
+
+cp ${HOME}/pai-deploy/cluster-cfg/openpai.yml ${HOME}/pai-deploy/kubespray/inventory/pai/
+cp ${HOME}/pai-deploy/cluster-cfg/hosts.yml ${HOME}/pai-deploy/kubespray/inventory/pai/

--- a/contrib/kubespray/script/configuration-services.sh
+++ b/contrib/kubespray/script/configuration-services.sh
@@ -18,13 +18,6 @@ while getopts "w:m:c:" opt; do
   esac
 done
 
-cd ${HOME}/pai-deploy/pai/contrib/kubespray
-mkdir -p ${HOME}/pai-deploy/cluster-cfg
-python3 ${HOME}/pai-deploy/pai/contrib/kubespray/script/k8s-generator.py -m ${MASTER_LIST} -w ${WORKER_LIST} -c ${CLUSTER_CONFIG} -o ${HOME}/pai-deploy/cluster-cfg || exit $?
-
-cp ${HOME}/pai-deploy/cluster-cfg/openpai.yml ${HOME}/pai-deploy/kubespray/inventory/pai/
-cp ${HOME}/pai-deploy/cluster-cfg/hosts.yml ${HOME}/pai-deploy/kubespray/inventory/pai/
-
 mkdir -p ${HOME}/pai-deploy/quick-start-config/
 cp ${WORKER_LIST} ${HOME}/pai-deploy/quick-start-config/worker.csv
 cp ${MASTER_LIST} ${HOME}/pai-deploy/quick-start-config/master.csv

--- a/contrib/kubespray/script/environment.sh
+++ b/contrib/kubespray/script/environment.sh
@@ -18,6 +18,7 @@ echo "Create working folder in ${HOME}/pai-deploy"
 mkdir -p ${HOME}/pai-deploy/
 
 echo "Clone kubespray source code from github to ${HOME}/pai-deploy"
+sudo rm -rf ${HOME}/pai-deploy/kubespray
 git clone -b release-2.11 https://github.com/kubernetes-sigs/kubespray.git ${HOME}/pai-deploy/kubespray
 
 echo "Copy inventory folder, and save it "
@@ -42,4 +43,5 @@ echo "Install kubespray's requirements and ansible is included"
 sudo pip3 install -r ${HOME}/pai-deploy/kubespray/requirements.txt
 
 echo "Clone OpenPAI source code from github to ${HOME}/pai-deploy"
+sudo rm -rf ${HOME}/pai-deploy/pai
 git clone -b ${OPENPAI_BRANCH_NAME} https://github.com/microsoft/pai.git ${HOME}/pai-deploy/pai

--- a/contrib/kubespray/script/environment.sh
+++ b/contrib/kubespray/script/environment.sh
@@ -16,14 +16,9 @@ OPENPAI_BRANCH_NAME=`cat ${CLUSTER_CONFIG} | grep branch_name | tr -d "[:space:]
 
 echo "Create working folder in ${HOME}/pai-deploy"
 mkdir -p ${HOME}/pai-deploy/
-cd ${HOME}/pai-deploy
 
-echo "Clone kubespray source code from github"
-git clone https://github.com/kubernetes-sigs/kubespray.git
-
-echo "Checkout to the Release Branch"
-cd kubespray
-git checkout release-2.11
+echo "Clone kubespray source code from github to ${HOME}/pai-deploy"
+git clone -b release-2.11 https://github.com/kubernetes-sigs/kubespray.git ${HOME}/pai-deploy/kubespray
 
 echo "Copy inventory folder, and save it "
 cp -rfp ${HOME}/pai-deploy/kubespray/inventory/sample ${HOME}/pai-deploy/kubespray/inventory/pai
@@ -44,13 +39,7 @@ echo "Install sshpass"
 sudo apt-get -y install sshpass
 
 echo "Install kubespray's requirements and ansible is included"
-cd ${HOME}/pai-deploy/kubespray
-sudo pip3 install -r requirements.txt
+sudo pip3 install -r ${HOME}/pai-deploy/kubespray/requirements.txt
 
-echo "Clone OpenPAI source code from github"
-cd ${HOME}/pai-deploy
-git clone https://github.com/microsoft/pai.git
-cd pai
-
-echo "switch to the branch ${OPENPAI_BRANCH_NAME}"
-git checkout ${OPENPAI_BRANCH_NAME}
+echo "Clone OpenPAI source code from github to ${HOME}/pai-deploy"
+git clone -b ${OPENPAI_BRANCH_NAME} https://github.com/microsoft/pai.git ${HOME}/pai-deploy/pai

--- a/contrib/kubespray/script/service-boot.sh
+++ b/contrib/kubespray/script/service-boot.sh
@@ -46,16 +46,6 @@ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py
 pip3 install kubernetes==11.0.0b2 jinja2
 
-cd /root
-
-git clone https://github.com/microsoft/pai.git
-cd pai
-
-echo "branch name: ${OPENPAI_BRANCH_NAME}"
-
-git checkout ${OPENPAI_BRANCH_NAME}
-git pull
-
 echo "starting nvidia device plugin to detect nvidia gpu resource"
 svn cat https://github.com/NVIDIA/k8s-device-plugin.git/tags/1.0.0-beta4/nvidia-device-plugin.yml \
   | kubectl apply --overwrite=true -f - || exit $?
@@ -66,6 +56,7 @@ svn cat https://github.com/RadeonOpenCompute/k8s-device-plugin.git/trunk/k8s-ds-
   | kubectl apply --overwrite=true -f - || exit $?
 sleep 5
 
+git clone -b ${OPENPAI_BRANCH_NAME} https://github.com/microsoft/pai.git /root/pai
 python3 /root/pai/contrib/kubespray/script/openpai-generator.py -m /quick-start-config/master.csv -w /quick-start-config/worker.csv -c /quick-start-config/config.yml -o /cluster-configuration || exit $?
 
 kubectl delete ds nvidia-device-plugin-daemonset -n kube-system || exit $?
@@ -79,10 +70,10 @@ pip3 install kubernetes
 kubectl create namespace pai-storage
 
 # 1. Push cluster config to cluster
-echo -e "pai\n" | python paictl.py config push -p /cluster-configuration -m service
+echo -e "pai\n" | python /root/pai/paictl.py config push -p /cluster-configuration -m service
 
 # 2. Start OpenPAI service
-echo -e "pai\n" | python paictl.py service start
+echo -e "pai\n" | python /root/pai/paictl.py service start
 EOF_DEV_BOX
 
 if [ $? -ne 0 ]; then

--- a/docs/manual/cluster-admin/how-to-uninstall-openpai.md
+++ b/docs/manual/cluster-admin/how-to-uninstall-openpai.md
@@ -2,10 +2,10 @@
 
 The uninstallation of OpenPAI is irreversible: all the data will be removed and you cannot find them back. If you need a backup, do it before uninstallation.
 
-First, log in to the dev box machine and delete all PAI services:
+First, log in to the dev box machine and delete all PAI services with dev box:
 
 ```bash
-./paictl.py service delete
+sudo docker exec -it dev-box /pai/paictl.py service delete
 ```
 
 Now all PAI services and data are deleted. If you want to destroy the Kubernetes cluster too, please go into [`~/pai-deploy/kubespray` folder](installation-guide.md#keep-a-folder), run:

--- a/docs/manual/cluster-admin/how-to-uninstall-openpai.md
+++ b/docs/manual/cluster-admin/how-to-uninstall-openpai.md
@@ -2,10 +2,10 @@
 
 The uninstallation of OpenPAI is irreversible: all the data will be removed and you cannot find them back. If you need a backup, do it before uninstallation.
 
-First, log in to the dev box machine and delete all PAI services with dev box:
+First, log in to the dev box machine and delete all PAI services with [dev box container](./basic-management-operations.md#pai-service-management-and-paictl).:
 
 ```bash
-sudo docker exec -it dev-box /pai/paictl.py service delete
+sudo docker exec -it `your-dev-box-name` /pai/paictl.py service delete
 ```
 
 Now all PAI services and data are deleted. If you want to destroy the Kubernetes cluster too, please go into [`~/pai-deploy/kubespray` folder](installation-guide.md#keep-a-folder), run:

--- a/docs/manual/cluster-admin/how-to-uninstall-openpai.md
+++ b/docs/manual/cluster-admin/how-to-uninstall-openpai.md
@@ -5,7 +5,7 @@ The uninstallation of OpenPAI is irreversible: all the data will be removed and 
 First, log in to the dev box machine and delete all PAI services with [dev box container](./basic-management-operations.md#pai-service-management-and-paictl).:
 
 ```bash
-sudo docker exec -it `your-dev-box-name` /pai/paictl.py service delete
+sudo docker exec -it dev-box /pai/paictl.py service delete
 ```
 
 Now all PAI services and data are deleted. If you want to destroy the Kubernetes cluster too, please go into [`~/pai-deploy/kubespray` folder](installation-guide.md#keep-a-folder), run:

--- a/docs/manual/cluster-admin/installation-guide.md
+++ b/docs/manual/cluster-admin/installation-guide.md
@@ -192,8 +192,7 @@ docker_image_tag: v1.0.0
 On the dev box machine, use the following commands to clone the OpenPAI repo:
 
 ```bash
-git clone https://github.com/microsoft/pai.git
-git checkout pai-1.0.y  # change to a different branch if you want to deploy a different version
+git clone -b pai-1.3.0 https://github.com/microsoft/pai.git # change to a different branch if you want to deploy a different version
 cd pai/contrib/kubespray
 ```
 

--- a/docs/manual/cluster-admin/installation-guide.md
+++ b/docs/manual/cluster-admin/installation-guide.md
@@ -102,8 +102,8 @@ openpai-004,10.0.0.4
 ```yaml
 user: <your-ssh-username>
 password: <your-ssh-password>
-branch_name: pai-1.0.y
-docker_image_tag: v1.0.0
+branch_name: pai-1.3.y
+docker_image_tag: v1.3.0
 
 # Optional
 

--- a/docs/manual/cluster-admin/installation-guide.md
+++ b/docs/manual/cluster-admin/installation-guide.md
@@ -192,7 +192,7 @@ docker_image_tag: v1.0.0
 On the dev box machine, use the following commands to clone the OpenPAI repo:
 
 ```bash
-git clone -b pai-1.3.0 https://github.com/microsoft/pai.git # change to a different branch if you want to deploy a different version
+git clone -b pai-1.3.y https://github.com/microsoft/pai.git # change to a different branch if you want to deploy a different version
 cd pai/contrib/kubespray
 ```
 

--- a/docs_zh_CN/manual/cluster-admin/installation-guide.md
+++ b/docs_zh_CN/manual/cluster-admin/installation-guide.md
@@ -191,8 +191,7 @@ docker_image_tag: v1.0.0
 在dev box机器上，使用下面的命令克隆OpenPAI的源代码。
 
 ```bash
-git clone https://github.com/microsoft/pai.git
-git checkout pai-1.0.y  # 如果您想要部署不同的版本，请切换到相应的branch。
+git clone -b pai-1.3.0 https://github.com/microsoft/pai.git # 如果您想要部署不同的版本，请切换到相应的branch。
 cd pai/contrib/kubespray
 ```
 

--- a/docs_zh_CN/manual/cluster-admin/installation-guide.md
+++ b/docs_zh_CN/manual/cluster-admin/installation-guide.md
@@ -191,7 +191,7 @@ docker_image_tag: v1.0.0
 在dev box机器上，使用下面的命令克隆OpenPAI的源代码。
 
 ```bash
-git clone -b pai-1.3.0 https://github.com/microsoft/pai.git # 如果您想要部署不同的版本，请切换到相应的branch。
+git clone -b pai-1.3.y https://github.com/microsoft/pai.git # 如果您想要部署不同的版本，请切换到相应的branch。
 cd pai/contrib/kubespray
 ```
 


### PR DESCRIPTION
Fix part of the deployment issues listed in #5001:
- move requirement check before configuration setting;
- move quick-start-config folder setting to quick-start-services.sh; 
- fix installation document branch checkout issue; change suggested version to v1.3.y;
- refine uninstallation doc
- fix git clone issue: clone to an existing folder may raise error, so the code pai/kubespray may be unsuccessfully cloned. 