### PR TITLE
replace deprecated dry-run with dry-run=client

### DIFF
--- a/contrib/api-stress-test/roles/locust/config/templates/start.sh
+++ b/contrib/api-stress-test/roles/locust/config/templates/start.sh
@@ -2,6 +2,6 @@
 
 KUBECONFIG={{kube_config_path}}
 
-kubectl --kubeconfig=${KUBECONFIG} create configmap locust-script-configuration --from-file={{ locust_base_dir }}/configmap/ --dry-run -o yaml | kubectl --kubeconfig=${KUBECONFIG} apply --overwrite=true -f - || exit $?
+kubectl --kubeconfig=${KUBECONFIG} create configmap locust-script-configuration --from-file={{ locust_base_dir }}/configmap/ --dry-run=client -o yaml | kubectl --kubeconfig=${KUBECONFIG} apply --overwrite=true -f - || exit $?
 
 kubectl --kubeconfig=${KUBECONFIG} apply -f {{ locust_base_dir }}/locust-sa.yml

--- a/src/alert-manager/deploy/start.sh.template
+++ b/src/alert-manager/deploy/start.sh.template
@@ -27,7 +27,7 @@ kubectl create configmap alert-templates \
 --from-file={{ template }}-html.ejs=alert-templates/{{ template }}/html.ejs \
 --from-file={{ template }}-subject.ejs=alert-templates/{{ template }}/subject.ejs \
 {% endfor -%}
---dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+--dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 {% endif -%}
 {% endif -%}
 

--- a/src/cluster-configuration/deploy/configmap-create.sh
+++ b/src/cluster-configuration/deploy/configmap-create.sh
@@ -17,8 +17,8 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap  host-configuration --from-file=host-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl create configmap  docker-credentials --from-file=docker-credentials/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl create configmap  gpu-configuration --from-file=gpu-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl create configmap  pai-version --from-file=../../../version/PAI.VERSION --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl create configmap  k8s-version --from-file=../../../version/K8S.VERSION --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  host-configuration --from-file=host-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  docker-credentials --from-file=docker-credentials/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  gpu-configuration --from-file=gpu-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  pai-version --from-file=../../../version/PAI.VERSION --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  k8s-version --from-file=../../../version/K8S.VERSION --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/cluster-configuration/deploy/refresh.sh
+++ b/src/cluster-configuration/deploy/refresh.sh
@@ -23,10 +23,10 @@ echo "refresh secret for k8s cluster"
 kubectl apply -f secret.yaml
 
 echo "refresh host-configuration"
-kubectl create configmap host-configuration --from-file=host-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap host-configuration --from-file=host-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 echo "refresh docker-credentials"
-kubectl create configmap docker-credentials --from-file=docker-credentials/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap docker-credentials --from-file=docker-credentials/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 echo "refresh gpu-configuration"
-kubectl create configmap gpu-configuration --from-file=gpu-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap gpu-configuration --from-file=gpu-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 popd > /dev/null

--- a/src/cluster-configuration/deploy/secret-create.sh
+++ b/src/cluster-configuration/deploy/secret-create.sh
@@ -20,7 +20,7 @@
 pushd $(dirname "$0") > /dev/null
 
 yes | ssh-keygen -t rsa -N "" -f id_rsa -q
-kubectl create secret generic job-ssh-secret --from-file=ssh-privatekey=id_rsa --from-file=ssh-publickey=id_rsa.pub --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create secret generic job-ssh-secret --from-file=ssh-privatekey=id_rsa --from-file=ssh-publickey=id_rsa.pub --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 rm id_rsa id_rsa.pub
 
 popd > /dev/null

--- a/src/dshuttle-master/deploy/delete.sh
+++ b/src/dshuttle-master/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop all dshuttle-master pod first"
 /bin/bash stop.sh || exit $?
 
 echo "Create dshuttle-master-delete configmap for deleting data on the host"
-kubectl create configmap dshuttle-master-delete --from-file=dshuttle-master-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap dshuttle-master-delete --from-file=dshuttle-master-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/dshuttle-master/deploy/start.sh.template
+++ b/src/dshuttle-master/deploy/start.sh.template
@@ -20,9 +20,9 @@
 {%- if cluster_cfg['cluster']['common']['dshuttle'] == 'true' %}
 pushd $(dirname "$0") > /dev/null
 
