### PR TITLE
set cluster.advertise-address to avoid docker use non-private ip

### DIFF
--- a/src/alert-manager/deploy/alert-manager-deployment.yaml.template
+++ b/src/alert-manager/deploy/alert-manager-deployment.yaml.template
@@ -47,6 +47,7 @@ spec:
           - '--storage.path=/alertmanager'
           - '--web.external-url={{ external_url }}/alert-manager/'
           - '--web.route-prefix=alert-manager'
+          - '--cluster.advertise-address=127.0.0.1:{{ cluster_cfg["alert-manager"]["port"] }}'
         ports:
         - name: alertmanager
           containerPort: {{ cluster_cfg["alert-manager"]["port"] }}


### PR DESCRIPTION
If docker use ono-private ip. There will be error: `alertmanager: no private IP found`.
Set `cluster.advertise-address` to avoid this issue