### PR TITLE
[Rest-Server] Add tokens check API for client

### DIFF
--- a/src/rest-server/src/routes/token.js
+++ b/src/rest-server/src/routes/token.js
@@ -95,17 +95,13 @@ router.delete(
 );
 
 /** GET /api/v2/tokens/check - Check a token */
-router.get(
-  '/check',
-  tokenMiddleware.check,
-  async (req, res, next) => {
-    try {
-      res.status(200).json(req[userProperty]);
-    } catch (err) {
-      next(createError.unknown(err));
-    }
+router.get('/check', tokenMiddleware.check, async (req, res, next) => {
+  try {
+    res.status(200).json(req[userProperty]);
+  } catch (err) {
+    next(createError.unknown(err));
   }
-)
+});
 
 // module exports
 module.exports = router;

--- a/src/rest-server/src/routes/token.js
+++ b/src/rest-server/src/routes/token.js
@@ -16,6 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // module dependencies
+const { userProperty } = require('@pai/config/token');
 const express = require('express');
 const jwt = require('jsonwebtoken');
 const authnConfig = require('@pai/config/authn');
@@ -92,6 +93,19 @@ router.delete(
     }
   },
 );
+
+/** GET /api/v2/tokens/check - Check a token */
+router.get(
+  '/check',
+  tokenMiddleware.check,
+  async (req, res, next) => {
+    try {
+      res.status(200).json(req[userProperty]);
+    } catch (err) {
+      next(createError.unknown(err));
+    }
+  }
+)
 
 // module exports
 module.exports = router;


### PR DESCRIPTION
Add `GET /api/v2/tokens/check` API for OpenPAI client to verify token.
Currently only Marketplace will use it.
Just for internal use, didn't add to swagger.

![image](https://user-images.githubusercontent.com/17357108/106710941-b91c4380-6631-11eb-8426-2206c06be277.png)
