### PR TITLE
extend grafana config to fit more metrics

### DIFF
--- a/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-clusterview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 
 {"dashboard": {
   "annotations": {
@@ -14,7 +14,7 @@
       }
     ]
   },
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": true,
@@ -466,7 +466,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - avg (irate(node_cpu_seconds_total{mode=\"idle\"}[{{interval}}s])) * 100",
+              "expr": "avg ((sum by (instance) (idelta(node_cpu_seconds_total{}[{{interval}}s])) > bool 0) * (100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\"}[{{interval}}s])) * 100)))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "cpu utilization",
@@ -553,14 +553,63 @@
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "free",
-              "refId": "D"
+              "refId": "B"
             },
             {
               "expr": "sum(node_memory_Buffers_bytes) + sum(node_memory_Cached_bytes)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "buff/cache",
-              "refId": "B"
+              "refId": "C"
+            },
+            {
+              "expr": "sum(node_memory_bytes{type=\"physical_total\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "phisical total",
+              "refId": "D"
+            },
+            {
+              "expr": "sum(node_memory_bytes{type=\"physical_available\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "phisical available",
+              "refId": "E"
+            },
+            {
+              "expr": "sum(node_memory_bytes{type=\"committed\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "committed",
+              "refId": "F"
+            },
+            {
+              "expr": "sum(node_memory_bytes{type=\"commit_limit\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "commit limit",
+              "refId": "G"
+            },
+            {
+              "expr": "sum(node_memory_bytes{type=\"system_cache\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "system cache",
+              "refId": "H"
+            },
+            {
+              "expr": "sum(node_memory_bytes{type=\"kernel_paged\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "kernel paged",
+              "refId": "I"
+            },
+            {
+              "expr": "(node_memory_bytes{type=\"kernel_non_paged\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "kernel non paged",
+              "refId": "J"
             }
           ],
           "thresholds": [],
@@ -631,14 +680,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_receive_bytes_total{device!~\"lo\"}[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "in",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_transmit_bytes_total{device!~\"lo\"}[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "out",
@@ -725,18 +774,25 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_disk_read_bytes_total[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_read_bytes_total[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "read",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(node_disk_written_bytes_total[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_written_bytes_total[{{interval}}s]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "write",
               "refId": "B"
+            },
+            {
+              "expr": "sum(irate(node_disk_other_bytes_total[{{interval}}s]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "other",
+              "refId": "C"
             }
           ],
           "thresholds": [],

--- a/src/grafana/deploy/grafana-configuration/pai-jobview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-jobview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -96,6 +96,13 @@
               "instant": false,
               "intervalFactor": 2,
               "refId": "A"
+            },
+            {
+              "expr": "avg by (job_name)(irate(task_cpu_seconds_total{job_name=~\"$job\"}[{{interval}}s])) * 100",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "refId": "B"
             }
           ],
           "thresholds": [
@@ -300,6 +307,26 @@
               "legendFormat": "Network Outbound",
               "refId": "B",
               "step": 600
+            },
+            {
+              "expr": "avg by (job_name) (irate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Network Inbound",
+              "refId": "C",
+              "step": 600
+            },
+            {
+              "expr": "avg by (job_name) (irate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Network Outbound",
+              "refId": "D",
+              "step": 600
             }
           ],
           "thresholds": [],
@@ -404,6 +431,13 @@
               "intervalFactor": 2,
               "legendFormat": "Disk Write",
               "refId": "B"
+            },
+            {
+              "expr": "avg by (job_name) (irate(task_block_other_byte{ job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Disk Other",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -633,7 +667,7 @@
         "multiFormat": "regex values",
         "name": "job",
         "options": [],
-        "query": "label_values(task_cpu_percent, job_name)",
+        "query": "label_values(task_mem_usage_byte, job_name)",
         "refresh": 1,
         "regex": "^(?!\\s*$).+",
         "sort": 1,

--- a/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-nodeview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -16,7 +16,7 @@
     ]
   },
   "description": "Dashboard to view multiple servers",
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": true,
@@ -89,11 +89,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])) * 100)",
+              "expr": "(sum by (instance) (idelta(node_cpu_seconds_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])) > bool 0) * (100 - (avg by (instance)(irate(node_cpu_seconds_total{mode=\"idle\",instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])) * 100))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "refId": "B"
+              "refId": "A"
             }
           ],
           "thresholds": [
@@ -206,7 +206,7 @@
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "free",
-              "refId": "E",
+              "refId": "B",
               "step": 600
             },
             {
@@ -214,7 +214,56 @@
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "buff/cache",
-              "refId": "B"
+              "refId": "C"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"physical_total\",instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "phisical total",
+              "refId": "D"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"physical_available\", instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "phisical available",
+              "refId": "E"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"committed\", instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "committed",
+              "refId": "F"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"commit_limit\", instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "commit limit",
+              "refId": "G"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"system_cache\", instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "system cache",
+              "refId": "H"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"kernel_paged\", instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "kernel paged",
+              "refId": "I"
+            },
+            {
+              "expr": "node_memory_bytes{type=\"kernel_non_paged\", instance=~'$node(:[0-9]*)?$'}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "kernel non paged",
+              "refId": "J"
             }
           ],
           "thresholds": [],
