### PR TITLE
[alert-handler] use pylon https uri as webportal_uri

### DIFF
--- a/src/alert-manager/build/alert-handler.common.dockerfile
+++ b/src/alert-manager/build/alert-handler.common.dockerfile
@@ -25,4 +25,4 @@ COPY ./src/alert-handler .
 
 RUN yarn install
 
-CMD ["npm", "start"]
+ENTRYPOINT ["npm", "start"]

--- a/src/alert-manager/deploy/alert-manager-configmap.yaml.template
+++ b/src/alert-manager/deploy/alert-manager-configmap.yaml.template
@@ -83,7 +83,7 @@ data:
         send_resolved: true
       {% endif %}
 
-      {% if (receiver["actions"]["email-user"]) is defined and ('email-user' in cluster_cfg["alert-manager"]["actions-available"]) %}
+      {% if (receiver["actions"]["email-user"] is defined) and ('email-user' in cluster_cfg["alert-manager"]["actions-available"]) %}
       {% set template = receiver["actions"]["email-user"]["template"] %}
       - url: 'http://localhost:{{ cluster_cfg["alert-manager"]["alert-handler"]["port"] }}/alert-handler/send-email-to-user/?template={{ template }}'
         send_resolved: false

--- a/src/alert-manager/deploy/alert-manager-configmap.yaml.template
+++ b/src/alert-manager/deploy/alert-manager-configmap.yaml.template
@@ -77,13 +77,13 @@ data:
     {% for receiver in cluster_cfg["alert-manager"]["customized-receivers"] %}
     - name: {{ receiver.name}}
       webhook_configs:
-      {% if receiver["actions"]["email-admin"] is defined %}
+      {% if (receiver["actions"]["email-admin"] is defined) and ('email-admin' in cluster_cfg["alert-manager"]["actions-available"]) %}
       {% set template = receiver["actions"]["email-admin"]["template"] %}
       - url: 'http://localhost:{{ cluster_cfg["alert-manager"]["alert-handler"]["port"] }}/alert-handler/send-email-to-admin/?template={{ template }}'
         send_resolved: true
       {% endif %}
 
-      {% if receiver["actions"]["email-user"] is defined %}
+      {% if (receiver["actions"]["email-user"]) is defined and ('email-user' in cluster_cfg["alert-manager"]["actions-available"]) %}
       {% set template = receiver["actions"]["email-user"]["template"] %}
       - url: 'http://localhost:{{ cluster_cfg["alert-manager"]["alert-handler"]["port"] }}/alert-handler/send-email-to-user/?template={{ template }}'
         send_resolved: false
@@ -91,14 +91,14 @@ data:
           bearer_token: {{ cluster_cfg["alert-manager"]["alert-handler"]["pai-bearer-token"] }}
       {% endif %}
 
-      {% if receiver["actions"]["stop-jobs"] is defined %}
+      {% if (receiver["actions"]["stop-jobs"] is defined) and ('stop-jobs' in cluster_cfg["alert-manager"]["actions-available"]) %}
       - url: 'http://localhost:{{ cluster_cfg["alert-manager"]["alert-handler"]["port"] }}/alert-handler/stop-jobs'
         send_resolved: false
         http_config:
           bearer_token: {{ cluster_cfg["alert-manager"]["alert-handler"]["pai-bearer-token"] }}
       {% endif %}
 
-      {% if receiver["actions"]["tag-jobs"] is defined %}
+      {% if (receiver["actions"]["tag-jobs"] is defined) and ('tag-jobs' in cluster_cfg["alert-manager"]["actions-available"]) %}
       {% for tag in receiver["actions"]["tag-jobs"]["tags"] %}
       - url: 'http://localhost:{{ cluster_cfg["alert-manager"]["alert-handler"]["port"] }}/alert-handler/tag-jobs/{{ tag }}'
         send_resolved: false
@@ -107,7 +107,7 @@ data:
       {% endfor %}
       {% endif %}
 
