### PR TITLE
[Plugins] Make sure click plugin item back to the plugin's home page 

### DIFF
--- a/src/webportal/src/app/layout/components/sidebar.jsx
+++ b/src/webportal/src/app/layout/components/sidebar.jsx
@@ -255,7 +255,8 @@ const Sidebar = ({ className, style }) => {
                 style: { display: isEmpty(plugins) ? 'none' : undefined },
                 links: (plugins || []).map((item, idx) => ({
                   name: item.title,
-                  url: `/plugin.html?index=${idx}`,
+                  onClick: () =>
+                    (window.location.href = `/plugin.html?index=${idx}`),
                   key: KEY_PLUGIN_PREFIX + idx,
                   icon: 'Puzzle',
                 })),


### PR DESCRIPTION
Bug from Marketplace
In `create item` or other subpage of marketplace, click the sidebar item will not navigation to he marketplace home page.
this PR will fix it.