### PR TITLE
[Build] Add --pull option to build script

### DIFF
--- a/build/core/build_utility.py
+++ b/build/core/build_utility.py
@@ -51,7 +51,7 @@ class DockerClient:
 
 
     def docker_image_build(self, image_name, dockerfile_path, build_path):
-        cmd = "docker build -t {0} -f {1} {2}".format(image_name, dockerfile_path, build_path)
+        cmd = "docker build --pull -t {0} -f {1} {2}".format(image_name, dockerfile_path, build_path)
         execute_shell(cmd)
 
 


### PR DESCRIPTION
Current marketplace component in OpenPAI master branch use the latest tag, the image will be update when the code change.
add --pull to OpenPAI build script can make sure the marketplace image up-to-date.