### PR TITLE
fix alert-manager config generation issue

### DIFF
--- a/src/alert-manager/config/alert-manager.yaml
+++ b/src/alert-manager/config/alert-manager.yaml
@@ -7,6 +7,7 @@ port: 9093
 actions-available:
 - webportal-notification
 - cordon-nodes
+- fix-nvidia-gpu-low-perf
 alert-handler:
   log-level: 'info'
   port: 9095

--- a/src/alert-manager/config/alert_manager.py
+++ b/src/alert-manager/config/alert_manager.py
@@ -75,7 +75,6 @@ class AlertManager(object):
             token_configured = False
 
         result["alert-handler"]["configured"] = True
-        result["actions-available"] = ["fix-nvidia-gpu-low-perf"]
         if email_configured and token_configured:
             result["actions-available"].extend(["email-admin", "email-user", "stop-jobs", "tag-jobs"])
         elif email_configured:


### PR DESCRIPTION
The actions with no dependencies should be placed in `alert-manager.yaml`

This bug was involved in #5383 