### PR TITLE
Get log for each attempt.

### DIFF
--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -12,7 +12,7 @@ info:
     Version 2.1.1: add get event api
     Version 2.2.0: add get task status api; add jobAttempId filter to job status api and extend job detail schema
     Version 2.2.1: a user can add/delete tags to/from his/her own jobs
-    version 2.2.2: add get pod logs api
+    version 2.2.2: add get task logs api
   license:
     name: MIT License
     url: "https://github.com/microsoft/pai/blob/master/LICENSE"

--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1741,7 +1741,7 @@ paths:
                       ssh: 37508
                       http: 24661
                     containerGpus: null
-                    containerLog: /api/v2/jobs/admin~admin_444da84f/attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
+                    containerLog: /api/v2/jobs/admin~admin_444da84f/attempts/0/taskRoles/taskrole/taskIndex/0/attempts/2/logs
                     containerExitCode: -220
                     containerExitSpec:
                       code: -220
@@ -1768,7 +1768,7 @@ paths:
                       ssh: 37508
                       http: 24661
                     containerGpus: null
-                    containerLog: /api/v2/jobs/admin~admin_444da84f/attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
+                    containerLog: /api/v2/jobs/admin~admin_444da84f/attempts/0/taskRoles/taskrole/taskIndex/0/attempts/2/logs
                     containerExitCode: -220
                     containerExitSpec:
                       code: -220
@@ -1787,20 +1787,22 @@ paths:
           $ref: "#/components/responses/NoTaskError"
         "500":
           $ref: "#/components/responses/UnknownError"
-  "/api/v2/jobs/{user}~{job}/attempts/{jobAttemptId}/pods/{podUid}/logs":
+  "/api/v2/jobs/{user}~{job}/attempts/{jobAttemptId}/taskRoles/{taskRoleName}/taskIndex/{taskIndex}/attempts/{taskAttemptId}/logs":
     get:
       tags:
         - job
-      summary: Get job pod log list.
-      description: Get job pod log list.
-      operationId: getPodLogs
+      summary: Get task log list.
+      description: Get task log list.
+      operationId: getTaskLogs
       security:
         - bearerAuth: []
       parameters:
       - $ref: "#/components/parameters/user"
       - $ref: "#/components/parameters/job"
       - $ref: "#/components/parameters/jobAttemptId"
-      - $ref: "#/components/parameters/podUid"
+      - $ref: "#/components/parameters/taskRoleName"
+      - $ref: "#/components/parameters/taskIndex"
+      - $ref: "#/components/parameters/taskAttemptId"
       - name: tailMode
         in: query
         description: getting log content via tail mode. Could be "true" or "false"
@@ -1822,7 +1824,7 @@ paths:
                 - name: stdout
                   uri: "https://mater_ip/log-manager/node_ip/api/v1/logs/user.pai.stdout?username=user&framework-name=34775529adebae576fbc0bf48d835386&pod-uid=07cdd036-1a7c-11eb-830b-000d3ab25bb6&taskrole=taskrole&token=token"
         "404":
-          $ref: "#/components/responses/NoPodLogsError"
+          $ref: "#/components/responses/NoTaskLogError"
         "500":
           $ref: "#/components/responses/UnknownError"
   /api/v2/kubernetes/nodes:
@@ -1958,10 +1960,10 @@ components:
       required: true
       schema:
         type: string
-    podUid:
-      name: podUid
+    taskAttemptId:
+      name: taskAttemptId
       in: path
-      description: job pod uid
+      description: task attempt id
       required: true
       schema:
         type: string
@@ -3288,8 +3290,8 @@ components:
               value:
                 code: NoJobSshInfoError
                 message: "SSH info of job {job} is not found."
-    NoPodLogsError:
-      description: NoPodLogsError
+    NoTaskLogError:
+      description: NoTaskLogError
       content:
         application/json:
           schema:
@@ -3297,8 +3299,8 @@ components:
           examples:
             NoJobSshInfoError:
               value:
-                code: NoPodLogsError
-                message: "Logs for pod {podUid} is not found."
+                code: NoTaskLogError
+                message: "Log of task is not found."
     ConflictUserError:
       description: ConflictUserError
       content:

