### PR TITLE
Fix wrong nvidia gpu card number 

### DIFF
--- a/contrib/kubespray/roles/requirement/computing-devices/nvidia.com_gpu/tasks/main.yml
+++ b/contrib/kubespray/roles/requirement/computing-devices/nvidia.com_gpu/tasks/main.yml
@@ -46,14 +46,14 @@
 
 - name: "Check NVIDIA GPU card number is matched or not"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + [\"NVIDIA GPU card number is not matched: {{ computing_device_count }} specified but only {{ nvidia_gpu_count.stdout_lines[0] }} found\"] }}"
+    unmet_requirements: "{{ unmet_requirements + [\"NVIDIA GPU card number is not matched: {{ computing_device_count }} specified but only {{ nvidia_gpu_count.stdout|trim }} found\"] }}"
   changed_when: false
   check_mode: false
   environment: {}
   when:
     # if nvidia-smi doesn't work, we can skip this step
     - nvidia_smi.rc == 0
-    - 'nvidia_gpu_count.stdout_lines|join("")|trim|int != computing_device_count'
+    - 'nvidia_gpu_count.stdout|trim|int != computing_device_count'
     - nvidia_gpu_count.rc == 0
 
 - name: "Check default docker runtime"

--- a/contrib/kubespray/roles/requirement/computing-devices/nvidia.com_gpu/tasks/main.yml
+++ b/contrib/kubespray/roles/requirement/computing-devices/nvidia.com_gpu/tasks/main.yml
@@ -53,7 +53,7 @@
   when:
     # if nvidia-smi doesn't work, we can skip this step
     - nvidia_smi.rc == 0
-    - "nvidia_gpu_count.stdout_lines[0]|int != computing_device_count"
+    - 'nvidia_gpu_count.stdout_lines|join("")|trim|int != computing_device_count'
     - nvidia_gpu_count.rc == 0
 
 - name: "Check default docker runtime"

--- a/contrib/kubespray/roles/requirement/computing-devices/nvidia.com_gpu/tasks/main.yml
+++ b/contrib/kubespray/roles/requirement/computing-devices/nvidia.com_gpu/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: "Check NVIDIA GPU card number is matched or not"
   set_fact:
-    unmet_requirements: "{{ unmet_requirements + [\"NVIDIA GPU card number is not matched: {{ computing_device_count }} specified but only {{ nvidia_gpu_count.stdout|trim }} found\"] }}"
+    unmet_requirements: "{{ unmet_requirements + [\"NVIDIA GPU card number is not matched: {{ computing_device_count }} specified but {{ nvidia_gpu_count.stdout|trim }} found\"] }}"
   changed_when: false
   check_mode: false
   environment: {}


### PR DESCRIPTION
Sometime `nvidia_gpu_count.stdout_lines` is `["<num>"]`, but sometimes it becomes `["", "<num>"]`.

Use `|join("")|trim` to unify them.