-kubectl create configmap dshuttle-log-config --from-file=log4j.properties --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap dshuttle-log-config --from-file=log4j.properties --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 kubectl create secret docker-registry dshuttle-regcred --docker-server=dshuttle.azurecr.io \
-        --docker-username={{ cluster_cfg['dshuttle']['registry_username'] }} --docker-password={{ cluster_cfg['dshuttle']['registry_password'] }} --dry-run -o yaml \
+        --docker-username={{ cluster_cfg['dshuttle']['registry_username'] }} --docker-password={{ cluster_cfg['dshuttle']['registry_password'] }} --dry-run=client -o yaml \
         | kubectl apply --overwrite=true -f - || exit $?
 kubectl apply --overwrite=true -f dshuttle-config.yaml || exit $?
 kubectl apply --overwrite=true -f dshuttle-service.yaml || exit $?

--- a/src/dshuttle-worker/deploy/delete.sh
+++ b/src/dshuttle-worker/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop all dshuttle-worker pod first"
 /bin/bash stop.sh || exit $?
 
 echo "Create dshuttle-wroker-delete configmap for deleting data on the host"
-kubectl create configmap dshuttle-worker-delete --from-file=dshuttle-worker-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap dshuttle-worker-delete --from-file=dshuttle-worker-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/grafana/deploy/configmap-create.sh
+++ b/src/grafana/deploy/configmap-create.sh
@@ -27,4 +27,4 @@ done
 # create configmap
 for i in `find grafana-configuration/ -type f -regex ".*json" ` ; do
     echo --from-file=$i
-done | xargs kubectl create configmap grafana-configuration --dry-run -o yaml | kubectl apply -f - || exit $?
+done | xargs kubectl create configmap grafana-configuration --dry-run=client -o yaml | kubectl apply -f - || exit $?

--- a/src/grafana/deploy/refresh.sh
+++ b/src/grafana/deploy/refresh.sh
@@ -20,7 +20,7 @@
 pushd $(dirname "$0") > /dev/null
 
 echo "refresh grafana-configuration"
-kubectl create configmap grafana-configuration --from-file=grafana-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap grafana-configuration --from-file=grafana-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 

--- a/src/hadoop-batch-job/deploy/configmap-create.sh
+++ b/src/hadoop-batch-job/deploy/configmap-create.sh
@@ -17,4 +17,4 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap hadoop-configuration --from-file=hadoop-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-configuration --from-file=hadoop-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/hadoop-batch-job/deploy/refresh.sh
+++ b/src/hadoop-batch-job/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 
 echo "refresh hadoop-configuration"
-kubectl create configmap hadoop-configuration --from-file=hadoop-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap hadoop-configuration --from-file=hadoop-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 if kubectl get job | grep -q "batch-job-hadoop"; then
     kubectl delete job batch-job-hadoop || exit $?

--- a/src/hadoop-data-node/deploy/configmap-create.sh
+++ b/src/hadoop-data-node/deploy/configmap-create.sh
@@ -17,4 +17,4 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap hadoop-data-node-configuration --from-file=hadoop-data-node-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-data-node-configuration --from-file=hadoop-data-node-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/hadoop-data-node/deploy/delete.sh
+++ b/src/hadoop-data-node/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop all hadoop-data-node pod first"
 /bin/bash stop.sh || exit $?
 
 echo "Create hadoop-data-node-delete configmap for deleting data on the host"
-kubectl create configmap hadoop-data-node-delete --from-file=hadoop-data-node-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-data-node-delete --from-file=hadoop-data-node-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/hadoop-data-node/deploy/refresh.sh
+++ b/src/hadoop-data-node/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 
 echo "refresh hadoop-data-node-configuration"
-kubectl create configmap hadoop-data-node-configuration --from-file=hadoop-data-node-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap hadoop-data-node-configuration --from-file=hadoop-data-node-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 popd > /dev/null

--- a/src/hadoop-jobhistory/deploy/configmap-create.sh
+++ b/src/hadoop-jobhistory/deploy/configmap-create.sh
@@ -17,4 +17,4 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap hadoop-jobhistory-configuration --from-file=hadoop-jobhistory-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-jobhistory-configuration --from-file=hadoop-jobhistory-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/hadoop-jobhistory/deploy/delete.sh
+++ b/src/hadoop-jobhistory/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop hadoop jobhistory first"
 /bin/bash stop.sh || exit $?
 
 echo "Create hadoop-jobhistory-delete configmap for deleting data on the host"
