### PR TITLE
Cpu metric dedup

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -14,7 +14,7 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": true,

--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -466,7 +466,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - avg (irate(node_cpu_seconds_total{mode=\"idle\"}[{{interval}}s])) * 100",
+              "expr": "avg ((sum by (instance) (idelta(node_cpu_seconds_total{}[{{interval}}s])) > bool 0) * (100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\"}[{{interval}}s])) * 100)))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "cpu utilization",

--- a/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -89,7 +89,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])) * 100)",
+              "expr": "(sum by (instance) (idelta(node_cpu_seconds_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])) > bool 0) * (100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])) * 100))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,

--- a/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -16,7 +16,7 @@
     ]
   },
   "description": "Dashboard to view multiple servers",
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": true,

--- a/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
@@ -16,7 +16,7 @@
     ]
   },
   "description": "Dashboard to view jobs in node",
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": true,


### PR DESCRIPTION
- avoid wrongly computed 100% node cpu utilization (caused by duplicated pulling of the same metric) using idelta in PromQL
- set `editable` as true