@@ -295,7 +344,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -306,9 +355,8 @@
               "target": ""
             },
             {
-              "expr": "sum(rate(node_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
-              "hide": true,
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "out",
@@ -402,7 +450,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_read_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -413,12 +461,20 @@
               "target": ""
             },
             {
-              "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "expr": "sum(irate(node_disk_written_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
               "legendFormat": "write",
               "refId": "B"
+            },
+            {
+              "expr": "sum(irate(node_disk_other_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "other",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -809,7 +865,7 @@
         "multiFormat": "regex values",
         "name": "node",
         "options": [],
-        "query": "label_values(node_uname_info, instance)",
+        "query": "label_values(node_cpu_seconds_total, instance)",
         "refresh": 1,
         "regex": "/([^:]*)/",
         "sort": 1,

--- a/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-serviceview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 
 {"dashboard": {
   "annotations": {
@@ -411,6 +411,11 @@
             "selected": false,
             "text": "prometheus",
             "value": "prometheus"
+          },
+          {
+            "selected": false,
+            "text": "prometheus-pushgateway",
+            "value": "prometheus-pushgateway"
           },
           {
             "selected": false,

--- a/src/grafana/deploy/grafana-configuration/pai-taskroleview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-taskroleview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -114,6 +114,13 @@
               "intervalFactor": 2,
               "legendFormat": "{{'{{role_name}}'}}",
               "refId": "A"
+            },
+            {
+              "expr": "avg by (job_name)(irate(task_cpu_seconds_total{job_name=~\"$job\"}[{{interval}}s])) * 100",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "refId": "B"
             }
           ],
           "thresholds": [
@@ -318,6 +325,26 @@
               "legendFormat": "Net Out {{'{{role_name}}'}}",
               "refId": "B",
               "step": 600
+            },
+            {
+              "expr": "avg by (job_name, role_name) (irate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Net In {{'{{role_name}}'}}",
+              "refId": "C",
+              "step": 600
+            },
+            {
+              "expr": "avg by (job_name, role_name) (irate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Net Out {{'{{role_name}}'}}",
+              "refId": "D",
+              "step": 600
             }
           ],
           "thresholds": [],
@@ -420,6 +447,13 @@
               "intervalFactor": 2,
               "legendFormat": "Write {{'{{role_name}}'}}",
               "refId": "B"
+            },
+            {
+              "expr": "avg by (job_name) (irate(task_block_other_byte{ job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Disk Other",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -665,7 +699,7 @@
         "multiFormat": "regex values",
         "name": "job",
         "options": [],
-        "query": "label_values(task_cpu_percent, job_name)",
+        "query": "label_values(task_mem_usage_byte, job_name)",
         "refresh": 1,
         "regex": "^(?!\\s*$).+",
         "sort": 1,

--- a/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-tasks-in-node-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -16,7 +16,7 @@
     ]
   },
   "description": "Dashboard to view jobs in node",
-  "editable": false,
+  "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": true,
@@ -86,6 +86,14 @@
               "intervalFactor": 2,
               "legendFormat": "{{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "A"
+            },
+            {
+              "expr": "irate(task_cpu_seconds_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s]) * 100",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -245,6 +253,20 @@
               "intervalFactor": 2,
               "legendFormat": "Net Out {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "B"
+            },
+            {
+              "expr": "irate(task_network_receive_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Net In {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
+              "refId": "C"
+            },
+            {
+              "expr": "irate(task_network_transmit_bytes_total{instance=~\"$node(:[0-9]*)?$\"}[{{interval}}s])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Net Out {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
+              "refId": "D"
             }
           ],
           "thresholds": [],