--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1741,7 +1741,7 @@ paths:
                       ssh: 37508
                       http: 24661
                     containerGpus: null
-                    containerLog: /api/v2/jobs/admin~admin_444da84f/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
+                    containerLog: /api/v2/jobs/admin~admin_444da84f/job-attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
                     containerExitCode: -220
                     containerExitSpec:
                       code: -220
@@ -1768,7 +1768,7 @@ paths:
                       ssh: 37508
                       http: 24661
                     containerGpus: null
-                    containerLog: /api/v2/jobs/admin~admin_444da84f/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
+                    containerLog: /api/v2/jobs/admin~admin_444da84f/job-attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
                     containerExitCode: -220
                     containerExitSpec:
                       code: -220
@@ -1787,7 +1787,7 @@ paths:
           $ref: "#/components/responses/NoTaskError"
         "500":
           $ref: "#/components/responses/UnknownError"
-  "/api/v2/jobs/{user}~{job}/pods/{podUid}/logs":
+  "/api/v2/jobs/{user}~{job}/attempts/{jobAttemptId}/pods/{podUid}/logs":
     get:
       tags:
         - job
@@ -1799,6 +1799,7 @@ paths:
       parameters:
       - $ref: "#/components/parameters/user"
       - $ref: "#/components/parameters/job"
+      - $ref: "#/components/parameters/jobAttemptId"
       - $ref: "#/components/parameters/podUid"
       - name: tailMode
         in: query

--- a/src/rest-server/docs/swagger.yaml
+++ b/src/rest-server/docs/swagger.yaml
@@ -1741,7 +1741,7 @@ paths:
                       ssh: 37508
                       http: 24661
                     containerGpus: null
-                    containerLog: /api/v2/jobs/admin~admin_444da84f/job-attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
+                    containerLog: /api/v2/jobs/admin~admin_444da84f/attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
                     containerExitCode: -220
                     containerExitSpec:
                       code: -220
@@ -1768,7 +1768,7 @@ paths:
                       ssh: 37508
                       http: 24661
                     containerGpus: null
-                    containerLog: /api/v2/jobs/admin~admin_444da84f/job-attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
+                    containerLog: /api/v2/jobs/admin~admin_444da84f/attempts/0/pods/07cdd036-1a7c-11eb-830b-000d3ab25bb6/logs
                     containerExitCode: -220
                     containerExitSpec:
                       code: -220

