### PR TITLE
Use `irate` instead of `rate` in PromQL for fast-moving metrics

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 
 {"dashboard": {
   "annotations": {
@@ -680,14 +680,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_receive_bytes_total{device!~\"lo\"}[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "in",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_transmit_bytes_total{device!~\"lo\"}[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "out",
@@ -774,21 +774,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_disk_read_bytes_total[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_read_bytes_total[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "read",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(node_disk_written_bytes_total[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_written_bytes_total[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "write",
               "refId": "B"
             },
             {
-              "expr": "sum(rate(node_disk_other_bytes_total[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_other_bytes_total[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "other",

--- a/src/grafana/deploy/grafana-configuration/pai-jobview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-jobview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -309,7 +309,7 @@
               "step": 600
             },
             {
-              "expr": "avg by (job_name) (rate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name) (irate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -319,7 +319,7 @@
               "step": 600
             },
             {
-              "expr": "avg by (job_name) (rate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name) (irate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "interval": "",

--- a/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -344,7 +344,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -355,7 +355,7 @@
               "target": ""
             },
             {
-              "expr": "sum(rate(node_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -450,7 +450,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -461,7 +461,7 @@
               "target": ""
             },
             {
-              "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -469,7 +469,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(rate(node_disk_other_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_other_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,

--- a/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 
 {"dashboard": {
   "annotations": {

--- a/src/grafana/deploy/grafana-configuration/pai-taskroleview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-taskroleview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -327,7 +327,7 @@
               "step": 600
             },
             {
-              "expr": "avg by (job_name, role_name) (rate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name) (irate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -337,7 +337,7 @@
               "step": 600
             },
             {
-              "expr": "avg by (job_name, role_name) (rate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name) (irate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "interval": "",

--- a/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -255,14 +255,14 @@
               "refId": "B"
             },
             {
-              "expr": "rate(task_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])",
+              "expr": "irate(task_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Net In {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "C"
             },
             {
-              "expr": "rate(task_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])",
+              "expr": "irate(task_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "Net Out {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",

--- a/src/grafana/deploy/grafana-configuration/pai-taskview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-taskview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -317,7 +317,7 @@
               "step": 600
             },
             {
-              "expr": "avg by (job_name, role_name, task_index) (rate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name, task_index) (irate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -327,7 +327,7 @@
               "step": 600
             },
             {
-              "expr": "avg by (job_name, role_name, task_index) (rate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "expr": "avg by (job_name, role_name, task_index) (irate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "interval": "",


### PR DESCRIPTION
- change `rate` to `irate`
- change interval to 60s 