@@ -328,6 +350,13 @@
               "intervalFactor": 2,
               "legendFormat": "Write {{'{{'}}job_name{{'}}'}}-{{'{{'}}role_name{{'}}'}}-{{'{{'}}task_index{{'}}'}}",
               "refId": "B"
+            },
+            {
+              "expr": "avg by (job_name) (irate(task_block_other_byte{ job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Disk Other",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -753,7 +782,7 @@
         "multi": false,
         "name": "node",
         "options": [],
-        "query": "label_values(node_uname_info, instance)",
+        "query": "label_values(node_cpu_seconds_total, instance)",
         "refresh": 1,
         "regex": "/([^:]*)/",
         "sort": 1,

--- a/src/grafana/deploy/grafana-configuration/pai-taskview-dashboard.json.template
+++ b/src/grafana/deploy/grafana-configuration/pai-taskview-dashboard.json.template
@@ -1,4 +1,4 @@
-{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 10 %}
+{% set interval = cluster_cfg["prometheus"]["scrape_interval"]|default(30) * 2 %}
 {% set url = cluster_cfg["grafana"]["url"] %}
 
 {"dashboard": {
@@ -102,6 +102,14 @@
               "intervalFactor": 2,
               "legendFormat": "{{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "refId": "A"
+            },
+            {
+              "expr": "avg by (job_name, role_name, task_index)(irate(task_cpu_seconds_total{job_name=~\"$job\"}[{{interval}}s])) * 100",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{'{{role_name}}'}}-{{'{{task_index}}'}}",
+              "refId": "B"
             }
           ],
           "thresholds": [
@@ -307,6 +315,26 @@
               "legendFormat": "Net Out {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "refId": "B",
               "step": 600
+            },
+            {
+              "expr": "avg by (job_name, role_name, task_index) (irate(task_network_receive_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Net In {{'{{role_name}}'}}-{{'{{task_index}}'}}",
+              "refId": "C",
+              "step": 600
+            },
+            {
+              "expr": "avg by (job_name, role_name, task_index) (irate(task_network_transmit_bytes_total{job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Net Out {{'{{role_name}}'}}-{{'{{task_index}}'}}",
+              "refId": "D",
+              "step": 600
             }
           ],
           "thresholds": [],
@@ -411,6 +439,13 @@
               "intervalFactor": 2,
               "legendFormat": "Write {{'{{role_name}}'}}-{{'{{task_index}}'}}",
               "refId": "B"
+            },
+            {
+              "expr": "avg by (job_name) (irate(task_block_other_byte{ job_name=~\"$job\"}[{{interval}}s]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "Disk Other",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -850,7 +885,7 @@
         "multiFormat": "regex values",
         "name": "job",
         "options": [],
-        "query": "label_values(task_cpu_percent, job_name)",
+        "query": "label_values(task_mem_usage_byte, job_name)",
         "refresh": 1,
         "regex": "^(?!\\s*$).+",
         "sort": 1,


### PR DESCRIPTION
- support more metrics, including
 - node_memory_bytes with `type` label
 - node_disk_other_bytes_total, task_block_other_byte
 - get task cpu utilization with `task_cpu_seconds_total`
 - task_network_receive_bytes_total, task_network_transmit_bytes_total
- avoid wrongly computed 100% cpu utilization by using `idelta`
- use `irate` instead of `rate` for fast-moving metrics & change the computing interval
- set `editable` as true in all the dashboards
