### PR TITLE
add alert for GPU low perf state

### DIFF
--- a/docs/manual/cluster-admin/troubleshooting.md
+++ b/docs/manual/cluster-admin/troubleshooting.md
@@ -95,13 +95,13 @@ kubectl uncordon <node name>
 
 ### NodeGpuLowPerfState
 This is a kind of alert from alert manager.
-It means the nviida cards from related node downgrade into low peroformance state unexpectedly.
-To fix this, plean run following commands:
+It means the nvidia cards from related node downgrade into low peroformance state unexpectedly.
+To fix this, please run following commands:
 ```bash
 sudo nvidia-smi -pm ENABLED -i <gpu-card-id>
 sudo nvidia-smi -ac <gpu-supported-memory-clock>,<gpu-supported-clock> -i <gpu-card-id>
 ```
-You can get the supportd clock by `sudo nvidia-smi -q -d SUPPORTED_CLOCKS`
+You can get the supported clock by `sudo nvidia-smi -q -d SUPPORTED_CLOCKS`
 
 ### Cannot See Utilization Information.
 

--- a/docs/manual/cluster-admin/troubleshooting.md
+++ b/docs/manual/cluster-admin/troubleshooting.md
@@ -93,6 +93,16 @@ After the problem is resolved, you can uncordon the node manually with the follo
 kubectl uncordon <node name>
 ```
 
+### NodeGpuLowPerfState
+This is a kind of alert from alert manager.
+It means the nviida cards from related node downgrade into low peroformance state unexpectedly.
+To fix this, plean run following commands:
+```bash
+sudo nvidia-smi -pm ENABLED -i <gpu-card-id>
+sudo nvidia-smi -ac <gpu-supported-memory-clock>,<gpu-supported-clock> -i <gpu-card-id>
+```
+You can get the supportd clock by `sudo nvidia-smi -q -d SUPPORTED_CLOCKS`
+
 ### Cannot See Utilization Information.
 
 If you cannot see utilization information (e.g. GPU, CPU, and network usage) in cluster, please check if the service `prometheus`, `grafana`, `job-exporter`, and `node-exporter` are working.

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -93,12 +93,7 @@ def gen_nvidia_gpu_memory_leak_counter():
 def gen_nvidia_gpu_performance_state():
     return GaugeMetricFamily("nvidiasmi_performance_state",
             "gpu performance state",
-            labels=["minor_number"])
-
-def gen_nvidia_gpu_clocks_throttle_reasons():
-    return GaugeMetricFamily("nvidiasmi_clocks_throttle_reasons",
-            "gpu clocks_throttle_reasons",
-            labels=["minor_number"])
+            labels=["minor_number", "clocks_throttle_reasons"])
 
 # AMD GPU metrics
 def gen_amd_gpu_util_gauge():
@@ -410,7 +405,6 @@ class GpuCollector(Collector):
         nvidia_ecc_errors = gen_nvidia_gpu_ecc_counter()
         nvidia_mem_leak = gen_nvidia_gpu_memory_leak_counter()
         nvidia_performance_state = gen_nvidia_gpu_performance_state()
-        nvidia_clocks_throttle_reasons = gen_nvidia_gpu_clocks_throttle_reasons()
         external_process = gen_gpu_used_by_external_process_counter()
         zombie_container = gen_gpu_used_by_zombie_container_counter()
 
@@ -428,10 +422,7 @@ class GpuCollector(Collector):
                 nvidia_gpu_temp.add_metric([minor], info.temperature)
             nvidia_ecc_errors.add_metric([node_name, minor, "single"], info.ecc_errors.single)
             nvidia_ecc_errors.add_metric([node_name, minor, "double"], info.ecc_errors.double)
-            nvidia_performance_state.add_metric([minor], info.performance_state)
-
-            if info.clocks_throttle_reasons:
-                nvidia_clocks_throttle_reasons.add_metric([minor], info.performance_state.join(","))
+            nvidia_performance_state.add_metric([minor, ",".join(info.clocks_throttle_reasons)], info.performance_state)
 
             # TODO: this piece of code seems not corret, gpu_mem_util is
             # a percentage number but mem_leak_thrashold is memory size. Need to fix it.
@@ -467,7 +458,7 @@ class GpuCollector(Collector):
         return [
             nvidia_core_utils, nvidia_mem_utils, nvidia_ecc_errors,
             nvidia_mem_leak, external_process, zombie_container,
-            nvidia_gpu_temp, gpu_core_util, gpu_mem_util
+            nvidia_gpu_temp, gpu_core_util, gpu_mem_util, nvidia_performance_state
         ]
 
     @staticmethod

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -90,6 +90,16 @@ def gen_nvidia_gpu_memory_leak_counter():
             "count of nvidia memory leak",
             labels=["minor_number"])
 
+def gen_nvidia_gpu_performance_state():
+    return GaugeMetricFamily("nvidiasmi_performance_state",
+            "gpu performance state",
+            labels=["minor_number"])
+
+def gen_nvidia_gpu_clocks_throttle_reasons():
+    return GaugeMetricFamily("nvidiasmi_clocks_throttle_reasons",
+            "gpu clocks_throttle_reasons",
+            labels=["minor_number"])
+
 # AMD GPU metrics
 def gen_amd_gpu_util_gauge():
     return GaugeMetricFamily("rocmsmi_utilization_gpu",
@@ -399,6 +409,8 @@ class GpuCollector(Collector):
         nvidia_gpu_temp = gen_nvidia_gpu_temperature_gauge()
         nvidia_ecc_errors = gen_nvidia_gpu_ecc_counter()
         nvidia_mem_leak = gen_nvidia_gpu_memory_leak_counter()
+        nvidia_performance_state = gen_nvidia_gpu_performance_state()
+        nvidia_clocks_throttle_reasons = gen_nvidia_gpu_clocks_throttle_reasons()
         external_process = gen_gpu_used_by_external_process_counter()
         zombie_container = gen_gpu_used_by_zombie_container_counter()
 
@@ -416,6 +428,10 @@ class GpuCollector(Collector):
                 nvidia_gpu_temp.add_metric([minor], info.temperature)
             nvidia_ecc_errors.add_metric([node_name, minor, "single"], info.ecc_errors.single)
             nvidia_ecc_errors.add_metric([node_name, minor, "double"], info.ecc_errors.double)
+            nvidia_performance_state.add_metric([minor], info.performance_state)
+
+            if info.clocks_throttle_reasons:
+                nvidia_clocks_throttle_reasons.add_metric([minor], info.performance_state.join(","))
 
             # TODO: this piece of code seems not corret, gpu_mem_util is
             # a percentage number but mem_leak_thrashold is memory size. Need to fix it.

--- a/src/job-exporter/src/collector.py
+++ b/src/job-exporter/src/collector.py
@@ -93,7 +93,7 @@ def gen_nvidia_gpu_memory_leak_counter():
 def gen_nvidia_gpu_performance_state():
     return GaugeMetricFamily("nvidiasmi_performance_state",
             "gpu performance state",
-            labels=["minor_number", "clocks_throttle_reasons"])
+            labels=["node_name", "minor_number", "clocks_throttle_reasons"])
 
 # AMD GPU metrics
 def gen_amd_gpu_util_gauge():
@@ -422,7 +422,7 @@ class GpuCollector(Collector):
                 nvidia_gpu_temp.add_metric([minor], info.temperature)
             nvidia_ecc_errors.add_metric([node_name, minor, "single"], info.ecc_errors.single)
             nvidia_ecc_errors.add_metric([node_name, minor, "double"], info.ecc_errors.double)
-            nvidia_performance_state.add_metric([minor, ",".join(info.clocks_throttle_reasons)], info.performance_state)
+            nvidia_performance_state.add_metric([node_name, minor, ",".join(info.clocks_throttle_reasons)], info.performance_state)
 
             # TODO: this piece of code seems not corret, gpu_mem_util is
             # a percentage number but mem_leak_thrashold is memory size. Need to fix it.

--- a/src/job-exporter/src/nvidia.py
+++ b/src/job-exporter/src/nvidia.py
@@ -83,7 +83,7 @@ class NvidiaGpuStatus(object):
         self.clocks_throttle_reasons = clocks_throttle_reasons # list of throttle reason
 
     def __repr__(self):
-        return "util: %.3f, mem_util: %.3f, pids: %s, ecc: %s, minor: %s, uuid: %s, temperature %.3f, performance status, clock throttle reasons" % \
+        return "util: %.3f, mem_util: %.3f, pids: %s, ecc: %s, minor: %s, uuid: %s, temperature %.3f, performance status: %d, clock throttle reasons: %s" % \
                 (self.gpu_util, self.gpu_mem_util, self.pids, self.ecc_errors, self.minor, self.uuid, self.temperature, self.performance_state,
                  self.clocks_throttle_reasons)
 
@@ -175,7 +175,7 @@ def parse_smi_xml_result(smi):
         try:
             temp_node = gpu.getElementsByTagName("performance_state")
             if len(temp_node) > 0:
-                performance_state = temp_node[0].childNodes[0].data
+                performance_state = int(re.findall(r"\d+", temp_node[0].childNodes[0].data)[0])
         except:
             logger.warning("Failed to get GPU performance status", exc_info=True)
 

--- a/src/job-exporter/test/test_collector.py
+++ b/src/job-exporter/test/test_collector.py
@@ -294,7 +294,7 @@ class TestGpuCollector(base.TestBase):
         self.assertEqual(target_gpu_temp, gpu_temp)
 
         target_perf_status = collector.gen_nvidia_gpu_performance_state()
-        target_perf_status.add_metric(["1", "clocks_throttle_reason_gpu_idle"], 8)
+        target_perf_status.add_metric(["node_0", "1", "clocks_throttle_reason_gpu_idle"], 8)
         self.assertEqual(target_perf_status, perf_status)
 
         # test minor 2

--- a/src/job-exporter/test/test_nvidia.py
+++ b/src/job-exporter/test/test_nvidia.py
@@ -36,11 +36,12 @@ class TestNvidia(base.TestBase):
         nvidia_smi_parse_result = nvidia.parse_smi_xml_result(nvidia_smi_result)
 
         zero = nvidia.NvidiaGpuStatus(100, 25, [1357, 2384, 3093], nvidia.EccError(),
-                "0", "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b", 60.0)
+                "0", "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b", 60.0, "P2", [])
         one = nvidia.NvidiaGpuStatus(98, 50, [3093], nvidia.EccError(),
-                "1", "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6", 59.0)
+                "1", "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6", 59.0, "P2", [])
 
-        target_smi_info = {"1": one, "0": zero, "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b": zero, "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6": one}
+        target_smi_info = {"1": one, "0": zero, "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b": zero,
+            "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6": one}
 
         self.assertEqual(target_smi_info, nvidia_smi_parse_result)
 
@@ -51,9 +52,9 @@ class TestNvidia(base.TestBase):
         nvidia_smi_parse_result = nvidia.parse_smi_xml_result(nvidia_smi_result)
 
         zero = nvidia.NvidiaGpuStatus(0.000, 0.000, [], nvidia.EccError(),
-                "0", "GPU-57567e11-0be2-381b-5132-2ad95c262e58", 24.0)
+                "0", "GPU-57567e11-0be2-381b-5132-2ad95c262e58", 24.0, "P8", ["clocks_throttle_reason_gpu_idle"])
         one = nvidia.NvidiaGpuStatus(0.000, 0.000, [], nvidia.EccError(),
-                "1", "GPU-ef1d0068-5bfd-f1e4-7e79-ff35d71d44b8", 24.0)
+                "1", "GPU-ef1d0068-5bfd-f1e4-7e79-ff35d71d44b8", 24.0, "P8", ["clocks_throttle_reason_sw_power_cap"])
 
         target_smi_info = {"0": zero, "GPU-57567e11-0be2-381b-5132-2ad95c262e58": zero, "1": one, "GPU-ef1d0068-5bfd-f1e4-7e79-ff35d71d44b8": one}
 

--- a/src/job-exporter/test/test_nvidia.py
+++ b/src/job-exporter/test/test_nvidia.py
@@ -36,9 +36,9 @@ class TestNvidia(base.TestBase):
         nvidia_smi_parse_result = nvidia.parse_smi_xml_result(nvidia_smi_result)
 
         zero = nvidia.NvidiaGpuStatus(100, 25, [1357, 2384, 3093], nvidia.EccError(),
-                "0", "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b", 60.0, "P2", [])
+                "0", "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b", 60.0, 2, [])
         one = nvidia.NvidiaGpuStatus(98, 50, [3093], nvidia.EccError(),
-                "1", "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6", 59.0, "P2", [])
+                "1", "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6", 59.0, 2, [])
 
         target_smi_info = {"1": one, "0": zero, "GPU-e511a7b2-f9d5-ba47-9b98-853732ca6c1b": zero,
             "GPU-28daffaf-8abe-aaf8-c298-4bd13aecb5e6": one}
@@ -52,9 +52,9 @@ class TestNvidia(base.TestBase):
         nvidia_smi_parse_result = nvidia.parse_smi_xml_result(nvidia_smi_result)
 
         zero = nvidia.NvidiaGpuStatus(0.000, 0.000, [], nvidia.EccError(),
-                "0", "GPU-57567e11-0be2-381b-5132-2ad95c262e58", 24.0, "P8", ["clocks_throttle_reason_gpu_idle"])
+                "0", "GPU-57567e11-0be2-381b-5132-2ad95c262e58", 24.0, 8, ["clocks_throttle_reason_gpu_idle"])
         one = nvidia.NvidiaGpuStatus(0.000, 0.000, [], nvidia.EccError(),
-                "1", "GPU-ef1d0068-5bfd-f1e4-7e79-ff35d71d44b8", 24.0, "P8", ["clocks_throttle_reason_sw_power_cap"])
+                "1", "GPU-ef1d0068-5bfd-f1e4-7e79-ff35d71d44b8", 24.0, 8, ["clocks_throttle_reason_sw_power_cap"])
 
         target_smi_info = {"0": zero, "GPU-57567e11-0be2-381b-5132-2ad95c262e58": zero, "1": one, "GPU-ef1d0068-5bfd-f1e4-7e79-ff35d71d44b8": one}
 

--- a/src/prometheus/deploy/alerting/gpu.rules
+++ b/src/prometheus/deploy/alerting/gpu.rules
@@ -78,3 +78,10 @@ groups:
         annotations:
           summary: "found gpu count changes in {{$labels.instance}}"
 
+      - alert: NodeGpuLowPerfState
+        expr: nvidiasmi_performance_state{clocks_throttle_reasons=""} <= 8
+        for: 5m
+        labels:
+          severity: warn
+        annotations:
+          summary: "found gpu in {{$labels.instance}} minor number {{$labels.minor_number}} in low perf state"

--- a/src/prometheus/deploy/alerting/gpu.rules
+++ b/src/prometheus/deploy/alerting/gpu.rules
@@ -79,7 +79,7 @@ groups:
           summary: "found gpu count changes in {{$labels.instance}}"
 
       - alert: NodeGpuLowPerfState
-        expr: nvidiasmi_performance_state{clocks_throttle_reasons=""} <= 8
+        expr: nvidiasmi_performance_state{clocks_throttle_reasons=""} >= 8
         for: 5m
         labels:
           severity: warn


### PR DESCRIPTION
GPU may drop into low perf state in some case. Which cause user workload run much slower. Add this alert. Fix: #3387