-kubectl create configmap hadoop-jobhistory-delete --from-file=hadoop-jobhistory-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-jobhistory-delete --from-file=hadoop-jobhistory-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/hadoop-jobhistory/deploy/refresh.sh
+++ b/src/hadoop-jobhistory/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 
 echo "refresh hadoop-jobhistory-configuration"
-kubectl create configmap hadoop-jobhistory-configuration --from-file=hadoop-jobhistory-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap hadoop-jobhistory-configuration --from-file=hadoop-jobhistory-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 popd > /dev/null

--- a/src/hadoop-name-node/deploy/configmap-create.sh
+++ b/src/hadoop-name-node/deploy/configmap-create.sh
@@ -17,4 +17,4 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap hadoop-name-node-configuration --from-file=hadoop-name-node-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-name-node-configuration --from-file=hadoop-name-node-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/hadoop-name-node/deploy/delete.sh
+++ b/src/hadoop-name-node/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop.sh to stop all hadoop service first"
 /bin/bash stop.sh || exit $?
 
 echo "Create hadoop-name-node-delete configmap for deleting data on the host"
-kubectl create configmap hadoop-name-node-delete --from-file=hadoop-name-node-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-name-node-delete --from-file=hadoop-name-node-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/hadoop-name-node/deploy/refresh.sh
+++ b/src/hadoop-name-node/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 
 echo "refrash hadoop-name-node-configuration"
-kubectl create configmap hadoop-name-node-configuration --from-file=hadoop-name-node-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap hadoop-name-node-configuration --from-file=hadoop-name-node-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 popd > /dev/null

--- a/src/hadoop-node-manager/deploy/configmap-create.sh
+++ b/src/hadoop-node-manager/deploy/configmap-create.sh
@@ -17,4 +17,4 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap hadoop-node-manager-configuration --from-file=hadoop-node-manager-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-node-manager-configuration --from-file=hadoop-node-manager-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/hadoop-node-manager/deploy/delete.sh
+++ b/src/hadoop-node-manager/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop hadoop node manager first"
 /bin/bash stop.sh || exit $?
 
 echo "Create hadoop-node-manager-delete configmap for deleting data on the host"
-kubectl create configmap hadoop-node-manager-delete --from-file=hadoop-node-manager-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-node-manager-delete --from-file=hadoop-node-manager-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/hadoop-node-manager/deploy/refresh.sh
+++ b/src/hadoop-node-manager/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 
 echo "refresh hadoop-node-manager-configuration"
-kubectl create configmap hadoop-node-manager-configuration --from-file=hadoop-node-manager-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap hadoop-node-manager-configuration --from-file=hadoop-node-manager-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 

--- a/src/hadoop-resource-manager/deploy/configmap-create.sh
+++ b/src/hadoop-resource-manager/deploy/configmap-create.sh
@@ -17,8 +17,8 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap hadoop-resource-manager-configuration --from-file=hadoop-resource-manager-configuration/ --dry-run -o yaml| kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-resource-manager-configuration --from-file=hadoop-resource-manager-configuration/ --dry-run=client -o yaml| kubectl apply --overwrite=true -f - || exit $?
 
 if ! kubectl get configmap | grep -q "exclude-file"; then
-    kubectl create configmap exclude-file --from-literal=nodes= --dry-run -o yaml| kubectl apply --overwrite=true -f - || exit $?
+    kubectl create configmap exclude-file --from-literal=nodes= --dry-run=client -o yaml| kubectl apply --overwrite=true -f - || exit $?
 fi

--- a/src/hadoop-resource-manager/deploy/delete.sh
+++ b/src/hadoop-resource-manager/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop.sh to stop hadoop resource manager first"
 /bin/bash stop.sh || exit $?
 
 echo "Create hadoop-delete configmap for deleting data on the host"
-kubectl create configmap hadoop-resource-manager-delete --from-file=hadoop-resource-manager-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap hadoop-resource-manager-delete --from-file=hadoop-resource-manager-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/hadoop-resource-manager/deploy/refresh.sh
+++ b/src/hadoop-resource-manager/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 
 echo "refresh hadoop-resource-manager-configuration"
