### PR TITLE
fix(webportal): patch Browserslist stats security vulnerability

### DIFF
--- a/src/webportal/package.json
+++ b/src/webportal/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "lint": "eslint --ext .js --ext .jsx .",
-    "test": "npm run lint",
+    "test": "npm run lint && node test/browserslist-security.js",
     "clean": "rimraf dist",
     "prebuild": "npm run clean && node config/preprocess.js",
     "build": "webpack --progress --profile --mode production",
@@ -143,5 +143,8 @@
     "node": ">=24.20.0 <25",
     "yarn": "1.22.22"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@1.22.22",
+  "resolutions": {
+    "browserslist": "4.28.9"
+  }
 }

--- a/src/webportal/test/browserslist-security.js
+++ b/src/webportal/test/browserslist-security.js
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const browserslist = require('browserslist');
+
+// GHSA-73wf-gq98-2v4g: untrusted stats must not crash unrelated queries.
+// JSON.parse preserves __proto__ as an own property rather than object syntax.
+const expected = browserslist('defaults', { stats: {} });
+const keys = [
+  '__proto__',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'constructor',
+  'isPrototypeOf',
+];
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pai-browserslist-'));
+try {
+  for (const key of keys) {
+    const stats = JSON.parse(`{"${key}":{"onekey":5},"chrome":{"100":50}}`);
+    assert.deepStrictEqual(
+      browserslist('defaults', { stats }),
+      expected,
+      `programmatic stats: ${key}`,
+    );
+
+    // A poisoned file in a parent directory is auto-discovered even when the
+    // query does not request custom stats, as happens in Babel/Autoprefixer.
+    const fixture = path.join(root, key);
+    const child = path.join(fixture, 'project');
+    fs.mkdirSync(child, { recursive: true });
+    fs.writeFileSync(
+      path.join(fixture, 'browserslist-stats.json'),
+      JSON.stringify(stats),
+    );
+    browserslist.clearCaches();
+    assert.deepStrictEqual(
+      browserslist('defaults', { path: child }),
+      expected,
+      `auto-discovered stats: ${key}`,
+    );
+  }
+  console.log('Browserslist security regression: 6 keys, 12 cases passed.');
+} finally {
+  browserslist.clearCaches();
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/src/webportal/yarn.lock
+++ b/src/webportal/yarn.lock
@@ -2682,6 +2682,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+baseline-browser-mapping@^2.11.20:
+  version "2.11.21"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz#99af73cb8e54007e4f5345e132278e26c2662f2c"
+  integrity sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==
+
 basic-auth@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
@@ -3019,16 +3024,16 @@ browserify@>=3.46.0:
     vm-browserify "^1.0.0"
     xtend "^4.0.0"
 
-browserslist@^4.0.0, browserslist@^4.6.0, browserslist@^4.6.1, browserslist@^4.6.2:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
-  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+browserslist@4.28.9, browserslist@^4.0.0, browserslist@^4.6.0, browserslist@^4.6.1, browserslist@^4.6.2:
+  version "4.28.9"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.9.tgz#07ce6b449b90af880eb9bfb7cd39372cc4f71c8c"
+  integrity sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==
   dependencies:
-    caniuse-lite "^1.0.30001219"
-    colorette "^1.2.2"
-    electron-to-chromium "^1.3.723"
-    escalade "^3.1.1"
-    node-releases "^1.1.71"
+    baseline-browser-mapping "^2.11.20"
+    caniuse-lite "^1.0.30001810"
+    electron-to-chromium "^1.5.420"
+    node-releases "^2.0.54"
+    update-browserslist-db "^1.3.2"
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -3220,10 +3225,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000971, caniuse-lite@^1.0.30001219:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000971:
   version "1.0.30001228"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
   integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+
+caniuse-lite@^1.0.30001810:
+  version "1.0.30001810"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz#4970b477dea3278374de9bc43aa8f5d39fc3cda2"
+  integrity sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3475,11 +3485,6 @@ color@^3.0.0:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.2"
-
-colorette@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 colors@1.0.x:
   version "1.0.3"
@@ -4720,10 +4725,10 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.2.tgz#3a32c63d1cd16d11266cd4703b14fec4e74ab4f6"
   integrity sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==
 
-electron-to-chromium@^1.3.723:
-  version "1.3.736"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.736.tgz#f632d900a1f788dab22fec9c62ec5c9c8f0c4052"
-  integrity sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig==
+electron-to-chromium@^1.5.420:
+  version "1.5.423"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.423.tgz#a889901c162e1de2830b456d1c61d323ad2887bf"
+  integrity sha512-rRZfTSY8ptHYMQxa+uIycJMFKmY1T0GIApNMXJYGehguTZa56TEEl19pKPCoBqk5Gpf7QizZn/jt7xur+DYxag==
 
 elliptic@^6.0.0:
   version "6.5.4"
@@ -4879,10 +4884,10 @@ es6-templates@^0.2.3:
     recast "~0.11.12"
     through "~2.3.6"
 
-escalade@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
-  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -7797,10 +7802,10 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.71:
-  version "1.1.72"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
-  integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
+node-releases@^2.0.54:
+  version "2.0.54"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.54.tgz#09af17d5647aa9f221ec5cf2becb95b68a981afe"
+  integrity sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==
 
 node-rsa@^1.0.5:
   version "1.0.5"
@@ -8346,6 +8351,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.2"
@@ -10854,6 +10864,14 @@ upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
+
+update-browserslist-db@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz#9d99fbff56c50bb11ba5fd35cece5916da595836"
+  integrity sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
 
 upper-case@^1.1.1:
   version "1.1.3"


### PR DESCRIPTION
## Summary

- Resolve [GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g) in the webportal by pinning all transitive Browserslist selectors to **4.28.9**, replacing vulnerable 4.16.6. The advisory's first patched version is 4.28.7; 4.28.9 is the stable patch selected during this update.
- Regenerate only Browserslist's required lockfile dependency closure, preserving older shared dependency resolutions used by other packages.
- Add a regression to `yarn test` covering six prototype-related keys through both programmatic stats and automatically discovered parent-directory `browserslist-stats.json` files (12 cases).

This is a separate security follow-up to the already merged Node 24 toolchain PR #5821, targeting `master`. No additional toolchain, Docker, CI configuration, or application behavior changes are included.

## Validation

Completed locally on **Node 24.20.0 / Yarn 1.22.22**, with engine checks enabled and without a legacy OpenSSL provider:

- **PASS:** strict offline frozen install with `--force`, including dependency lifecycle scripts.
- **PASS:** subsequent strict offline frozen install; lockfile SHA-256 unchanged across validation.
- **PASS:** `yarn test` (ESLint and all 12 security regression cases).
- **PASS:** negative control: the same regression rejects the old Browserslist 4.16.6 with the expected `TypeError` (`versions.length`).
- **PASS:** production `yarn build` (exit 0).
- **PASS:** localhost production Express smoke: HTML returns HTTP 200; one built JavaScript asset and one built CSS asset return HTTP 200 with correct content types and byte-for-byte disk matches.
- **PASS:** semantic lockfile scope/range/Node-engine audit; all Browserslist selectors patched; 13 selector checks and SHA-1/SRI verification for 8 unique cached tarballs.
- **PASS:** `git diff --check`.

The HTTP smoke is not a real-browser execution test or authenticated cluster E2E test. Docker image build/deployment were not run for this security-only PR. Local command logs and exit receipts were retained; this description does not claim remote CI success or that unrelated dependency advisories are resolved.
