### PR TITLE
Fix get-pip.py compatibility problem with Python3.5

### DIFF
--- a/contrib/kubespray/script/environment.sh
+++ b/contrib/kubespray/script/environment.sh
@@ -27,9 +27,11 @@ echo "Install necessray packages"
 
 echo "Install Python3 and pip"
 sudo apt-get -y update
-sudo apt-get -y install software-properties-common python3 python3-dev
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-sudo python3 get-pip.py
+sudo apt-get -y install software-properties-common python3 python3-dev python3-pip
+# "apt-get install python3" will install python3.5 on Ubuntu 16.04
+# The lastest pip doesn't support python3.5.
+# Here we use a fixed version number to ensure compatiblity.
+sudo python3 -m pip install pip==20.3.4
 
 echo "Install python packages"
 sudo python3 -m pip install paramiko # need paramiko for ansible-playbook

--- a/contrib/kubespray/script/environment.sh
+++ b/contrib/kubespray/script/environment.sh
@@ -30,7 +30,7 @@ sudo apt-get -y update
 sudo apt-get -y install software-properties-common python3 python3-dev python3-pip
 # "apt-get install python3" will install python3.5 on Ubuntu 16.04
 # The lastest pip doesn't support python3.5.
-# Here we use a fixed version number to ensure compatiblity.
+# Here we use a fixed version number to ensure compatibility.
 sudo python3 -m pip install pip==20.3.4
 
 echo "Install python packages"

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -44,7 +44,6 @@ RUN apt-get -y update && \
     git clone https://github.com/Microsoft/pai.git &&\
     pip install bcrypt==3.1.7 dnspython==1.16.0 python-etcd docker kubernetes==12.0.0 paramiko==2.6.0 cryptography==3.2 cachetools==3.1.1 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
-    pip3 install pip==20.3.4 && \
     pip3 install kubernetes==12.0.0 jinja2
 
 WORKDIR /tmp

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -44,7 +44,7 @@ RUN apt-get -y update && \
     git clone https://github.com/Microsoft/pai.git &&\
     pip install bcrypt==3.1.7 dnspython==1.16.0 python-etcd docker kubernetes==12.0.0 paramiko==2.6.0 cryptography==3.2 cachetools==3.1.1 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
-    python3 -m pip3 install pip3==20.3.4 && \
+    pip3 install pip3==20.3.4 && \
     pip3 install kubernetes==12.0.0 jinja2
 
 WORKDIR /tmp

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -44,7 +44,7 @@ RUN apt-get -y update && \
     git clone https://github.com/Microsoft/pai.git &&\
     pip install bcrypt==3.1.7 dnspython==1.16.0 python-etcd docker kubernetes==12.0.0 paramiko==2.6.0 cryptography==3.2 cachetools==3.1.1 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
-    python3 -m pip install pip==20.3.4 && \
+    python3 -m pip3 install pip3==20.3.4 && \
     pip3 install kubernetes==12.0.0 jinja2
 
 WORKDIR /tmp

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -44,6 +44,7 @@ RUN apt-get -y update && \
     git clone https://github.com/Microsoft/pai.git &&\
     pip install bcrypt==3.1.7 dnspython==1.16.0 python-etcd docker kubernetes==12.0.0 paramiko==2.6.0 cryptography==3.2 cachetools==3.1.1 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
+    python3 -m pip install pip==20.3.4 && \
     pip3 install kubernetes==12.0.0 jinja2
 
 WORKDIR /tmp

--- a/src/dev-box/build/dev-box.common.dockerfile
+++ b/src/dev-box/build/dev-box.common.dockerfile
@@ -44,7 +44,7 @@ RUN apt-get -y update && \
     git clone https://github.com/Microsoft/pai.git &&\
     pip install bcrypt==3.1.7 dnspython==1.16.0 python-etcd docker kubernetes==12.0.0 paramiko==2.6.0 cryptography==3.2 cachetools==3.1.1 GitPython==2.1.15 jsonschema attrs dicttoxml beautifulsoup4 future setuptools==44.1.0 &&\
     python -m easy_install --upgrade pyOpenSSL && \
-    pip3 install pip3==20.3.4 && \
+    pip3 install pip==20.3.4 && \
     pip3 install kubernetes==12.0.0 jinja2
 
 WORKDIR /tmp


### PR DESCRIPTION
`https://bootstrap.pypa.io/get-pip.py` is updated and doesn't support python3.5 anymore.