### PR TITLE
query aad group info until succeed

### DIFF
--- a/src/rest-server/src/utils/manager/group/adapter/msGraphAdapter.js
+++ b/src/rest-server/src/utils/manager/group/adapter/msGraphAdapter.js
@@ -16,6 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // module dependencies
+const { catch } = require('@pai/server');
 const axios = require('axios');
 
 function initConfig(msGraphUrl, accessToken) {
@@ -30,17 +31,21 @@ async function getUserGroupList(username, config) {
   let requestUrl = config.msGraphAPI;
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const response = await axios.get(requestUrl, {
-      headers: {
-        Accept: 'application/json',
-        Authorization: config.Authorization,
-      },
-    });
-    responseData.push(response.data.value);
-    if ('@odata.nextLink' in response.data) {
-      requestUrl = response.data['@odata.nextLink'];
-    } else {
-      break;
+    try {
+      const response = await axios.get(requestUrl, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: config.Authorization,
+        },
+      });
+      responseData.push(response.data.value);
+      if ('@odata.nextLink' in response.data) {
+        requestUrl = response.data['@odata.nextLink'];
+      } else {
+        break;
+      }
+    } catch (err) {
+      logger.warn('request config is', config, err);
     }
   }
   const groupList = [];


### PR DESCRIPTION
Fix ms graph API fail