--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -293,6 +293,7 @@ const getLogs = asyncHandler(async (req, res) => {
   try {
     const data = await log.getLogListFromLogManager(
       req.params.frameworkName,
+      req.params.jobAttemptId,
       req.params.podUid,
       req.query['tail-mode'],
     );

--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -294,7 +294,9 @@ const getLogs = asyncHandler(async (req, res) => {
     const data = await log.getLogListFromLogManager(
       req.params.frameworkName,
       req.params.jobAttemptId,
-      req.params.podUid,
+      req.params.taskRoleName,
+      req.params.taskIndex,
+      req.params.taskAttemptId,
       req.query['tail-mode'],
     );
     res.json(data);

--- a/src/rest-server/src/controllers/v2/job.js
+++ b/src/rest-server/src/controllers/v2/job.js
@@ -302,7 +302,7 @@ const getLogs = asyncHandler(async (req, res) => {
     res.json(data);
   } catch (error) {
     logger.error(`Got error when retrieving log list, error: ${error}`);
-    throw error.code === 'NoPodLogsError'
+    throw error.code === 'NoTaskLogErr'
       ? error
       : createError(
           'Internal Server Error',

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -77,6 +77,7 @@ const convertFrameworkSummary = (framework) => {
 };
 
 const convertTaskDetail = async (
+  taskName,
   taskStatus,
   jobAttemptId,
   ports,
@@ -96,6 +97,7 @@ const convertTaskDetail = async (
   const completionStatus = taskStatus.attemptStatus.completionStatus;
   const diagnostics = completionStatus ? completionStatus.diagnostics : null;
   const exitDiagnostics = generateExitDiagnostics(diagnostics);
+  const taskAttemptId = taskStatus.attemptStatus.id;
   return {
     taskIndex: taskStatus.index,
     taskUid: taskStatus.instanceUID,
@@ -108,7 +110,7 @@ const convertTaskDetail = async (
     containerNodeName: taskStatus.attemptStatus.podNodeName,
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/taskRoles/${taskName}/taskIndex/${taskStatus.index}/attempts/${taskAttemptId}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)
@@ -123,7 +125,7 @@ const convertTaskDetail = async (
       new Date(taskStatus.runTime || taskStatus.completionTime).getTime() ||
       null,
     completedTime: new Date(taskStatus.completionTime).getTime() || null,
-    attemptId: taskStatus.attemptStatus.id,
+    attemptId: taskAttemptId,
     attemptState: convertAttemptState(
       taskStatus.state || null,
       completionStatus ? completionStatus.code : null,
@@ -291,6 +293,7 @@ const convertFrameworkDetail = async (
       taskRoleStatus.taskStatuses.map(
         async (status) =>
           await convertTaskDetail(
+            taskRoleStatus.name,
             status,
             specifiedAttemptStatus.id,
             ports[taskRoleStatus.name],

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -104,7 +104,7 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
     containerNodeName: taskStatus.attemptStatus.podNodeName,
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/job-attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -91,6 +91,7 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
   const completionStatus = taskStatus.attemptStatus.completionStatus;
   const diagnostics = completionStatus ? completionStatus.diagnostics : null;
   const exitDiagnostics = generateExitDiagnostics(diagnostics);
+  const attemptId = taskStatus.attemptStatus.id;
   return {
     taskIndex: taskStatus.index,
     taskUid: taskStatus.instanceUID,
@@ -103,7 +104,7 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
     containerNodeName: taskStatus.attemptStatus.podNodeName,
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/job-attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)
@@ -118,7 +119,7 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
       new Date(taskStatus.runTime || taskStatus.completionTime).getTime() ||
       null,
     completedTime: new Date(taskStatus.completionTime).getTime() || null,
-    attemptId: taskStatus.attemptStatus.id,
+    attemptId: attemptId,
     attemptState: convertAttemptState(
       taskStatus.state || null,
       completionStatus ? completionStatus.code : null,

--- a/src/rest-server/src/models/v2/job/k8s.js
+++ b/src/rest-server/src/models/v2/job/k8s.js
@@ -76,7 +76,12 @@ const convertFrameworkSummary = (framework) => {
   };
 };
 
-const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
+const convertTaskDetail = async (
+  taskStatus,
+  jobAttemptId,
+  ports,
+  frameworkName,
+) => {
   // get containerPorts
   const containerPorts = getContainerPorts(
     ports,
@@ -91,7 +96,6 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
   const completionStatus = taskStatus.attemptStatus.completionStatus;
   const diagnostics = completionStatus ? completionStatus.diagnostics : null;
   const exitDiagnostics = generateExitDiagnostics(diagnostics);
-  const attemptId = taskStatus.attemptStatus.id;
   return {
     taskIndex: taskStatus.index,
     taskUid: taskStatus.instanceUID,
@@ -104,7 +108,7 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
     containerNodeName: taskStatus.attemptStatus.podNodeName,
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)
@@ -119,7 +123,7 @@ const convertTaskDetail = async (taskStatus, ports, frameworkName) => {
       new Date(taskStatus.runTime || taskStatus.completionTime).getTime() ||
       null,
     completedTime: new Date(taskStatus.completionTime).getTime() || null,
-    attemptId: attemptId,
+    attemptId: taskStatus.attemptStatus.id,
     attemptState: convertAttemptState(
       taskStatus.state || null,
       completionStatus ? completionStatus.code : null,
@@ -288,6 +292,7 @@ const convertFrameworkDetail = async (
         async (status) =>
           await convertTaskDetail(
             status,
+            specifiedAttemptStatus.id,
             ports[taskRoleStatus.name],
             `${userName}~${jobName}`,
           ),

--- a/src/rest-server/src/models/v2/job/log.js
+++ b/src/rest-server/src/models/v2/job/log.js
@@ -49,9 +49,9 @@ const getLogListFromLogManager = async (
 
   const taskDetail = await task.get(
     frameworkName,
-    jobAttemptId,
+    Number(jobAttemptId),
     taskRoleName,
-    taskIndex,
+    Number(taskIndex),
   );
   const noPodLogsErr = createError(
     'Not Found',

--- a/src/rest-server/src/models/v2/job/log.js
+++ b/src/rest-server/src/models/v2/job/log.js
@@ -58,14 +58,14 @@ const getLogListFromLogManager = async (
     'NoTaskLogsError',
     `Logs for task is not found.`,
   );
-  const taskStatus = taskDetail.attempts[taskAttemptId];
+  const taskStatus = taskDetail.data.attempts[Number(taskAttemptId)];
   if (!taskStatus) {
     logger.error(`Failed to find task to retrive log`);
     throw noPodLogsErr;
   }
 
   const nodeIp = taskStatus.containerIp;
-  const podUid = taskStatus.podUid;
+  const podUid = taskStatus.containerId;
 
   let res = await loginLogManager(nodeIp, adminName, adminPassword);
   const token = res.data.token;
@@ -74,7 +74,7 @@ const getLogListFromLogManager = async (
   try {
     const params = {
       token: token,
-      username: taskDetail.username,
+      username: taskDetail.data.username,
       taskrole: taskRoleName,
     };
     params['framework-name'] = encodeName(frameworkName);

--- a/src/rest-server/src/models/v2/job/log.js
+++ b/src/rest-server/src/models/v2/job/log.js
@@ -55,8 +55,8 @@ const getLogListFromLogManager = async (
   );
   const noPodLogsErr = createError(
     'Not Found',
-    'NoTaskLogsError',
-    `Logs for task is not found.`,
+    'NoTaskLogError',
+    `Log of task is not found.`,
   );
   const taskStatus = taskDetail.data.attempts[Number(taskAttemptId)];
   if (!taskStatus) {

--- a/src/rest-server/src/models/v2/job/log.js
+++ b/src/rest-server/src/models/v2/job/log.js
@@ -36,11 +36,16 @@ const loginLogManager = async (nodeIp, username, password) => {
   });
 };
 
-const getLogListFromLogManager = async (frameworkName, podUid, tailMode) => {
+const getLogListFromLogManager = async (
+  frameworkName,
+  jobAttemptId,
+  podUid,
+  tailMode,
+) => {
   const adminName = process.env.LOG_MANAGER_ADMIN_NAME;
   const adminPassword = process.env.LOG_MANAGER_ADMIN_PASSWORD;
 
-  const jobDetail = await job.get(frameworkName);
+  const jobDetail = await job.get(frameworkName, jobAttemptId);
   const noPodLogsErr = createError(
     'Not Found',
     'NoPodLogsError',

--- a/src/rest-server/src/models/v2/job/log.js
+++ b/src/rest-server/src/models/v2/job/log.js
@@ -53,7 +53,7 @@ const getLogListFromLogManager = async (
     taskRoleName,
     Number(taskIndex),
   );
-  const noPodLogsErr = createError(
+  const NoTaskLogErr = createError(
     'Not Found',
     'NoTaskLogError',
     `Log of task is not found.`,
@@ -61,7 +61,7 @@ const getLogListFromLogManager = async (
   const taskStatus = taskDetail.data.attempts[Number(taskAttemptId)];
   if (!taskStatus) {
     logger.error(`Failed to find task to retrive log`);
-    throw noPodLogsErr;
+    throw NoTaskLogErr;
   }
 
   const nodeIp = taskStatus.containerIp;
@@ -84,7 +84,7 @@ const getLogListFromLogManager = async (
     });
   } catch (err) {
     if (err.response && err.response.status === 404) {
-      throw noPodLogsErr;
+      throw NoTaskLogErr;
     }
     throw err;
   }

--- a/src/rest-server/src/models/v2/job/log.js
+++ b/src/rest-server/src/models/v2/job/log.js
@@ -16,8 +16,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 const axios = require('axios');
-const job = require('./k8s');
 const logger = require('@pai/config/logger');
+const task = require('@pai/models/v2/task');
 const createError = require('@pai/utils/error');
 const { encodeName } = require('@pai/models/v2/utils/name');
 
@@ -39,31 +39,33 @@ const loginLogManager = async (nodeIp, username, password) => {
 const getLogListFromLogManager = async (
   frameworkName,
   jobAttemptId,
-  podUid,
+  taskRoleName,
+  taskIndex,
+  taskAttemptId,
   tailMode,
 ) => {
   const adminName = process.env.LOG_MANAGER_ADMIN_NAME;
   const adminPassword = process.env.LOG_MANAGER_ADMIN_PASSWORD;
 
-  const jobDetail = await job.get(frameworkName, jobAttemptId);
+  const taskDetail = await task.get(
+    frameworkName,
+    jobAttemptId,
+    taskRoleName,
+    taskIndex,
+  );
   const noPodLogsErr = createError(
     'Not Found',
-    'NoPodLogsError',
-    `Logs for pod ${podUid} is not found.`,
+    'NoTaskLogsError',
+    `Logs for task is not found.`,
   );
-  let nodeIp;
-  let taskRoleName;
-  for (const [key, taskRole] of Object.entries(jobDetail.taskRoles)) {
-    const status = taskRole.taskStatuses.find(
-      (status) => status.containerId === podUid,
-    );
-    if (!status) {
-      logger.error(`Failed to find pod which has pod uid ${podUid}`);
-      throw noPodLogsErr;
-    }
-    nodeIp = status.containerIp;
-    taskRoleName = key;
+  const taskStatus = taskDetail.attempts[taskAttemptId];
+  if (!taskStatus) {
+    logger.error(`Failed to find task to retrive log`);
+    throw noPodLogsErr;
   }
+
+  const nodeIp = taskStatus.containerIp;
+  const podUid = taskStatus.podUid;
 
   let res = await loginLogManager(nodeIp, adminName, adminPassword);
   const token = res.data.token;
@@ -72,7 +74,7 @@ const getLogListFromLogManager = async (
   try {
     const params = {
       token: token,
-      username: jobDetail.jobStatus.username,
+      username: taskDetail.username,
       taskrole: taskRoleName,
     };
     params['framework-name'] = encodeName(frameworkName);

--- a/src/rest-server/src/models/v2/task.js
+++ b/src/rest-server/src/models/v2/task.js
@@ -79,7 +79,7 @@ const get = async (frameworkName, jobAttemptIndex, taskRoleName, taskIndex) => {
   );
   if (taskRoleStatus) {
     taskStatus = taskRoleStatus.taskStatuses.find(
-      (taskAttemptStatus) => taskAttemptStatus.index === Number(taskIndex),
+      (taskAttemptStatus) => taskAttemptStatus.index === taskIndex,
     );
   }
   if (taskStatus === undefined) {

--- a/src/rest-server/src/models/v2/task.js
+++ b/src/rest-server/src/models/v2/task.js
@@ -79,7 +79,7 @@ const get = async (frameworkName, jobAttemptIndex, taskRoleName, taskIndex) => {
   );
   if (taskRoleStatus) {
     taskStatus = taskRoleStatus.taskStatuses.find(
-      (taskAttemptStatus) => taskAttemptStatus.index === taskIndex,
+      (taskStatus) => taskStatus.index === taskIndex,
     );
   }
   if (taskStatus === undefined) {

--- a/src/rest-server/src/models/v2/task.js
+++ b/src/rest-server/src/models/v2/task.js
@@ -79,7 +79,7 @@ const get = async (frameworkName, jobAttemptIndex, taskRoleName, taskIndex) => {
   );
   if (taskRoleStatus) {
     taskStatus = taskRoleStatus.taskStatuses.find(
-      (taskRoleStatus) => taskRoleStatus.index === taskIndex,
+      (taskAttemptStatus) => taskAttemptStatus.index === Number(taskIndex),
     );
   }
   if (taskStatus === undefined) {

--- a/src/rest-server/src/models/v2/utils/frameworkConverter.js
+++ b/src/rest-server/src/models/v2/utils/frameworkConverter.js
@@ -424,6 +424,7 @@ const convertTaskDetail = async (taskStatus, frameworkName, withoutGetPod) => {
     taskStatus.attemptStatus.podName,
   );
   const completionStatus = taskStatus.attemptStatus.completionStatus;
+  const attemptId = taskStatus.attemptStatus.id;
   return {
     taskIndex: taskStatus.index,
     taskState: convertState(
@@ -433,7 +434,7 @@ const convertTaskDetail = async (taskStatus, frameworkName, withoutGetPod) => {
     containerId: taskStatus.attemptStatus.podUID,
     containerIp: taskStatus.attemptStatus.podHostIP,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/job-attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
   };
 };
@@ -479,7 +480,7 @@ const convertTaskAttempt = async (
     // Job level info
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/pods/${attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/job-attempts/${attemptStatus.id}/pods/${attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)

--- a/src/rest-server/src/models/v2/utils/frameworkConverter.js
+++ b/src/rest-server/src/models/v2/utils/frameworkConverter.js
@@ -451,6 +451,7 @@ const convertTaskAttempt = async (
   frameworkName,
   jobAttemptId,
   taskRoleName,
+  taskIndex,
   ports,
   attemptState, // attempt level info
   attemptStatus,
@@ -490,7 +491,7 @@ const convertTaskAttempt = async (
     // Job level info
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/taskRoles/${taskRoleName}/taskIndex/${attemptStatus.index}/attempts/${attemptStatus.id}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/taskRoles/${taskRoleName}/taskIndex/${taskIndex}/attempts/${attemptStatus.id}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)
@@ -557,6 +558,7 @@ const convertToTaskDetail = async (
       `${userName}~${jobName}`,
       jobAttemptId,
       taskRoleName,
+      taskStatus.index,
       ports,
       lastTaskAttemptState,
       lastTaskAttemptStatus,
@@ -570,6 +572,7 @@ const convertToTaskDetail = async (
         `${userName}~${jobName}`,
         jobAttemptId,
         taskRoleName,
+        taskStatus.index,
         ports,
         taskHistory.status.state,
         taskHistory.status.attemptStatus,

--- a/src/rest-server/src/models/v2/utils/frameworkConverter.js
+++ b/src/rest-server/src/models/v2/utils/frameworkConverter.js
@@ -379,6 +379,7 @@ const convertToJobAttempt = async (framework) => {
         taskRoleStatus.taskStatuses.map(
           async (status) =>
             await convertTaskDetail(
+              taskRoleStatus.name,
               status,
               attemptIndex,
               `${userName}~${jobName}`,
@@ -419,6 +420,7 @@ const convertToJobAttempt = async (framework) => {
 };
 
 const convertTaskDetail = async (
+  taskRoleName,
   taskStatus,
   jobAttemptId,
   frameworkName,
@@ -430,6 +432,7 @@ const convertTaskDetail = async (
     taskStatus.attemptStatus.podName,
   );
   const completionStatus = taskStatus.attemptStatus.completionStatus;
+  const taskAttemptId = taskStatus.attemptStatus.id;
   return {
     taskIndex: taskStatus.index,
     taskState: convertState(
@@ -439,7 +442,7 @@ const convertTaskDetail = async (
     containerId: taskStatus.attemptStatus.podUID,
     containerIp: taskStatus.attemptStatus.podHostIP,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/taskRoles/${taskRoleName}/taskIndex/${taskStatus.index}/attempts/${taskAttemptId}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
   };
 };
@@ -447,6 +450,7 @@ const convertTaskDetail = async (
 const convertTaskAttempt = async (
   frameworkName,
   jobAttemptId,
+  taskRoleName,
   ports,
   attemptState, // attempt level info
   attemptStatus,
@@ -486,7 +490,7 @@ const convertTaskAttempt = async (
     // Job level info
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/pods/${attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${jobAttemptId}/taskRoles/${taskRoleName}/taskIndex/${attemptStatus.index}/attempts/${attemptStatus.id}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)
@@ -552,6 +556,7 @@ const convertToTaskDetail = async (
     await convertTaskAttempt(
       `${userName}~${jobName}`,
       jobAttemptId,
+      taskRoleName,
       ports,
       lastTaskAttemptState,
       lastTaskAttemptStatus,
@@ -564,6 +569,7 @@ const convertToTaskDetail = async (
       await convertTaskAttempt(
         `${userName}~${jobName}`,
         jobAttemptId,
+        taskRoleName,
         ports,
         taskHistory.status.state,
         taskHistory.status.attemptStatus,

--- a/src/rest-server/src/models/v2/utils/frameworkConverter.js
+++ b/src/rest-server/src/models/v2/utils/frameworkConverter.js
@@ -434,7 +434,7 @@ const convertTaskDetail = async (taskStatus, frameworkName, withoutGetPod) => {
     containerId: taskStatus.attemptStatus.podUID,
     containerIp: taskStatus.attemptStatus.podHostIP,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/job-attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${attemptId}/pods/${taskStatus.attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
   };
 };
@@ -480,7 +480,7 @@ const convertTaskAttempt = async (
     // Job level info
     containerPorts,
     containerGpus,
-    containerLog: `/api/v2/jobs/${frameworkName}/job-attempts/${attemptStatus.id}/pods/${attemptStatus.podUID}/logs`,
+    containerLog: `/api/v2/jobs/${frameworkName}/attempts/${attemptStatus.id}/pods/${attemptStatus.podUID}/logs`,
     containerExitCode: completionStatus ? completionStatus.code : null,
     containerExitSpec: completionStatus
       ? generateExitSpec(completionStatus.code)

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -54,6 +54,11 @@ router
   .get(token.check, taskController.get);
 
 router
+  .route('/:frameworkName/attempts/:jobAttemptId/pods/:podUid/logs')
+  /** GET /api/v2/jobs/:frameworkName/attempts/:jobAttemptId/pods/:podUid/logs - Get logs of a pod */
+  .get(token.check, controller.getLogs);
+
+router
   .route('/:frameworkName/executionType')
   /** PUT /api/v2/jobs/:frameworkName/executionType - Start or stop job */
   .put(
@@ -96,11 +101,6 @@ router
   .route('/:frameworkName/events')
   /** GET /api/v2/jobs/:frameworkName/events - Get events of a framework */
   .get(token.check, controller.getEvents);
-
-router
-  .route('/:frameworkName/pods/:podUid/logs')
-  /** GET /api/v2/jobs/:frameworkName/pods/:podUid/logs - Get logs of a pod */
-  .get(token.check, controller.getLogs);
 
 // module exports
 module.exports = router;

--- a/src/rest-server/src/routes/v2/job.js
+++ b/src/rest-server/src/routes/v2/job.js
@@ -54,8 +54,10 @@ router
   .get(token.check, taskController.get);
 
 router
-  .route('/:frameworkName/attempts/:jobAttemptId/pods/:podUid/logs')
-  /** GET /api/v2/jobs/:frameworkName/attempts/:jobAttemptId/pods/:podUid/logs - Get logs of a pod */
+  .route(
+    '/:frameworkName/attempts/:jobAttemptId/taskRoles/:taskRoleName/taskIndex/:taskIndex/attempts/:taskAttemptId/logs',
+  )
+  /** GET /api/v2/jobs/:frameworkName/attempts/:jobAttemptId/taskRoles/:taskRoleName/taskIndex/:taskIndex/attempts/:taskAttemptId/logs - Get logs of a task */
   .get(token.check, controller.getLogs);
 
 router

--- a/src/rest-server/src/utils/error.d.ts
+++ b/src/rest-server/src/utils/error.d.ts
@@ -49,7 +49,7 @@ declare type Code =
     'UnauthorizedUserError' |
     'NoEnoughQuotaError' |
     'NotImplementedError' |
-    'NoPodLogsError' |
+    'NoTaskLogsError' |
     'UnknownError';
 
 declare function createError(status: Status, code: Code, message: string): HttpError;

--- a/src/rest-server/src/utils/error.d.ts
+++ b/src/rest-server/src/utils/error.d.ts
@@ -49,7 +49,7 @@ declare type Code =
     'UnauthorizedUserError' |
     'NoEnoughQuotaError' |
     'NotImplementedError' |
-    'NoTaskLogsError' |
+    'NoTaskLogError' |
     'UnknownError';
 
 declare function createError(status: Status, code: Code, message: string): HttpError;


### PR DESCRIPTION
Change log API from  `/jobs/{job-name}/pods/podUid/logs` to 
 `/jobs/{job-name}/taskRoles/{taskRoleName}/taskIndex/{taskIndex}/attempts/{taskAttemptId}/logs`
 
Previous, get log for each task attempt need to query DB: 
1. get job level info. 2. get job attempt level info 3. get task level info 4. get task attempt level info. 

After this change, only need to get task level info.