### PR TITLE
remove log4j dependency from frameworklauncher

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -184,23 +184,3 @@ jobs:
         yarn install --frozen-lockfiles
         yarn build
 
-  frameworklauncher:
-    name: Test frameworklauncher on java-${{ matrix.java }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        java: [8.0]
-        os: [ubuntu-16.04, ubuntu-latest]
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup java
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
-    - name: Test frameworklauncher
-      run: |
-        cd subprojects/frameworklauncher/yarn
-        mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-        mvn clean test jacoco:report

--- a/subprojects/frameworklauncher/yarn/pom.xml
+++ b/subprojects/frameworklauncher/yarn/pom.xml
@@ -148,11 +148,12 @@
       <artifactId>snakeyaml</artifactId>
       <version>${snakeyaml.version}</version>
     </dependency>
-    <dependency>
+    <!--Comment log4j for security issue-->
+    <!--dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>
-    </dependency>
+    </dependency-->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
Remove log4j from `frameworklauncher`.
Framework launcher is not be used in pure k8s version and it uses log4j which has high security issue.
Remove this log4j dependency to fix security issue