### PR TITLE
web change to support general log type

### DIFF
--- a/src/webportal/deploy/webportal.yaml.template
+++ b/src/webportal/deploy/webportal.yaml.template
@@ -64,12 +64,6 @@ spec:
 {%- endif %}
         - name: PROMETHEUS_URI
           value: {{ cluster_cfg['prometheus']['url'] }}
-        - name: LOG_TYPE
-{%- if cluster_cfg["cluster"]["common"]["cluster-type"] == "k8s" %}
-          value: log-manager
-{%- else %}
-          value: yarn
-{%- endif %}
 {%- if cluster_cfg["cluster"]["common"]["cluster-type"] == "yarn" %}
         - name: YARN_WEB_PORTAL_URI
           value: http://{{ cluster_cfg['hadoop-resource-manager']['master-ip'] }}:8088

--- a/src/webportal/src/app/env.js.template
+++ b/src/webportal/src/app/env.js.template
@@ -11,7 +11,6 @@ window.ENV = {
   authnMethod: '${AUTHN_METHOD}',
   pylonAddress: '${PYLON_ADDRESS}',
   webHDFSUri: '${WEBHDFS_URI}',
-  logType: '${LOG_TYPE}',
   alertManagerUri: '${ALERT_MANAGER_URI}/alert-manager',
   launcherType: '${LAUNCHER_TYPE}',
   launcherScheduler: '${LAUNCHER_SCHEDULER}',

--- a/src/webportal/src/app/job/job-view/fabric/job-detail/components/task-role-container-list.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/components/task-role-container-list.jsx
@@ -267,13 +267,10 @@ export default class TaskRoleContainerList extends React.Component {
 
   showContainerTailLog(logListUrl, logType) {
     let title;
-    let logHint = '';
+    const logHint = 'Last 16384 bytes';
     this.setState({ logListUrl: logListUrl });
     getContainerLogList(logListUrl)
       .then(({ fullLogUrls, tailLogUrls }) => {
-        if (config.logType === 'log-manager') {
-          logHint = 'Last 16384 bytes';
-        }
         switch (logType) {
           case 'stdout':
             title = `Standard Output (${logHint})`;

--- a/src/webportal/src/app/job/job-view/fabric/job-detail/conn.js
+++ b/src/webportal/src/app/job/job-view/fabric/job-detail/conn.js
@@ -190,30 +190,21 @@ export async function getContainerLog(tailLogUrls, fullLogUrls, logType) {
   }
   let text = await res.text();
 
-  // Check log type. The log type is in LOG_TYPE only support log-manager.
-  if (config.logType === 'log-manager') {
-    // Try to get roated log if currently log content is less than 15KB
-    if (text.length <= 15 * 1024 && tailLogUrls[logType + '.1']) {
-      const rotatedLogUrl = tailLogUrls[logType + '.1'];
-      const rotatedLogRes = await fetch(rotatedLogUrl);
-      const fullLogRes = await fetch(fullLogUrls[logType]);
-      const rotatedText = await rotatedLogRes.text();
-      const fullLog = await fullLogRes.text();
-      if (rotatedLogRes.ok) {
-        text = rotatedText
-          .concat(
-            '\n ------- log is rotated, may be lost during this ------- \n',
-          )
-          .concat(fullLog);
-      }
-      // get last 16KB
-      text = text.slice(-16 * 1024);
+  // Try to get roated log if currently log content is less than 15KB
+  if (text.length <= 15 * 1024 && tailLogUrls[logType + '.1']) {
+    const rotatedLogUrl = tailLogUrls[logType + '.1'];
+    const rotatedLogRes = await fetch(rotatedLogUrl);
+    const rotatedText = await rotatedLogRes.text();
+    if (rotatedLogRes.ok) {
+      text = rotatedText
+        .concat('\n ------- log is rotated, may be lost during this ------- \n')
+        .concat(text);
     }
-    return {
-      fullLogLink: fullLogUrls[logType],
-      text: text,
-    };
-  } else {
-    throw new Error(`Log not available`);
+    // get last 16KB
+    text = text.slice(-16 * 1024);
   }
+  return {
+    fullLogLink: fullLogUrls[logType],
+    text: text,
+  };
 }

--- a/src/webportal/src/app/job/job-view/fabric/task-attempt/conn.js
+++ b/src/webportal/src/app/job/job-view/fabric/task-attempt/conn.js
@@ -86,30 +86,21 @@ export async function getContainerLog(tailLogUrls, fullLogUrls, logType) {
   }
   let text = await res.text();
 
-  // Check log type. The log type is in LOG_TYPE only support log-manager.
-  if (config.logType === 'log-manager') {
-    // Try to get roated log if currently log content is less than 15KB
-    if (text.length <= 15 * 1024 && tailLogUrls[logType + '.1']) {
-      const rotatedLogUrl = tailLogUrls[logType + '.1'];
-      const rotatedLogRes = await fetch(rotatedLogUrl);
-      const fullLogRes = await fetch(fullLogUrls[logType]);
-      const rotatedText = await rotatedLogRes.text();
-      const fullLog = await fullLogRes.text();
-      if (rotatedLogRes.ok) {
-        text = rotatedText
-          .concat(
-            '\n ------- log is rotated, may be lost during this ------- \n',
-          )
-          .concat(fullLog);
-      }
-      // get last 16KB
-      text = text.slice(-16 * 1024);
+  // Try to get roated log if currently log content is less than 15KB
+  if (text.length <= 15 * 1024 && tailLogUrls[logType + '.1']) {
+    const rotatedLogUrl = tailLogUrls[logType + '.1'];
+    const rotatedLogRes = await fetch(rotatedLogUrl);
+    const rotatedText = await rotatedLogRes.text();
+    if (rotatedLogRes.ok) {
+      text = rotatedText
+        .concat('\n ------- log is rotated, may be lost during this ------- \n')
+        .concat(text);
     }
-    return {
-      fullLogLink: fullLogUrls[logType],
-      text: text,
-    };
-  } else {
-    throw new Error(`Log not available`);
+    // get last 16KB
+    text = text.slice(-16 * 1024);
   }
+  return {
+    fullLogLink: fullLogUrls[logType],
+    text: text,
+  };
 }

--- a/src/webportal/src/app/job/job-view/fabric/task-attempt/task-attempt-list.jsx
+++ b/src/webportal/src/app/job/job-view/fabric/task-attempt/task-attempt-list.jsx
@@ -253,13 +253,10 @@ export default class TaskAttemptList extends React.Component {
 
   showContainerTailLog(logListUrl, logType) {
     let title;
-    let logHint = '';
+    const logHint = 'Last 16384 bytes';
     this.setState({ logListUrl: logListUrl });
     getContainerLogList(logListUrl)
       .then(({ fullLogUrls, tailLogUrls }) => {
-        if (config.logType === 'log-manager') {
-          logHint = 'Last 16384 bytes';
-        }
         switch (logType) {
           case 'stdout':
             title = `Standard Output (${logHint})`;


### PR DESCRIPTION
Since we already unified log api in rest-server. We don't need log-type env any more.
Remove this env and unified the experience