### PR TITLE
make de webportal bind to all ip addresses

### DIFF
--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -376,7 +376,7 @@ const config = (env, argv) => ({
   devServer: {
     contentBase: path.resolve(__dirname, '..', 'dist'),
     port: 9286,
-    host: '0.0.0.0'
+    host: '0.0.0.0',
   },
   optimization: {
     moduleIds: 'hashed',

--- a/src/webportal/config/webpack.common.js
+++ b/src/webportal/config/webpack.common.js
@@ -376,6 +376,7 @@ const config = (env, argv) => ({
   devServer: {
     contentBase: path.resolve(__dirname, '..', 'dist'),
     port: 9286,
+    host: '0.0.0.0'
   },
   optimization: {
     moduleIds: 'hashed',


### PR DESCRIPTION
If have not` host: '0.0.0.0'`, ` yarn dev `-> the page `IP:9286` show not conneted.