### PR TITLE
refine kill low-efficiency-job-alert email templates

### DIFF
--- a/src/alert-manager/deploy/alert-templates/kill-low-efficiency-job-alert/html.ejs
+++ b/src/alert-manager/deploy/alert-templates/kill-low-efficiency-job-alert/html.ejs
@@ -8,10 +8,21 @@
     Dear OpenPAI user:
     </br>
     </br>
-    Your jobs in OpenPAI cluster <b><%= cluster_id %></b> have very low GPU utilization.
-
+    Some of your jobs in OpenPAI cluster <b><%= cluster_id %></b> are considered low-efficiency.
+    </br>
+    The may be caused by:
+    </br>
+    - The jobs have low GPU utilization
+    </br>
+    - The jobs have been running too long
+    </br>
+    - A combination of the above reasons
+    </br>
     <p style="color: red; font-weight: bold">The jobs will be killed automatically by OpenPAI services.</p>
-
+    </br>
+    Refer to the following summary to check details.
+    </br>
+    </br>
     Related Job(s):
     </br>
     </br>


### PR DESCRIPTION
After this change, the template can also be applied for killing long-running jobs