### PR TITLE
use vc{index} as vc name instead of sku name

### DIFF
--- a/contrib/kubespray/quick-start/services-configuration.yaml.template
+++ b/contrib/kubespray/quick-start/services-configuration.yaml.template
@@ -90,7 +90,7 @@ hivedscheduler:
         {%- if loop.index0 == 0 %}
         default:
         {%- else %}
-        {{ sku_name }}:
+        vc{{loop.index0 }}:
         {%- endif %}
           virtualCells:
           - cellType: {{ sku_name }}-NODE-POOL.{{ sku_name }}-NODE


### PR DESCRIPTION
###  Background
Current (master) vc name generation logic:
- name the first vc as default vc
- name the others with corresponding sku name

### Constaints
VC name has many constraints:
* it is used by [hiveD](https://github.com/microsoft/pai/blob/master/src/hivedscheduler/deploy/hivedscheduler.yaml.template#L65) to create a StateFulSet, the constraints is [DNS subdomain](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
* it is used by to generate a group name, the constraint is : [rest-server](https://github.com/microsoft/pai/blob/master/src/rest-server/src/utils/manager/group/group.js#L23)

To follow these 2 conventions, only lowercase alphanumeric characters are allowed.

### Target
To avoid bringing these constraints to the naming of `sku`, we should not generate `vc` name with sku name.