-kubectl create configmap hadoop-resource-manager-configuration --from-file=hadoop-resource-manager-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap hadoop-resource-manager-configuration --from-file=hadoop-resource-manager-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 

--- a/src/openpai-runtime/deploy/refresh.sh
+++ b/src/openpai-runtime/deploy/refresh.sh
@@ -19,6 +19,6 @@
 
 pushd $(dirname "$0") > /dev/null
 
-kubectl create configmap runtime-exit-spec-configuration --from-file=runtime-exit-spec.yaml --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap runtime-exit-spec-configuration --from-file=runtime-exit-spec.yaml --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 popd > /dev/null

--- a/src/openpai-runtime/deploy/start.sh
+++ b/src/openpai-runtime/deploy/start.sh
@@ -20,6 +20,6 @@
 pushd $(dirname "$0") > /dev/null
 
 kubectl apply --overwrite=true -f rbac.yaml || exit $?
-kubectl create configmap runtime-exit-spec-configuration --from-file=runtime-exit-spec.yaml --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap runtime-exit-spec-configuration --from-file=runtime-exit-spec.yaml --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 popd > /dev/null

--- a/src/prometheus/deploy/delete.sh
+++ b/src/prometheus/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop service first"
 /bin/bash stop.sh || exit $?
 
 echo "Create prometheus-delete configmap for deleting data on the host"
-kubectl create configmap prometheus-delete --from-file=prometheus-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap prometheus-delete --from-file=prometheus-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/prometheus/deploy/start.sh
+++ b/src/prometheus/deploy/start.sh
@@ -21,8 +21,8 @@
 
 pushd $(dirname "$0") > /dev/null
 
-kubectl create configmap prometheus-alert --from-file=alerting --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
-kubectl create configmap prometheus-record --from-file=recording --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap prometheus-alert --from-file=alerting --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap prometheus-record --from-file=recording --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 kubectl apply --overwrite=true -f prometheus-configmap.yaml || exit $?
 kubectl apply --overwrite=true -f rbac.yaml || exit $?
 kubectl apply --overwrite=true -f prometheus-deployment.yaml || exit $?

--- a/src/pylon/deploy/start.sh.template
+++ b/src/pylon/deploy/start.sh.template
@@ -25,11 +25,11 @@ mkdir -p https-config/
 cp {{ cluster_cfg["pylon"]["ssl"]["crt_path"] }} https-config/
 cp {{ cluster_cfg["pylon"]["ssl"]["key_path"] }} https-config/
 
-kubectl create configmap https-config --from-file=https-config/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap https-config --from-file=https-config/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 {% endif %}
 
-kubectl create configmap pylon-config --from-file=pylon-config/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap pylon-config --from-file=pylon-config/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 kubectl apply --overwrite=true -f pylon.yaml || exit $?
 

--- a/src/rest-server/deploy/configmap-create.sh.template
+++ b/src/rest-server/deploy/configmap-create.sh.template
@@ -20,15 +20,15 @@
 pushd $(dirname "$0") > /dev/null
 
 {% if cluster_cfg['authentication']['OIDC']  %}
-kubectl create configmap  auth-configuration --from-file=auth-configmap/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  auth-configuration --from-file=auth-configmap/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 {% endif %}
 
-kubectl create configmap  group-configuration --from-file=group-configmap/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  group-configuration --from-file=group-configmap/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 {% if cluster_cfg["cluster"]["common"]["cluster-type"] == "yarn" %}
-kubectl create configmap  job-exit-spec-configuration --from-file=job-exit-spec-config/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  job-exit-spec-configuration --from-file=job-exit-spec-config/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 {% else %}
-kubectl create configmap  k8s-job-exit-spec-configuration --from-file=k8s-job-exit-spec-config/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap  k8s-job-exit-spec-configuration --from-file=k8s-job-exit-spec-config/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 {% endif %}
 
 popd > /dev/null

--- a/src/rest-server/deploy/secret-create.sh
+++ b/src/rest-server/deploy/secret-create.sh
@@ -25,11 +25,11 @@ if [[ ! $(kubectl get namespace | grep pai-storage) ]]; then
 fi
 
 if [[ ! $(kubectl get secrets --namespace pai-storage | grep storage-config) ]]; then
