### PR TITLE
Change to new log API for task attempts

### DIFF
--- a/src/webportal/src/app/job/job-view/fabric/task-attempt/task-attempt-list.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/task-attempt/task-attempt-list.jsx
@@ -219,12 +219,14 @@ export default class TaskAttemptList extends React.Component {
   showAllLogDialog(logListUrl) {
     const { hideAllLogsDialog } = this.state;
 
-    getContainerLogList(logListUrl).then(({ fullLogUrls, _ }) => {
-      this.setState({
-        hideAllLogsDialog: !hideAllLogsDialog,
-        fullLogUrls: fullLogUrls,
-      });
-    });
+    getContainerLogList(logListUrl)
+      .then(({ fullLogUrls, _ }) => {
+        this.setState({
+          hideAllLogsDialog: !hideAllLogsDialog,
+          fullLogUrls: fullLogUrls,
+        });
+      })
+      .catch(() => this.setState({ hideAllLogsDialog: !hideAllLogsDialog }));
   }
 
   showContainerTailLog(logListUrl, logType) {

--- a/src/webportal/src/app/job/job-view/fabric/task-attempt/task-attempt-list.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/task-attempt/task-attempt-list.jsx
@@ -98,6 +98,9 @@ const LogDialogContent = ({ urlLists }) => {
   for (const p of urlLists) {
     lists.push(p);
   }
+  if (lists.length === 0) {
+    return <Stack>No log file generated or log files be rotated</Stack>;
+  }
   const urlpairs = lists.map((lists, index) => (
     <Stack key={`log-list-${index}`}>
       <Link


### PR DESCRIPTION
The are some dup code under `task-attempt` and `job-detail`. Here just keep them synced, we need to refactor it later. 