### PR TITLE
fix kubeconfig issue

### DIFF
--- a/contrib/kubespray/quick-start-service.sh
+++ b/contrib/kubespray/quick-start-service.sh
@@ -8,9 +8,6 @@ CLUSTER_CONFIG="$PWD/config/config.yaml"
 echo "layout config file path: ${LAYOUT}"
 echo "cluster config file path: ${CLUSTER_CONFIG}"
 
-echo "Generating services configurations..."
-sudo python3 script/openpai_generator.py -l ${LAYOUT} -c ${CLUSTER_CONFIG} -o ${HOME}/pai-deploy/cluster-cfg
-
 echo "Saving layout.yaml & config.yaml to ${HOME}/pai-deploy/cluster-cfg"
 cp ${LAYOUT} ${HOME}/pai-deploy/cluster-cfg
 cp ${CLUSTER_CONFIG} ${HOME}/pai-deploy/cluster-cfg

--- a/contrib/kubespray/script/start-service-in-dev-box.sh
+++ b/contrib/kubespray/script/start-service-in-dev-box.sh
@@ -3,10 +3,14 @@ set -e
 
 echo "pai" > cluster-id
 
+# assume the workdir is pai
+echo "Generating services configurations..."
+sudo python3 script/openpai_generator.py -l ./contrib/kubespray/config/layout.yaml -c ./contrib/kubespray/config/config.yaml -o /cluster-configuration
+
 echo "Pushing cluster config to k8s..." 
-/mnt/pai/paictl.py config push -p /cluster-configuration -m service < cluster-id
+./paictl.py config push -p /cluster-configuration -m service < cluster-id
 
 echo "Starting OpenPAI service..."
-/mnt/pai/paictl.py service start < cluster-id
+./paictl.py service start < cluster-id
 
 rm cluster-id

--- a/contrib/kubespray/script/start-service-in-dev-box.sh
+++ b/contrib/kubespray/script/start-service-in-dev-box.sh
@@ -5,7 +5,7 @@ echo "pai" > cluster-id
 
 # assume the workdir is pai
 echo "Generating services configurations..."
-python3 script/openpai_generator.py -l ./contrib/kubespray/config/layout.yaml -c ./contrib/kubespray/config/config.yaml -o /cluster-configuration
+python3 ./contrib/kubespray/script/openpai_generator.py -l ./contrib/kubespray/config/layout.yaml -c ./contrib/kubespray/config/config.yaml -o /cluster-configuration
 
 echo "Pushing cluster config to k8s..." 
 ./paictl.py config push -p /cluster-configuration -m service < cluster-id

--- a/contrib/kubespray/script/start-service-in-dev-box.sh
+++ b/contrib/kubespray/script/start-service-in-dev-box.sh
@@ -5,7 +5,7 @@ echo "pai" > cluster-id
 
 # assume the workdir is pai
 echo "Generating services configurations..."
-sudo python3 script/openpai_generator.py -l ./contrib/kubespray/config/layout.yaml -c ./contrib/kubespray/config/config.yaml -o /cluster-configuration
+python3 script/openpai_generator.py -l ./contrib/kubespray/config/layout.yaml -c ./contrib/kubespray/config/config.yaml -o /cluster-configuration
 
 echo "Pushing cluster config to k8s..." 
 ./paictl.py config push -p /cluster-configuration -m service < cluster-id


### PR DESCRIPTION
Fix the second issue in #5231 
The generation of hived config relies on k8s api & kubeconfig may not be correctly set on the dev-box machine. So this should be done in the container.