-    kubectl create secret generic storage-config -n pai-storage --from-literal=empty='{"name":"empty","default":false}' --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+    kubectl create secret generic storage-config -n pai-storage --from-literal=empty='{"name":"empty","default":false}' --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 fi
 
 if [[ ! $(kubectl get secrets --namespace pai-storage | grep storage-server) ]]; then
-    kubectl create secret generic storage-server -n pai-storage --from-literal=empty='{"spn":"empty","type":"other"}' --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+    kubectl create secret generic storage-server -n pai-storage --from-literal=empty='{"spn":"empty","type":"other"}' --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 fi
 
 popd > /dev/null

--- a/src/storage-manager/deploy/start.sh.template
+++ b/src/storage-manager/deploy/start.sh.template
@@ -26,7 +26,7 @@ deploy=1
 {% endfor %}
 
 if [[ $deploy == 1 ]]; then
-    kubectl create configmap  storage-configuration --from-file=conf/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+    kubectl create configmap  storage-configuration --from-file=conf/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
     kubectl apply --overwrite=true -f storage-manager.yaml || exit $?
 
     # Wait until the service is ready.

--- a/src/yarn-frameworklauncher/deploy/configmap-create.sh
+++ b/src/yarn-frameworklauncher/deploy/configmap-create.sh
@@ -17,6 +17,6 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap yarn-frameworklauncher-configmap --from-file=yarn-frameworklauncher-configuration/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap yarn-frameworklauncher-configmap --from-file=yarn-frameworklauncher-configuration/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
-kubectl create configmap yarn-frameworklauncher-delete --from-file=yarn-frameworklauncher-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap yarn-frameworklauncher-delete --from-file=yarn-frameworklauncher-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?

--- a/src/yarn-frameworklauncher/deploy/delete.sh
+++ b/src/yarn-frameworklauncher/deploy/delete.sh
@@ -24,7 +24,7 @@ echo "Call stop script to stop all service first"
 /bin/bash stop.sh || exit $?
 
 echo "Create yarn-frameworklauncher-delete configmap for deleting data on the host"
-kubectl create configmap yarn-frameworklauncher-delete --from-file=yarn-frameworklauncher-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap yarn-frameworklauncher-delete --from-file=yarn-frameworklauncher-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?

--- a/src/yarn-frameworklauncher/deploy/refresh.sh
+++ b/src/yarn-frameworklauncher/deploy/refresh.sh
@@ -21,7 +21,7 @@ pushd $(dirname "$0") > /dev/null
 
 echo "refresh the configmap of launcher"
 
-kubectl create configmap yarn-frameworklauncher-configmap --from-file=yarn-frameworklauncher-configuration/ --dry-run -o yaml | kubectl apply -f - || exit $?
+kubectl create configmap yarn-frameworklauncher-configmap --from-file=yarn-frameworklauncher-configuration/ --dry-run=client -o yaml | kubectl apply -f - || exit $?
 
 
 popd > /dev/null

--- a/src/zookeeper/deploy/configmap-create.sh
+++ b/src/zookeeper/deploy/configmap-create.sh
@@ -17,4 +17,4 @@
 # DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-kubectl create configmap zk-configuration --from-file=zk-configuration/ --dry-run -o yaml| kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap zk-configuration --from-file=zk-configuration/ --dry-run=client -o yaml| kubectl apply --overwrite=true -f - || exit $?

--- a/src/zookeeper/deploy/delete.sh
+++ b/src/zookeeper/deploy/delete.sh
@@ -23,7 +23,7 @@ echo "Call stop to stop all hadoop service first"
 /bin/bash stop.sh || exit $?
 
 echo "Create hadoop-delete configmap for deleting data on the host"
-kubectl create configmap zookeeper-delete --from-file=zookeeper-delete/ --dry-run -o yaml | kubectl apply --overwrite=true -f - || exit $?
+kubectl create configmap zookeeper-delete --from-file=zookeeper-delete/ --dry-run=client -o yaml | kubectl apply --overwrite=true -f - || exit $?
 
 echo "Create cleaner daemon"
 kubectl apply --overwrite=true -f delete.yaml || exit $?


### PR DESCRIPTION
`--dry-run` causes lots of deprecation warnings when we start services.
This flag is used to preview the object that would be sent to your cluster, without really submitting it.
This can be exactly replaced by `--dry-run=client`.