### PR TITLE
Use `hub.docker.com` to mirror the images that will be used by OpenPAI hosted on `gcr.io`.

### DIFF
--- a/.github/workflows/image-sync.yml
+++ b/.github/workflows/image-sync.yml
@@ -1,0 +1,28 @@
+name: image-sync
+
+on:
+  release:
+    types: [published]
+
+env:
+  IMAGE_SYNCER_VERSION: v1.3.1
+
+jobs:
+  image-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: install image-sync tool
+      run: |
+        wget https://github.com/AliyunContainerService/image-syncer/releases/download/${IMAGE_SYNCER_VERSION}/image-syncer-${IMAGE_SYNCER_VERSION}-linux-amd64.tar.gz
+        tar -zxf image-syncer-${IMAGE_SYNCER_VERSION}-linux-amd64.tar.gz
+    - name: init config.yaml with env
+      run: |
+        sed -i "s/DOCKERHUB_USERNAME/${{ secrets.DOCKERHUB_USERNAME }}/g" contrib/kubespray/sync-images.yml
+        sed -i "s/DOCKERHUB_PASSWORD/${{ secrets.DOCKERHUB_PASSWORD }}/g" contrib/kubespray/sync-images.yml
+    - name: sync images
+      run: |
+        ./image-syncer --proc=20 --config=contrib/kubespray/sync-images.yml --retries=1

--- a/contrib/kubespray/sync-images.yml
+++ b/contrib/kubespray/sync-images.yml
@@ -1,0 +1,12 @@
+auth:
+  registry.hub.docker.com:
+    username: DOCKERHUB_USERNAME
+    password: DOCKERHUB_PASSWORD
+images:
+  "gcr.io/google-containers/kube-apiserver:v1.15.11": DOCKERHUB_USERNAME/kube-apiserver
+  "gcr.io/google-containers/kube-controller-manager:v1.15.11": DOCKERHUB_USERNAME/kube-controller-manager
+  "gcr.io/google-containers/kube-scheduler:v1.15.11": DOCKERHUB_USERNAME/kube-scheduler
+  "gcr.io/google-containers/kube-proxy:v1.15.11": DOCKERHUB_USERNAME/kube-proxy
+  "gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.6.0": DOCKERHUB_USERNAME/cluster-proportional-autoscaler-amd64
+  "gcr.io/google_containers/pause-amd64:3.1": DOCKERHUB_USERNAME/pause-amd64
+  "gcr.io/google_containers/pause:3.1": DOCKERHUB_USERNAME/pause


### PR DESCRIPTION
Use `hub.docker.com` to mirror the image that will be used by OpenPAI hosted on `gcr.io`.

Signed-off-by: siaimes <34199488+siaimes@users.noreply.github.com>