### PR TITLE
Fix remove nodes doc issue

### DIFF
--- a/docs/manual/cluster-admin/how-to-add-and-remove-nodes.md
+++ b/docs/manual/cluster-admin/how-to-add-and-remove-nodes.md
@@ -6,7 +6,19 @@ OpenPAI doesn't support changing master nodes, thus, only the solution of adding
 
 ### Preparation
 
-To add worker nodes, please check if the nodes meet [the requirements for worker machines](./installation-guide.md#installation-requirements).
+To add worker nodes, please check if the nodes meet the following requirements:
+
+  - Ubuntu 16.04 (18.04 should work, but not fully tested.)
+  - Assign each node a **static IP address**, and make sure nodes can communicate with each other. 
+  - The nodes can access internet, especially need to have access to the docker hub registry service or its mirror. Deployment process will pull Docker images.
+  - SSH service is enabled and share the same username/password with current master/worker machines and have sudo privilege.
+  - (For CPU workers, you can ignore this requirement) **Have GPU and GPU driver is installed.**  You may use [a command](./installation-faqs-and-troubleshooting.md#how-to-check-whether-the-gpu-driver-is-installed) to check it. Refer to [the installation guidance](./installation-faqs-and-troubleshooting.md#how-to-install-gpu-driver) in FAQs if the driver is not successfully installed. If you are wondering which version of GPU driver you should use, please also refer to [FAQs](./installation-faqs-and-troubleshooting.md#which-version-of-nvidia-driver-should-i-install).
+  - **Docker is installed.**  You may use command `docker --version` to check it. Refer to [docker's installation guidance](https://docs.docker.com/engine/install/ubuntu/) if it is not successfully installed.
+  - (For CPU workers, you can ignore this requirement) **[nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime) or other device runtime is installed. And be configured as the default runtime of docker. Please configure it in [docker-config-file](https://docs.docker.com/config/daemon/#configure-the-docker-daemon), because kubespray will overwrite systemd's env.**
+    - You may use command `sudo docker run nvidia/cuda:10.0-base nvidia-smi` to check it. This command should output information of available GPUs if it is setup properly.
+    - Refer to [the installation guidance](./installation-faqs-and-troubleshooting.md#how-to-install-nvidia-container-runtime) if the it is not successfully set up.
+  - OpenPAI reserves memory and CPU for service running, so make sure there are enough resource to run machine learning jobs. Check hardware requirements for details.
+  - Dedicated servers for OpenPAI. OpenPAI manages all CPU, memory and GPU resources of servers. If there is any other workload, it may cause unknown problem due to insufficient resource.
 
 Log in to your dev box machine, find [the pre-kept folder `~/pai-deploy`](./installation-guide.md#keep-a-folder).
 

--- a/docs/manual/cluster-admin/how-to-add-and-remove-nodes.md
+++ b/docs/manual/cluster-admin/how-to-add-and-remove-nodes.md
@@ -6,19 +6,7 @@ OpenPAI doesn't support changing master nodes, thus, only the solution of adding
 
 ### Preparation
 
-To add worker nodes, please check if the nodes meet the following requirements:
-
-  - Ubuntu 16.04 (18.04 should work, but not fully tested.)
-  - Assign each node a **static IP address**, and make sure nodes can communicate with each other. 
-  - The nodes can access internet, especially need to have access to the docker hub registry service or its mirror. Deployment process will pull Docker images.
-  - SSH service is enabled and share the same username/password with current master/worker machines and have sudo privilege.
-  - (For CPU workers, you can ignore this requirement) **Have GPU and GPU driver is installed.**  You may use [a command](./installation-faqs-and-troubleshooting.md#how-to-check-whether-the-gpu-driver-is-installed) to check it. Refer to [the installation guidance](./installation-faqs-and-troubleshooting.md#how-to-install-gpu-driver) in FAQs if the driver is not successfully installed. If you are wondering which version of GPU driver you should use, please also refer to [FAQs](./installation-faqs-and-troubleshooting.md#which-version-of-nvidia-driver-should-i-install).
-  - **Docker is installed.**  You may use command `docker --version` to check it. Refer to [docker's installation guidance](https://docs.docker.com/engine/install/ubuntu/) if it is not successfully installed.
-  - (For CPU workers, you can ignore this requirement) **[nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime) or other device runtime is installed. And be configured as the default runtime of docker. Please configure it in [docker-config-file](https://docs.docker.com/config/daemon/#configure-the-docker-daemon), because kubespray will overwrite systemd's env.**
-    - You may use command `sudo docker run nvidia/cuda:10.0-base nvidia-smi` to check it. This command should output information of available GPUs if it is setup properly.
-    - Refer to [the installation guidance](./installation-faqs-and-troubleshooting.md#how-to-install-nvidia-container-runtime) if the it is not successfully set up.
-  - OpenPAI reserves memory and CPU for service running, so make sure there are enough resource to run machine learning jobs. Check hardware requirements for details.
-  - Dedicated servers for OpenPAI. OpenPAI manages all CPU, memory and GPU resources of servers. If there is any other workload, it may cause unknown problem due to insufficient resource.
+To add worker nodes, please check if the nodes meet [the requirements for worker machines](./installation-guide.md#installation-requirements).
 
 Log in to your dev box machine, find [the pre-kept folder `~/pai-deploy`](./installation-guide.md#keep-a-folder).
 
@@ -107,36 +95,28 @@ all:
 Go into folder `~/pai-deploy/kubespray/`, run:
 
 ```bash
-ansible-playbook -i inventory/pai/hosts.yml upgrade-cluster.yml --become --become-user=root  --limit=a,b -e "@inventory/pai/openpai.yml"
+ansible-playbook -i inventory/pai/hosts.yml scale.yml -b --become-user=root -e "node=a,b" -e "@inventory/pai/openpai.yml"
 ```
+
+The nodes to remove are specified with `-e` flag.
 
 ### Update OpenPAI Service Configuration
 
 Find your [service configuration file `layout.yaml` and `services-configuration.yaml`](./basic-management-operations.md#pai-service-management-and-paictl) in  `~/pai-deploy/cluster-cfg`.
 
-- Add the new node into `layout.yaml`
+- Add the new node into `machine-list` field in `layout.yaml`
 
 ```yaml
-...
-
 machine-list:
+  - hostname: a
+    hostip: x.x.x.x
+    machine-type: xxx-sku
+    pai-worker: "true"
 
-    ...
-
-    - hostname: a
-      hostip: x.x.x.x
-      machine-type: sku
-      nodename: a
-      k8s-role: worker
-      pai-worker: "true"
-
-
-    - hostname: b
-      hostip: x.x.x.x
-      machine-type: sku
-      nodename: b
-      k8s-role: worker
-      pai-worker: "true"
+  - hostname: b
+    hostip: x.x.x.x
+    machine-type: xxx-sku
+    pai-worker: "true"
 ```
 
 - You should modify the hived scheduler setting in `services-configuration.yaml` properly. Please refer to [how to set up virtual clusters](./how-to-set-up-virtual-clusters.md) and the [hived scheduler doc](https://github.com/microsoft/hivedscheduler/blob/master/doc/user-manual.md) for details. 
@@ -155,11 +135,14 @@ If you have configured any PV/PVC storage, please confirm the added worker node 
 
 Please refer to the operation of add nodes. They are very similar.
 
-First, modify `hosts.yml` accordingly, then go into `~/pai-deploy/kubespray/`, run
+To remove nodes from the cluster, there is no need to modify `hosts.yml`. 
+Go into `~/pai-deploy/kubespray/`, run
 
 ```bash
-ansible-playbook -i inventory/mycluster/hosts.yml upgrade-cluster.yml --become --become-user=root  --limit=a,b -e "@inventory/mycluster/openpai.yml"
+ansible-playbook -i inventory/pai/hosts.yml remove-node.yml -b --become-user=root -e "node=a,b" -e "@inventory/pai/openpai.yml"
 ``` 
+
+The nodes to remove are specified with `-e` flag.
 
 Modify the `layout.yaml` and `services-configuration.yaml`.
 


### PR DESCRIPTION
changes:
- remove node: no need to modify `hosts.yml`, as introduced in  [kubespray](https://github.com/kubernetes-sigs/kubespray/blob/release-2.11/docs/getting-started.md#remove-nodes)
- use `scale.yml`, `remove-node.yml` instead of `update-cluster.yml`
- `--limit` flag is no longer recommended in kubespray 2.11, we can use twice `-e` to specify the nodes to modify

Future refactor about using `layout.yaml` instead of `hosts.yaml` will be discussed separately.
