### PR TITLE
[Alert manager] Add firing status to the cert expiration checker alert

### DIFF
--- a/docs/manual/cluster-admin/how-to-use-alert-system.md
+++ b/docs/manual/cluster-admin/how-to-use-alert-system.md
@@ -287,12 +287,11 @@ To make your configuration take effect, restart the `alert-manager` service afte
 
 We provide the functionality to check the k8s cert expiration date and send warning to admin users.
 
-This feature will be enable by default, if the action `email-admin` is enabled.
 You can configure the `alert-manager`->`cert-expiration-checker` field in `services-configuration.yml`.
 `schedule`, `alert-residual-days` and `cert-path` are necessary fields for this feature, and we have default value for the fields.
 For the syntax of `schedule`, please refer to [Cron Schedule Syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax).
 For example, `"0 0 * * *"` means daily report at UTC 00:00.
-Please also make sure that the [`email-admin`](#Existing-Actions-and-Matching-Rules) action is enabled.
+An alert will be send to the admin, if [`email-admin`](#Existing-Actions-and-Matching-Rules) action is enabled.
 
 ```yaml
 alert-manager:

--- a/src/alert-manager/src/cert-expiration-checker/send_alert.py
+++ b/src/alert-manager/src/cert-expiration-checker/send_alert.py
@@ -30,6 +30,7 @@ def send_alert(pai_url: str, residualTime: int, certExpirationInfo: str):
     post_url = pai_url.rstrip("/") + ALERT_PREFIX
     alerts = []
     alert = {
+        "status": "firing",
         "labels": {
             "alertname": "k8s cert expiration",
             "severity": "fatal",


### PR DESCRIPTION
Add `"status": "firing"` to the alert.
So the alert will be shown on the webportal home page.
![image](https://user-images.githubusercontent.com/17357108/115843845-dc48d900-a451-11eb-959e-3f5ee551bee8.png)
