### PR TITLE
[Marketplace]Use marketplace images from docker hub

### DIFF
--- a/src/marketplace-restserver/deploy/marketplace-restserver.yaml.template
+++ b/src/marketplace-restserver/deploy/marketplace-restserver.yaml.template
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
       - name: marketplace-restserver
-        image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}marketplace-restserver:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
+        image: docker.io/openpai/pai-marketplace-restserver:v1.2.0
         imagePullPolicy: Always
         env:
         - name: DB_USERNAME

--- a/src/marketplace-webportal/deploy/marketplace-webportal.yaml.template
+++ b/src/marketplace-webportal/deploy/marketplace-webportal.yaml.template
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
       - name: marketplace-webportal
-        image: {{ cluster_cfg["cluster"]["docker-registry"]["prefix"] }}marketplace-webportal:{{ cluster_cfg["cluster"]["docker-registry"]["tag"] }}
+        image: docker.io/openpai/pai-marketplace-restserver:v1.2.0
         imagePullPolicy: Always
         env:
         - name: MARKETPLACE_API_URL


### PR DESCRIPTION
After this change.
Admin can view the marketplace image tag in k8s dashboard, and don't have to build images by `paictl.py` before deploy marketplace.