-      {% if receiver["actions"]["cordon-nodes"] is defined %}
+      {% if (receiver["actions"]["cordon-nodes"] is defined) and ('cordon-nodes' in cluster_cfg["alert-manager"]["actions-available"]) %}
       - url: 'http://localhost:{{ cluster_cfg["alert-manager"]["alert-handler"]["port"] }}/alert-handler/cordon-nodes'
         send_resolved: false
       {% endif %}

--- a/src/alert-manager/deploy/alert-manager-deployment.yaml.template
+++ b/src/alert-manager/deploy/alert-manager-deployment.yaml.template
@@ -67,8 +67,13 @@ spec:
           value: {{ cluster_cfg["cluster"]["common"]["cluster-id"] }}
         - name: REST_SERVER_URI
           value: {{ cluster_cfg['rest-server']['uri'] }}
+{% if 'uri-https' in cluster_cfg['pylon'] %}
+{% set webportal_uri = cluster_cfg['pylon']['uri-https'] %}
+{% else %}
+{% set webportal_uri = cluster_cfg['pylon']['uri'] %}
+{% endif %}
         - name: WEBPORTAL_URI
-          value: {{ cluster_cfg['webportal']['uri'] }}
+          value: {{ webportal_uri }}
         - name: LOG_LEVEL
           value: {{ cluster_cfg["alert-manager"]["alert-handler"]["log-level"] }}
 {% if 'email-admin' in cluster_cfg["alert-manager"]["actions-available"] %}

--- a/src/alert-manager/deploy/alert-manager-deployment.yaml.template
+++ b/src/alert-manager/deploy/alert-manager-deployment.yaml.template
@@ -67,13 +67,12 @@ spec:
           value: {{ cluster_cfg["cluster"]["common"]["cluster-id"] }}
         - name: REST_SERVER_URI
           value: {{ cluster_cfg['rest-server']['uri'] }}
-{% if 'uri-https' in cluster_cfg['pylon'] %}
-{% set webportal_uri = cluster_cfg['pylon']['uri-https'] %}
-{% else %}
-{% set webportal_uri = cluster_cfg['pylon']['uri'] %}
-{% endif %}
         - name: WEBPORTAL_URI
-          value: {{ webportal_uri }}
+{%- if "ssl" in cluster_cfg["pylon"] and cluster_cfg["pylon"]["ssl"] %}
+          value: "{{ cluster_cfg['pylon']['uri-https']}}"
+{%- else %}
+          value: "{{ cluster_cfg['pylon']['uri']}}"
+{%- endif %}
         - name: LOG_LEVEL
           value: {{ cluster_cfg["alert-manager"]["alert-handler"]["log-level"] }}
 {% if 'email-admin' in cluster_cfg["alert-manager"]["actions-available"] %}

--- a/src/alert-manager/src/alert-handler/controllers/mail.js
+++ b/src/alert-manager/src/alert-handler/controllers/mail.js
@@ -130,22 +130,9 @@ const sendEmailToUser = async (req, res) => {
   }
 
   // group alerts by username
-  let userNames;
-  try {
-    userNames = await Promise.all(
-      alerts.map(async (alert) =>
-        getUserNameByJobName(alert.labels.job_name, req.token),
-      ),
-    );
-  } catch (error) {
-    logger.error('alert-handler failed to get user name', error);
-    return res.status(500).json({
-      message: 'alert-handler failed to get user name',
-    });
-  }
-
   const alertsGrouped = {};
-  userNames.map((userName, index) => {
+  alerts.map((alert, index) => {
+    let userName = alert.labels.job_name.split('~')[0];
     if (userName in alertsGrouped) {
       alertsGrouped[userName].push(alerts[index]);
     } else {


### PR DESCRIPTION
- Fix #5124 : webportal uri in alert-template not correct
- refine alert-handler:
    - docker file: use ENTRYPOINT instead of CMD to avoid additional process creation 
    - refine customized receivers render rules : not render non-available actions
    - get username by split `job_name`, no need to query rest server 